### PR TITLE
Customize CKEditor css to handle overflowing images

### DIFF
--- a/src/pages/Campaign/CKEditor5_custom.css
+++ b/src/pages/Campaign/CKEditor5_custom.css
@@ -1,0 +1,3 @@
+.ck-content img {
+    max-width: 100%;
+}

--- a/src/pages/Campaign/index.tsx
+++ b/src/pages/Campaign/index.tsx
@@ -41,6 +41,7 @@ import oembed2iframe from 'utils/oembed2iframe'
 
 // This is needed to make sure the UI looks just like in Editor
 import './CKEditor5.css'
+import './CKEditor5_custom.css'
 import ModalSelectCampaign from './ModalSelectCampaign'
 
 const LoaderParagraphs = () => (


### PR DESCRIPTION
# Description
If the admin uploads too big images, they will be scrollable in Campaign page. This PR addresses this by setting max-width on images

| Before        | After           |
| ------------- |:-------------:|
| ![image](https://user-images.githubusercontent.com/19758667/184333405-792c9403-755c-4c52-86c1-9e0ef0eab739.png) | ![image](https://user-images.githubusercontent.com/19758667/184333481-bf2d51c2-a8a2-4274-8199-34d2930751b4.png) |
