### PR TITLE
Dark/Light mode for preloaded html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -215,19 +215,27 @@
     </div>
     <script>
       ;(() => {
+        function doesUseDarkMode() {
+          const rawLocalState = window.localStorage.getItem('redux_localstorage_simple_user')
+          const hasRawLocalState = typeof rawLocalState === 'string'
+          if (hasRawLocalState) {
+            try {
+              // need JSON.parse here as we useLocalStorage when storing theme mode
+              const localState = JSON.parse(rawLocalState)
+              return localState.userDarkMode
+            } catch (e) {
+              // empty
+            }
+          }
+        }
+
         function setInitialColorMode() {
           function getInitialColorMode() {
-            const preference = window.localStorage.getItem('theme')
-            const hasExplicitPreference = typeof preference === 'string'
-            if (hasExplicitPreference) {
-              try {
-                // need JSON.parse here as we useLocalStorage when storing theme mode
-                const mode = JSON.parse(preference)
-                return mode
-              } catch (e) {
-                // empty
-              }
+            const useDarkMode = doesUseDarkMode()
+            if (typeof useDarkMode === 'boolean') {
+              return useDarkMode ? 'dark' : 'light'
             }
+
             // If there is no saved preference, use a media query
             const mediaQuery = '(prefers-color-scheme: dark)'
             const mql = window.matchMedia(mediaQuery)
@@ -235,14 +243,15 @@
             if (hasImplicitPreference) {
               return mql.matches ? 'dark' : 'light'
             }
+
             // default to 'light'.
             return 'light'
           }
           const colorMode = getInitialColorMode()
-          const root = document.documentElement
-          root.style.setProperty('--initial-color-mode', colorMode)
           // add HTML attribute if dark mode
-          if (colorMode === 'dark') document.documentElement.setAttribute('data-theme', 'dark')
+          if (colorMode === 'dark') {
+            document.documentElement.setAttribute('data-theme', 'dark')
+          }
         }
         setInitialColorMode()
       })()

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico?version=v" />
@@ -56,16 +56,27 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background-color: #0f0f0f;
         font-family: 'Work Sans', 'Inter', sans-serif;
+      }
+      [data-theme='dark'] .preloadhtml {
+        background-color: #0f0f0f;
+      }
+      [data-theme='light'] .preloadhtml {
+        background-color: rgb(245, 245, 245);
       }
 
       .preloadhtml-header {
         display: flex;
         padding: 1rem;
+        z-index: 2;
+      }
+      [data-theme='dark'] .preloadhtml-header {
         background-color: #1c1c1c;
         border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-        z-index: 2;
+      }
+      [data-theme='light'] .preloadhtml-header {
+        background-color: rgb(255, 255, 255);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
       }
 
       .preloadhtml-logo {
@@ -80,14 +91,18 @@
         display: flex;
         align-items: center;
         margin-left: 12px;
-        color: #c3c5cb;
       }
 
       .preloadhtml-header-link-item {
         padding: 10px 12px;
         width: max-content;
-        font-weight: 400;
-        color: #a9a9a9;
+        font-weight: 500;
+      }
+      [data-theme='dark'] .preloadhtml-header-link-item {
+        color: rgb(169, 169, 169);
+      }
+      [data-theme='light'] .preloadhtml-header-link-item {
+        color: rgb(94, 94, 94);
       }
 
       .preloadhtml-header-link-item-icon {
@@ -100,7 +115,14 @@
 
       .preloadhtml-header-link-item-icon * {
         color: #a9a9a9;
-        fill: #a9a9a9;
+        fill: currentColor;
+      }
+
+      [data-theme='dark'] .onlyVisibleInLightMode {
+        display: none;
+      }
+      [data-theme='light'] .onlyVisibleInDarkMode {
+        display: none;
       }
 
       @keyframes pulse {
@@ -120,13 +142,20 @@
     <div class="preloadhtml">
       <div class="preloadhtml-header">
         <div>
-          <img style="margin-top:1px;" width="140px" src="/logo-dark.svg" alt="DmmLogo" />
+          <img
+            class="onlyVisibleInDarkMode"
+            style="margin-top: 1px;"
+            width="140px"
+            src="/logo-dark.svg"
+            alt="DmmLogo"
+          />
+          <img class="onlyVisibleInLightMode" style="margin-top: 1px;" width="140px" src="/logo.svg" alt="DmmLogo" />
         </div>
         <div class="preloadhtml-header-link">
-          <div style="color: #31CB9E; font-weight: 500;" class="preloadhtml-header-link-item">Swap</div>
+          <div style="color: #31cb9e;" class="preloadhtml-header-link-item">Swap</div>
           <div class="preloadhtml-header-link-item">Earn</div>
           <div class="preloadhtml-header-link-item">Farm</div>
-          <div class="preloadhtml-header-link-item">Analytics</div>
+          <div class="preloadhtml-header-link-item">Campaigns</div>
           <div class="preloadhtml-header-link-item">
             Discover
             <svg
@@ -163,15 +192,23 @@
               />
             </svg>
           </div>
-          <div class="preloadhtml-header-link-item">Campaign</div>
+          <div class="preloadhtml-header-link-item">Analytics</div>
           <div class="preloadhtml-header-link-item">About</div>
         </div>
       </div>
       <div style="height: 180px; display: flex;">
         <img
-          style="animation: pulse 800ms linear infinite; margin: auto; "
+          class="onlyVisibleInDarkMode"
+          style="animation: pulse 800ms linear infinite; margin: auto;"
           width="160px"
           src="/logo-dark.svg"
+          alt="DmmLogo"
+        />
+        <img
+          class="onlyVisibleInLightMode"
+          style="animation: pulse 800ms linear infinite; margin: auto;"
+          width="160px"
+          src="/logo.svg"
           alt="DmmLogo"
         />
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -213,6 +213,40 @@
         />
       </div>
     </div>
+    <script>
+      ;(() => {
+        function setInitialColorMode() {
+          function getInitialColorMode() {
+            const preference = window.localStorage.getItem('theme')
+            const hasExplicitPreference = typeof preference === 'string'
+            if (hasExplicitPreference) {
+              try {
+                // need JSON.parse here as we useLocalStorage when storing theme mode
+                const mode = JSON.parse(preference)
+                return mode
+              } catch (e) {
+                // empty
+              }
+            }
+            // If there is no saved preference, use a media query
+            const mediaQuery = '(prefers-color-scheme: dark)'
+            const mql = window.matchMedia(mediaQuery)
+            const hasImplicitPreference = typeof mql.matches === 'boolean'
+            if (hasImplicitPreference) {
+              return mql.matches ? 'dark' : 'light'
+            }
+            // default to 'light'.
+            return 'light'
+          }
+          const colorMode = getInitialColorMode()
+          const root = document.documentElement
+          root.style.setProperty('--initial-color-mode', colorMode)
+          // add HTML attribute if dark mode
+          if (colorMode === 'dark') document.documentElement.setAttribute('data-theme', 'dark')
+        }
+        setInitialColorMode()
+      })()
+    </script>
     <script src="/charting_library/charting_library.standalone.js"></script>
     <!--
       This HTML file is a template.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,6 +68,7 @@ Sentry.configureScope(scope => {
 
 const preloadhtml = document.querySelector('.preloadhtml')
 const preloadhtmlStyle = document.querySelector('.preloadhtml-style')
+
 const hideLoader = () => {
   setTimeout(() => {
     preloadhtml?.remove()
@@ -75,7 +76,7 @@ const hideLoader = () => {
   }, 100)
 }
 
-const ReactApp = ({ hideLoader }: { hideLoader: () => void }) => {
+const ReactApp = () => {
   useEffect(hideLoader, [])
 
   return (
@@ -104,7 +105,7 @@ const ReactApp = ({ hideLoader }: { hideLoader: () => void }) => {
   )
 }
 
-ReactDOM.render(<ReactApp hideLoader={hideLoader} />, document.getElementById('root'))
+ReactDOM.render(<ReactApp />, document.getElementById('root'))
 
 // if (process.env.REACT_APP_SERVICE_WORKER === 'true') {
 //   serviceWorkerRegistration.register()

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -1,9 +1,8 @@
 import { Pair } from '@kyberswap/ks-sdk-classic'
 import { ChainId, Token } from '@kyberswap/ks-sdk-core'
 import flatMap from 'lodash.flatmap'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
-import { useLocalStorage } from 'react-use'
 
 import { useSingleContractMultipleData } from 'state/multicall/hooks'
 import { SupportedLocale } from 'constants/locales'
@@ -77,47 +76,21 @@ function deserializeToken(serializedToken: SerializedToken): Token {
         serializedToken.name,
       )
 }
-// function deserializeTokenUNI(serializedToken: SerializedToken): TokenUNI {
-//   return new TokenUNI(
-//     serializedToken.chainId,
-//     serializedToken.address,
-//     serializedToken.decimals,
-//     serializedToken.symbol,
-//     serializedToken.name
-//   )
-// }
 
 export function useIsDarkMode(): boolean {
-  const { userDarkMode, matchesDarkMode } = useSelector<
-    AppState,
-    { userDarkMode: boolean | null; matchesDarkMode: boolean }
-  >(
-    ({ user: { matchesDarkMode, userDarkMode } }) => ({
-      userDarkMode,
-      matchesDarkMode,
-    }),
-    shallowEqual,
-  )
+  const userDarkMode = useSelector<AppState, boolean | null>(state => state.user.userDarkMode)
+  const matchesDarkMode = useSelector<AppState, boolean>(state => state.user.matchesDarkMode)
 
-  return userDarkMode === null ? matchesDarkMode : userDarkMode
+  return typeof userDarkMode !== 'boolean' ? matchesDarkMode : userDarkMode
 }
 
 export function useDarkModeManager(): [boolean, () => void] {
-  const [localThemeMode, setLocalThemeMode] = useLocalStorage('theme', '')
   const dispatch = useDispatch<AppDispatch>()
   const darkMode = useIsDarkMode()
 
   const toggleSetDarkMode = useCallback(() => {
     dispatch(updateUserDarkMode({ userDarkMode: !darkMode }))
   }, [darkMode, dispatch])
-
-  useEffect(() => {
-    if (darkMode) {
-      setLocalThemeMode('dark')
-    } else {
-      setLocalThemeMode('light')
-    }
-  }, [darkMode, setLocalThemeMode])
 
   return [darkMode, toggleSetDarkMode]
 }

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -110,7 +110,7 @@ export const defaultShowLiveCharts: { [chainId in ChainId]: boolean } = {
 }
 
 export const initialState: UserState = {
-  userDarkMode: true,
+  userDarkMode: null, // default to system preference
   matchesDarkMode: false,
   userExpertMode: false,
   userLocale: null,


### PR DESCRIPTION
# Description
There's currently a flicker when users go the page. It happens because the preloaded HTML is only in Dark mode. This PR contains:
- Dark/Light mode for the preloaded html
- Check for dark/light mode right when the html is loaded