### PR TITLE
fix not select default pair when params wrong

### DIFF
--- a/src/components/Tutorial/TutorialSwap/index.tsx
+++ b/src/components/Tutorial/TutorialSwap/index.tsx
@@ -517,7 +517,9 @@ export default memo(function TutorialSwap() {
       <Walktour
         tooltipSeparation={25}
         disableMaskInteraction
-        customTooltipRenderer={CustomPopup}
+        customTooltipRenderer={(props: WalktourLogic | undefined) => (
+          <CustomPopup {...(props || ({} as WalktourLogic))} />
+        )}
         steps={steps as Step[]}
         isOpen={show}
         initialStepIndex={step}

--- a/src/pages/SwapV2/index.tsx
+++ b/src/pages/SwapV2/index.tsx
@@ -487,6 +487,7 @@ export default function Swap({ history }: RouteComponentProps) {
 
   function findTokenPairFromUrl() {
     let { fromCurrency, toCurrency, network } = getUrlMatchParams()
+    if (!fromCurrency || !network) return
 
     const compareNetwork = getNetworkSlug(chainId)
 
@@ -544,13 +545,15 @@ export default function Swap({ history }: RouteComponentProps) {
 
     const findChainId = SUPPORTED_NETWORKS.find(chainId => NETWORKS_INFO[chainId].route === network) || ChainId.MAINNET
     if (findChainId !== chainId) {
-      changeNetwork(findChainId)
-        .then(() => {
+      changeNetwork(
+        findChainId,
+        () => {
           refIsCheckNetworkAutoSelect.current = true
-        })
-        .catch(() => {
+        },
+        () => {
           navigate('/swap')
-        })
+        },
+      )
     } else {
       refIsCheckNetworkAutoSelect.current = true
     }


### PR DESCRIPTION
**Fix bug**

- when visit: [https://kyberswap.com/swap/ethereum/eth-to-xxx.](https://kyberswap.com/swap/ethereum/eth-to-xxx.)  xxx is not found, 
- expect: redirect to /swap and select default pair ETH vs USDT.
- actual: redirect to /swap and select pair ETH vs USDT **but** wait 1s it auto select KNC vs USDT after that.

**Fix warning tutorial swap**
![image](https://user-images.githubusercontent.com/33005392/186811548-2ae9adab-3166-45c1-8e12-74a762ca0857.png)
