### PR TITLE
fix(swap): blink when re-fetch aggregator API

### DIFF
--- a/src/components/PoolList/index.tsx
+++ b/src/components/PoolList/index.tsx
@@ -29,7 +29,6 @@ import ShareModal from 'components/ShareModal'
 import { useModalOpen, useOpenModal } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/actions'
 import ListItem from 'components/PoolList/ListItem'
-import useTheme from 'hooks/useTheme'
 import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { Input as PaginationInput } from 'components/Pagination/PaginationInputOnMobile'
 
@@ -369,8 +368,6 @@ const PoolList = ({ currencies, searchValue, isShowOnlyActiveFarmPools, onlyShow
       setSharedPoolId(undefined)
     }
   }, [isShareModalOpen, setSharedPoolId])
-
-  const theme = useTheme()
 
   if (loadingUserLiquidityPositions || loadingPoolsData) return <LocalLoader />
 

--- a/src/components/swapv2/RefreshButton.tsx
+++ b/src/components/swapv2/RefreshButton.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import styled from 'styled-components'
-import { TIME_TO_REFRESH_SWAP_RATE } from '../../constants'
+import { AGGREGATOR_WAITING_TIME, TIME_TO_REFRESH_SWAP_RATE } from '../../constants'
 import { Aggregator } from '../../utils/aggregator'
 import { IconButton } from './styleds'
 
@@ -104,7 +104,7 @@ const StyledArrowLocatorLoading = styled(ArrowLocatorLoading)<{ enable_click_to_
 interface RefreshButtonProps {
   isConfirming?: boolean
   trade?: Aggregator
-  onRefresh: (value?: boolean) => void
+  onRefresh: (resetRoute: boolean, minimumLoadingTime: number) => void
 }
 
 export default function RefreshButton({ isConfirming, trade, onRefresh }: RefreshButtonProps) {
@@ -121,7 +121,7 @@ export default function RefreshButton({ isConfirming, trade, onRefresh }: Refres
         // reset svg animate duration to 0 and UNPAUSE animations
         svgLoadingRef.current.setCurrentTime(0)
         svgLoadingRef.current.unpauseAnimations()
-        interval = setInterval(() => onRefresh(false), TIME_TO_REFRESH_SWAP_RATE * 1000)
+        interval = setInterval(() => onRefresh(false, AGGREGATOR_WAITING_TIME), TIME_TO_REFRESH_SWAP_RATE * 1000)
       } else {
         interval && clearInterval(interval)
         // reset svg animate duration to 0 and PAUSE animations
@@ -137,7 +137,10 @@ export default function RefreshButton({ isConfirming, trade, onRefresh }: Refres
   const enableClickToRefresh = false
 
   return (
-    <IconButton enableClickToRefresh={enableClickToRefresh} onClick={() => enableClickToRefresh && onRefresh(false)}>
+    <IconButton
+      enableClickToRefresh={enableClickToRefresh}
+      onClick={() => enableClickToRefresh && onRefresh(false, AGGREGATOR_WAITING_TIME)}
+    >
       <StyledArrowLocatorLoading enable_click_to_refresh={enableClickToRefresh ? 1 : 0} ref={svgLoadingRef} />
     </IconButton>
   )

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1002,3 +1002,5 @@ export const DEFAULT_OUTPUT_TOKEN_BY_CHAIN: Partial<Record<ChainId, Token>> = {
   [ChainId.OASIS]: USDC[ChainId.OASIS],
   [ChainId.BTTC]: USDT[ChainId.BTTC], // USDT_b
 }
+
+export const AGGREGATOR_WAITING_TIME = 1700 // 1700 means that we at least show '.' '..' '...' '.' '..' '...'

--- a/src/pages/ProAmmPools/index.tsx
+++ b/src/pages/ProAmmPools/index.tsx
@@ -1,5 +1,4 @@
 import { Currency } from '@kyberswap/ks-sdk-core'
-import useTheme from 'hooks/useTheme'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useMedia } from 'react-use'
 import { Field } from 'state/mint/proamm/actions'
@@ -86,7 +85,6 @@ export default function ProAmmPoolList({
   onlyShowStable,
 }: PoolListProps) {
   const above1000 = useMedia('(min-width: 1000px)')
-  const theme = useTheme()
 
   const { data: farms } = useProMMFarms()
 

--- a/src/state/swap/useAggregator.ts
+++ b/src/state/swap/useAggregator.ts
@@ -25,7 +25,7 @@ export function useDerivedSwapInfoV2(): {
   v2Trade: Aggregator | undefined
   tradeComparer: AggregationComparer | undefined
   inputError?: string
-  onRefresh: (value?: boolean) => void
+  onRefresh: (resetRoute: boolean, minimumLoadingTime: number) => void
   loading: boolean
 } {
   const { account } = useActiveWeb3React()

--- a/src/utils/fetchWaiting.ts
+++ b/src/utils/fetchWaiting.ts
@@ -1,0 +1,8 @@
+export default async function fetchWaiting(input: RequestInfo, init?: RequestInit, minimumLoadingTime = 0) {
+  const startTime = Date.now()
+  const response = await fetch(input, init)
+  const endTime = Date.now()
+  const timeoutTime = minimumLoadingTime - (endTime - startTime)
+  await new Promise(resolve => setTimeout(resolve, timeoutTime))
+  return response
+}


### PR DESCRIPTION
Deadline doesn't need to be based on `currentBlockTimestamp`. Instead, `Date.now()` is a better option.