### PR TITLE
fix can not change network

### DIFF
--- a/src/components/NetworkModal/index.tsx
+++ b/src/components/NetworkModal/index.tsx
@@ -1,6 +1,8 @@
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
+import { stringify } from 'qs'
 import { X } from 'react-feather'
+import { useHistory } from 'react-router-dom'
 import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
@@ -8,6 +10,7 @@ import { ButtonEmpty } from 'components/Button'
 import Modal from 'components/Modal'
 import { useActiveWeb3React } from 'hooks'
 import { useActiveNetwork } from 'hooks/useActiveNetwork'
+import useParsedQueryString from 'hooks/useParsedQueryString'
 import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useNetworkModalToggle } from 'state/application/hooks'
 import { useIsDarkMode } from 'state/user/hooks'
@@ -83,6 +86,8 @@ export default function NetworkModal(): JSX.Element | null {
   const toggleNetworkModal = useNetworkModalToggle()
   const { changeNetwork } = useActiveNetwork()
   const isDarkMode = useIsDarkMode()
+  const history = useHistory()
+  const qs = useParsedQueryString()
 
   return (
     <Modal isOpen={networkModalOpen} onDismiss={toggleNetworkModal} maxWidth={624}>
@@ -123,7 +128,12 @@ export default function NetworkModal(): JSX.Element | null {
                 padding="0"
                 onClick={() => {
                   toggleNetworkModal()
-                  changeNetwork(key)
+                  changeNetwork(key, () => {
+                    const { networkId, inputCurrency, outputCurrency, ...rest } = qs
+                    history.replace({
+                      search: stringify(rest),
+                    })
+                  })
                 }}
               >
                 <ListItem>

--- a/src/hooks/useActiveNetwork.ts
+++ b/src/hooks/useActiveNetwork.ts
@@ -44,9 +44,9 @@ export function useActiveNetwork() {
   const locationWithoutNetworkId = useMemo(() => {
     // Delete networkId from qs object
     const { networkId, ...qsWithoutNetworkId } = qs
-
     return { ...location, search: stringify({ ...qsWithoutNetworkId }) }
   }, [location, qs])
+
   const changeNetwork = useCallback(
     async (desiredChainId: ChainId, successCallback?: () => void, failureCallback?: () => void) => {
       const switchNetworkParams = {
@@ -58,6 +58,7 @@ export function useActiveNetwork() {
       const isWrongNetwork = error instanceof UnsupportedChainIdError
       if (isNotConnected && !isWrongNetwork) {
         dispatch(updateChainIdWhenNotConnected(desiredChainId))
+        history.push(locationWithoutNetworkId)
         return
       }
 

--- a/src/hooks/useActiveNetwork.ts
+++ b/src/hooks/useActiveNetwork.ts
@@ -58,7 +58,6 @@ export function useActiveNetwork() {
       const isWrongNetwork = error instanceof UnsupportedChainIdError
       if (isNotConnected && !isWrongNetwork) {
         dispatch(updateChainIdWhenNotConnected(desiredChainId))
-        history.push(locationWithoutNetworkId)
         successCallback && successCallback()
         return
       }

--- a/src/hooks/useActiveNetwork.ts
+++ b/src/hooks/useActiveNetwork.ts
@@ -59,6 +59,7 @@ export function useActiveNetwork() {
       if (isNotConnected && !isWrongNetwork) {
         dispatch(updateChainIdWhenNotConnected(desiredChainId))
         history.push(locationWithoutNetworkId)
+        successCallback && successCallback()
         return
       }
 

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -256,7 +256,11 @@ function parseCurrencyFromURLParameter(urlParam: any, chainId: ChainId): string 
   if (typeof urlParam === 'string') {
     const valid = isAddress(urlParam)
     if (valid) return valid
-    return nativeOnChain(chainId).symbol as string
+    const symbolNative = nativeOnChain(chainId).symbol as string
+    /**
+     * handle case ex: at chainId=1 (ethereum) urlParam=BNB => we will return '' to redirect /swap
+     *  */
+    return symbolNative.toLowerCase() === urlParam.toLowerCase() ? symbolNative : ''
   }
   return nativeOnChain(chainId).symbol ?? ''
 }

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -256,11 +256,7 @@ function parseCurrencyFromURLParameter(urlParam: any, chainId: ChainId): string 
   if (typeof urlParam === 'string') {
     const valid = isAddress(urlParam)
     if (valid) return valid
-    const symbolNative = nativeOnChain(chainId).symbol as string
-    /**
-     * handle case ex: at chainId=1 (ethereum) urlParam=BNB => we will return '' to redirect /swap
-     *  */
-    return symbolNative.toLowerCase() === urlParam.toLowerCase() ? symbolNative : ''
+    return nativeOnChain(chainId).symbol as string
   }
   return nativeOnChain(chainId).symbol ?? ''
 }


### PR DESCRIPTION
- fix bug can not change network: [link](https://www.notion.so/kybernetwork/Unable-to-switch-network-with-share-link-when-wallet-is-not-connected-d5bbb9fe7f814c6bbce4aa6ee13ac2d9)
- remove params: `inputCurrency/outputCurrency` when change network to prevent confused.  (product confirmed)
-- you are on ethereum. your url `/swap?networkId=1&inputCurrency=ETH&outputCurrency=...`
you switch network to bnb: your network changed, params still `inputCurrency=ETH`, input currently select BNB. that is confused. 

### **_Note: QC tested done._**