### PR TITLE
Display tooltip for APR values in both mobile and desktop in Pool/Farm pages

### DIFF
--- a/src/components/PoolList/ItemCard/ItemCardInfoRow.tsx
+++ b/src/components/PoolList/ItemCard/ItemCardInfoRow.tsx
@@ -9,14 +9,14 @@ import InfoHelper from 'components/InfoHelper'
 import { SubgraphPoolData } from 'state/pools/hooks'
 import { priceRangeCalcBySubgraphPool } from 'utils/dmm'
 
-const Field = styled.div`
+export const Field = styled.div`
   font-size: 12px;
   font-weight: 500;
   color: ${({ theme }) => theme.subText};
   line-height: 24px;
 `
 
-const Value = styled.div`
+export const Value = styled.div`
   font-size: 12px;
   font-weight: 400;
   color: ${({ theme }) => theme.text};

--- a/src/components/PoolList/ItemCard/TabInfoItems.tsx
+++ b/src/components/PoolList/ItemCard/TabInfoItems.tsx
@@ -1,11 +1,16 @@
-import { t } from '@lingui/macro'
-import React from 'react'
+import { Trans, t } from '@lingui/macro'
+import { Flex, Text } from 'rebass'
 
-import ItemCardInfoRow from 'components/PoolList/ItemCard/ItemCardInfoRow'
+import InfoHelper from 'components/InfoHelper'
+import FarmingPoolAPRCell from 'components/YieldPools/FarmingPoolAPRCell'
 import { MAX_ALLOW_APY } from 'constants/index'
+import useTheme from 'hooks/useTheme'
+import { useActiveAndUniqueFarmsData } from 'state/farms/hooks'
 import { SubgraphPoolData, UserLiquidityPosition } from 'state/pools/hooks'
 import { formattedNum } from 'utils'
 import { getMyLiquidity, getTradingFeeAPR } from 'utils/dmm'
+
+import ItemCardInfoRow, { Field, Value } from './ItemCardInfoRow'
 
 export default function TabInfoItems({
   poolData,
@@ -14,19 +19,54 @@ export default function TabInfoItems({
   poolData: SubgraphPoolData
   myLiquidity: UserLiquidityPosition | undefined
 }) {
+  const theme = useTheme()
   const volume = poolData?.oneDayVolumeUSD ? poolData?.oneDayVolumeUSD : poolData?.oneDayVolumeUntracked
   const fee = poolData?.oneDayFeeUSD ? poolData?.oneDayFeeUSD : poolData?.oneDayFeeUntracked
   const totalValueLocked = formattedNum(`${parseFloat(poolData?.reserveUSD)}`, true)
   const oneYearFL = getTradingFeeAPR(poolData?.reserveUSD, fee).toFixed(2)
 
+  const { data: uniqueAndActiveFarms } = useActiveAndUniqueFarmsData()
+  const farm = uniqueAndActiveFarms.find(f => f.id.toLowerCase() === poolData.id.toLowerCase())
+  const isFarmingPool = !!farm
+
+  const renderAPR = () => {
+    if (Number(oneYearFL) > MAX_ALLOW_APY) {
+      return '--'
+    }
+
+    if (isFarmingPool) {
+      return (
+        <FarmingPoolAPRCell
+          tooltipPlacement="top"
+          poolAPR={Number(oneYearFL)}
+          fairlaunchAddress={farm.fairLaunchAddress}
+          pid={farm.pid}
+        />
+      )
+    }
+
+    return <Value>{oneYearFL}%</Value>
+  }
+
   return (
     <>
       <ItemCardInfoRow name={t`Total Value Locked`} value={totalValueLocked as string} />
-      <ItemCardInfoRow
-        name="APR"
-        value={Number(oneYearFL) > MAX_ALLOW_APY ? '--' : oneYearFL + '%'}
-        infoHelperText={t`Estimated return based on yearly fees of the pool`}
-      />
+      <Flex justifyContent="space-between">
+        <Field>
+          <Flex>
+            <Text>
+              <Trans>APR</Trans>
+            </Text>
+            <InfoHelper text={t`Estimated return based on yearly fees of the pool`} />
+          </Flex>
+        </Field>
+        <Flex
+          alignItems="center"
+          sx={{ gap: '4px', fontSize: '12px', fontWeight: 400, color: theme.text, lineHeight: '24px' }}
+        >
+          {renderAPR()}
+        </Flex>
+      </Flex>
       <ItemCardInfoRow name={t`Volume (24H)`} value={formattedNum(volume, true)} />
       <ItemCardInfoRow name={t`Fees (24H)`} value={formattedNum(fee, true)} />
       <ItemCardInfoRow name={t`Your Liquidity Balance`} value={getMyLiquidity(myLiquidity)} />

--- a/src/components/YieldPools/FarmingPoolAPRCell.tsx
+++ b/src/components/YieldPools/FarmingPoolAPRCell.tsx
@@ -1,19 +1,24 @@
-import { t } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
+import { Placement } from '@popperjs/core'
+import { useMedia } from 'react-use'
 import { Box, Flex, Text } from 'rebass'
 
 import { MoneyBag } from 'components/Icons'
 import { MouseoverTooltip } from 'components/Tooltip'
 import useTheme from 'hooks/useTheme'
 import { useProMMFarmTVL } from 'state/farms/promm/hooks'
+import { MEDIA_WIDTHS } from 'theme'
 
 type Props = {
   poolAPR: number
   fairlaunchAddress: string
   pid: number
+  tooltipPlacement?: Placement
 }
 
 export const APRTooltipContent = ({ poolAPR, farmAPR }: { poolAPR: number; farmAPR: number }) => {
   const theme = useTheme()
+  const upToSmall = useMedia(`(max-width: ${MEDIA_WIDTHS.upToSmall}px)`)
 
   return (
     <Flex
@@ -21,7 +26,7 @@ export const APRTooltipContent = ({ poolAPR, farmAPR }: { poolAPR: number; farmA
         flexDirection: 'column',
         background: theme.tableHeader,
         gap: '8px',
-        width: 'fit-content',
+        width: upToSmall ? '300px' : 'fit-content',
       }}
     >
       <Text as="span" fontSize={'14px'}>
@@ -52,8 +57,12 @@ export const APRTooltipContent = ({ poolAPR, farmAPR }: { poolAPR: number; farmA
         <Text
           as="span"
           fontStyle="italic"
-          sx={{ whiteSpace: 'nowrap' }}
-        >{t`Estimated return from trading fees if you participate in the pool`}</Text>
+          sx={{
+            whiteSpace: upToSmall ? 'wrap' : 'nowrap',
+          }}
+        >
+          <Trans>Estimated return from trading fees if you participate in the pool</Trans>
+        </Text>
       </Flex>
 
       <Flex
@@ -72,17 +81,20 @@ export const APRTooltipContent = ({ poolAPR, farmAPR }: { poolAPR: number; farmA
         <Text
           as="span"
           fontStyle="italic"
-          sx={{ whiteSpace: 'nowrap' }}
-        >{t`Estimated return from additional rewards if you also participate in the farm`}</Text>
+          sx={{
+            whiteSpace: upToSmall ? 'wrap' : 'nowrap',
+          }}
+        >
+          <Trans>Estimated return from additional rewards if you also participate in the farm</Trans>
+        </Text>
       </Flex>
     </Flex>
   )
 }
 
-const FarmingPoolAPRCell: React.FC<Props> = ({ poolAPR, fairlaunchAddress, pid }) => {
+const FarmingPoolAPRCell: React.FC<Props> = ({ poolAPR, fairlaunchAddress, pid, tooltipPlacement = 'right' }) => {
   const theme = useTheme()
   const { farmAPR } = useProMMFarmTVL(fairlaunchAddress, pid)
-
   return (
     <Flex
       alignItems={'center'}
@@ -90,10 +102,10 @@ const FarmingPoolAPRCell: React.FC<Props> = ({ poolAPR, fairlaunchAddress, pid }
         gap: '4px',
       }}
     >
-      {(poolAPR + farmAPR).toFixed(2)}%
+      <Text as="span">{(poolAPR + farmAPR).toFixed(2)}%</Text>
       <MouseoverTooltip
         width="fit-content"
-        placement="right"
+        placement={tooltipPlacement}
         text={<APRTooltipContent farmAPR={farmAPR} poolAPR={poolAPR} />}
       >
         <MoneyBag size={16} color={theme.apr} />

--- a/src/components/YieldPools/ListItem.tsx
+++ b/src/components/YieldPools/ListItem.tsx
@@ -715,12 +715,16 @@ const ListItem = ({ farm, setSharedPoolAddress }: ListItemProps) => {
                 />
               </Text>
 
-              <Text color={theme.apr} fontWeight="500">
-                {apr.toFixed(2)}%
-                {apr !== 0 && (
-                  <InfoHelper text={t`${tradingFeeAPR.toFixed(2)}% LP Fee + ${farmAPR.toFixed(2)}% Rewards`} />
-                )}
-              </Text>
+              <Flex alignItems={'center'} sx={{ gap: '4px' }} color={theme.apr} fontWeight="500">
+                <Text as="span">{(tradingFeeAPR + farmAPR).toFixed(2)}%</Text>
+                <MouseoverTooltip
+                  width="fit-content"
+                  placement="top"
+                  text={<APRTooltipContent farmAPR={farmAPR} poolAPR={tradingFeeAPR} />}
+                >
+                  <MoneyBag size={16} color={theme.apr} />
+                </MouseoverTooltip>
+              </Flex>
             </Flex>
 
             <Flex justifyContent="space-between" fontSize={12} marginTop="12px">

--- a/src/components/YieldPools/ProMMFarmGroup/Row.tsx
+++ b/src/components/YieldPools/ProMMFarmGroup/Row.tsx
@@ -312,10 +312,16 @@ const Row = ({
                 }
               />
             </Text>
-            <Text color={theme.apr}>
-              {(farmAPR + poolAPY).toFixed(2)}%
-              <InfoHelper text={`${poolAPY.toFixed(2)}% Fee + ${farmAPR.toFixed(2)}% Rewards`} />
-            </Text>
+            <Flex alignItems={'center'} sx={{ gap: '4px' }} color={theme.apr}>
+              <Text as="span">{(farmAPR + poolAPY).toFixed(2)}%</Text>
+              <MouseoverTooltip
+                width="fit-content"
+                placement="top"
+                text={<APRTooltipContent farmAPR={farmAPR} poolAPR={poolAPY} />}
+              >
+                <MoneyBag size={16} color={theme.apr} />
+              </MouseoverTooltip>
+            </Flex>
           </InfoRow>
 
           <InfoRow>


### PR DESCRIPTION
# Description

| Page | Mobile | Desktop |
| --- | --- | --- |
| Elastic pool | ![image](https://user-images.githubusercontent.com/19758667/190635292-ef772c2f-53db-4e69-b754-2a81cb45f569.png) | ![image](https://user-images.githubusercontent.com/19758667/190635335-2ecd2284-8032-4aa3-a7c4-03071cbb7f5e.png) |
| Elastic farm | ![image](https://user-images.githubusercontent.com/19758667/190635549-d80fac76-3938-4dff-9635-f45cae8fe539.png) | ![image](https://user-images.githubusercontent.com/19758667/190635525-0c7faf32-6dd1-44ac-9ec9-b1fe145fbf6e.png) |


