### PR TITLE
Remove default token list from Uniswap

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "@sentry/react": "^6.16.1",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@typeform/embed-react": "^1.2.4",
-    "@uniswap/default-token-list": "^2.0.0",
     "aos": "^2.3.4",
     "d3": "^7.3.0",
     "dayjs": "^1.10.7",

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -1,5 +1,4 @@
 import { ChainId } from '@kyberswap/ks-sdk-core'
-import DEFAULT_TOKEN_LIST from '@uniswap/default-token-list'
 import { Tags, TokenList } from '@uniswap/token-lists'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -65,8 +64,6 @@ function listToTokenMap(list: TokenList): TokenAddressMap {
   listCache?.set(list, map)
   return map
 }
-
-const TRANSFORMED_DEFAULT_TOKEN_LIST = listToTokenMap(DEFAULT_TOKEN_LIST)
 
 // returns all downloaded current lists
 export type ListType = {
@@ -188,10 +185,7 @@ function useDMMTokenList(): TokenAddressMap {
 
 function useDefaultTokenList(): TokenAddressMap {
   const dmmTokens = useDMMTokenList()
-
-  return useMemo(() => {
-    return combineMaps(dmmTokens, TRANSFORMED_DEFAULT_TOKEN_LIST)
-  }, [dmmTokens])
+  return dmmTokens
 }
 
 // get all the tokens from active lists, combine with local default tokens

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,11 +4340,6 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@uniswap/default-token-list@^2.0.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/default-token-list/-/default-token-list-2.3.0.tgz#e5e522e775791999643aac9b0faf1ccfb4c49bd8"
-  integrity sha512-yfd4snv9K20tEbNwy9Vjym41RU3Yb2lN0seKxsgkr+m3f6oub2lWyXfTiNwgGFbOQPDvX4dxjMhA+M+S7mxqKg==
-
 "@uniswap/lib@^4.0.1-alpha":
   version "4.0.1-alpha"
   resolved "https://registry.yarnpkg.com/@uniswap/lib/-/lib-4.0.1-alpha.tgz#2881008e55f075344675b3bca93f020b028fbd02"


### PR DESCRIPTION
# Description
There's a scam KNC on Polygon, which originated from @uniswap/default-token-list. This dependency was removed and some of tokens (from that default list) was merged into ks-assets (PR. https://github.com/KyberNetwork/ks-assets/pull/23)