### PR TITLE
fix: can not add liquidity in 1 tick

### DIFF
--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -59,7 +59,6 @@ export default class ErrorBoundary extends React.Component<PropsWithChildren<unk
     })
     e.name = 'AppCrash'
     captureException(e, { level: 'fatal' })
-    localStorage.clear()
   }
 
   render() {
@@ -101,6 +100,7 @@ export default class ErrorBoundary extends React.Component<PropsWithChildren<unk
                 margin="auto"
                 width="fit-content"
                 onClick={() => {
+                  localStorage.clear()
                   window.location.reload()
                 }}
               >

--- a/src/components/ZapError/index.tsx
+++ b/src/components/ZapError/index.tsx
@@ -1,5 +1,4 @@
 import { rgba } from 'polished'
-import React from 'react'
 import { AlertTriangle } from 'react-feather'
 import styled from 'styled-components'
 
@@ -11,7 +10,7 @@ export const ZapErrorWrapper = styled.div<{ warning?: boolean }>`
   gap: 8px;
   background: ${({ theme, warning }) => rgba(warning ? theme.warning : theme.red, 0.35)};
   padding: 1rem;
-  border-radius: 4px;
+  border-radius: 999px;
   margin-bottom: 28px;
   color: ${({ theme }) => theme.text};
   font-size: 12px;

--- a/src/state/burn/hooks.ts
+++ b/src/state/burn/hooks.ts
@@ -452,13 +452,14 @@ export function useDerivedZapOutInfo(
 
   if (
     zapOutAmount.error &&
-    (zapOutAmount.error.message.includes('INSUFFICIENT_LIQUIDITY') ||
-      zapOutAmount.error.data?.message.includes('INSUFFICIENT_LIQUIDITY'))
+    (zapOutAmount.error.message?.includes('INSUFFICIENT_LIQUIDITY') ||
+      zapOutAmount.error.data?.message?.includes('INSUFFICIENT_LIQUIDITY'))
   ) {
     insufficientLiquidity = true
   }
 
   if (zapOutAmount.error && !insufficientLiquidity) {
+    console.error(zapOutAmount.error)
     error = t`Something went wrong`
   }
 

--- a/src/state/mint/proamm/hooks.tsx
+++ b/src/state/mint/proamm/hooks.tsx
@@ -363,7 +363,7 @@ export function useProAmmDerivedMintInfo(
     typeof tickUpper === 'number' && poolForPosition && poolForPosition.tickCurrent >= tickUpper,
   )
   const deposit1Disabled = Boolean(
-    typeof tickLower === 'number' && poolForPosition && poolForPosition.tickCurrent <= tickLower,
+    typeof tickLower === 'number' && poolForPosition && poolForPosition.tickCurrent < tickLower,
   )
   // sorted for token order
   const depositADisabled =


### PR DESCRIPTION
- Can not add liquidity in 1 tick
![image](https://user-images.githubusercontent.com/11427213/187488882-11343c20-189e-45ad-a3d0-a115b9d50610.png)

- Page crash for some classic position when pool inactive