### PR TITLE
Support Eth PoW

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "workbox-routing": "^6.3.0"
   },
   "resolutions": {
-    "@kyberswap/ks-sdk-core": "^0.0.15-beta-1",
+    "@kyberswap/ks-sdk-core": "^0.0.16",
     "trezor-connect": "8.1.15",
     "react-error-overlay": "6.0.9"
   },
@@ -129,7 +129,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.11",
     "@kyberswap/ks-sdk-classic": "^0.0.13",
-    "@kyberswap/ks-sdk-core": "^0.0.15-beta-1",
+    "@kyberswap/ks-sdk-core": "^0.0.16",
     "@kyberswap/ks-sdk-elastic": "^0.0.43",
     "@lingui/react": "^3.14.0",
     "@sentry/react": "^7.11.1",

--- a/src/components/TradingViewChart/datafeed.tsx
+++ b/src/components/TradingViewChart/datafeed.tsx
@@ -47,6 +47,8 @@ const getNetworkString = (chainId: ChainId | undefined) => {
       return 'chain-oasis'
     case ChainId.OPTIMISM:
       return 'chain-optimism'
+    case ChainId.ETHW:
+      return 'chain-ethw'
     default:
       return ''
   }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -169,7 +169,7 @@ export const DAI: { [chainId in ChainId]: Token } = {
 
 export const USDC: { [chainId in ChainId]: Token } = {
   [ChainId.MAINNET]: new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC', 'USD Coin'),
-  [ChainId.ETHW]: new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC', 'USD Coin'),
+  [ChainId.ETHW]: new Token(ChainId.MAINNET, '0x25de68ef588cb0c2c8f3537861e828ae699cd0db', 6, 'USDC', 'USD Coin'),
   [ChainId.ROPSTEN]: new Token(ChainId.ROPSTEN, '0x068B43f7F2f2c6a662C36E201144aE45f7a1C040', 6, 'USDC', 'USD Coin'),
   [ChainId.RINKEBY]: new Token(ChainId.RINKEBY, '0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b', 6, 'USDC', 'USD Coin'),
   [ChainId.GÖRLI]: new Token(ChainId.GÖRLI, '0x8e9Bd30D15420bAe4B7EC0aC014B7ECeE864373C', 18, 'USDC', 'USD Coin'),
@@ -237,7 +237,7 @@ export const USDC: { [chainId in ChainId]: Token } = {
 
 export const USDT: { [chainId in ChainId]: Token } = {
   [ChainId.MAINNET]: new Token(ChainId.MAINNET, '0xdAC17F958D2ee523a2206206994597C13D831ec7', 6, 'USDT', 'Tether USD'),
-  [ChainId.ETHW]: new Token(ChainId.MAINNET, '0xdAC17F958D2ee523a2206206994597C13D831ec7', 6, 'USDT', 'Tether USD'),
+  [ChainId.ETHW]: new Token(ChainId.MAINNET, '0x2ad7868ca212135c6119fd7ad1ce51cfc5702892', 6, 'USDT', 'Tether'),
   [ChainId.ROPSTEN]: new Token(ChainId.ROPSTEN, '0x65Bd1F48f1dd07bb285a3715c588F75684128acE', 6, 'USDT', 'Tether USD'),
   [ChainId.RINKEBY]: new Token(ChainId.RINKEBY, '0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02', 18, 'USDT', 'Tether USD'),
   [ChainId.GÖRLI]: new Token(ChainId.GÖRLI, '0x2bf64acf7ead856209749d0d125e9ade2d908e7f', 18, 'USDT', 'Tether USD'),
@@ -550,7 +550,7 @@ export const SUGGESTED_BASES: ChainTokenList = {
     USDC[ChainId.MAINNET],
     USDT[ChainId.MAINNET],
   ],
-
+  [ChainId.ETHW]: [USDT[ChainId.ETHW], USDC[ChainId.ETHW]],
   [ChainId.GÖRLI]: [...WETH_ONLY[ChainId.GÖRLI], DAI[ChainId.GÖRLI], USDC[ChainId.GÖRLI], USDT[ChainId.GÖRLI]],
   [ChainId.MATIC]: [
     ...WETH_ONLY[ChainId.MATIC],

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -106,7 +106,7 @@ export const defaultShowLiveCharts: { [chainId in ChainId]: boolean } = {
   [ChainId.CRONOSTESTNET]: false,
   [ChainId.AVAXTESTNET]: false,
   [ChainId.ARBITRUM_TESTNET]: false,
-  [ChainId.ETHW]: false,
+  [ChainId.ETHW]: true,
 }
 
 export const initialState: UserState = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -442,17 +442,19 @@ export const getTokenLogoURL = (inputAddress: string, chainId?: ChainId): string
     address = WETH[chainId].address
   }
 
-  if (address.toLowerCase() === KNC[chainId as ChainId].address.toLowerCase()) {
-    return 'https://raw.githubusercontent.com/KyberNetwork/kyberswap-interface/develop/src/assets/images/KNC.svg'
-  }
+  if (chainId !== ChainId.ETHW) {
+    if (address.toLowerCase() === KNC[chainId as ChainId].address.toLowerCase()) {
+      return 'https://raw.githubusercontent.com/KyberNetwork/kyberswap-interface/develop/src/assets/images/KNC.svg'
+    }
 
-  if (address.toLowerCase() === KNCL_ADDRESS.toLowerCase()) {
-    return 'https://raw.githubusercontent.com/KyberNetwork/kyberswap-interface/develop/src/assets/images/KNCL.png'
-  }
+    if (address.toLowerCase() === KNCL_ADDRESS.toLowerCase()) {
+      return 'https://raw.githubusercontent.com/KyberNetwork/kyberswap-interface/develop/src/assets/images/KNCL.png'
+    }
 
-  // WBTC
-  if (address.toLowerCase() === '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f') {
-    return 'https://assets.coingecko.com/coins/images/7598/thumb/wrapped_bitcoin_wbtc.png?1548822744'
+    // WBTC
+    if (address.toLowerCase() === '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f') {
+      return 'https://assets.coingecko.com/coins/images/7598/thumb/wrapped_bitcoin_wbtc.png?1548822744'
+    }
   }
 
   let imageURL
@@ -462,6 +464,7 @@ export const getTokenLogoURL = (inputAddress: string, chainId?: ChainId): string
     .lists.byUrl[NETWORKS_INFO[chainId || ChainId.MAINNET].tokenListUrl].current?.tokens.find(
       item => item.address.toLowerCase() === address.toLowerCase(),
     )?.logoURI
+
   if (imageURL) return imageURL
 
   switch (chainId) {
@@ -502,6 +505,10 @@ export const getTokenLogoURL = (inputAddress: string, chainId?: ChainId): string
     case ChainId.ARBITRUM:
       imageURL = `https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/arbitrum/assets/${address}/logo.png`
       break
+    case ChainId.ETHW: {
+      imageURL = ''
+      break
+    }
     default:
       imageURL = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${isAddress(
         address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,10 +2715,10 @@
     tiny-warning "^1.0.3"
     toformat "^2.0.0"
 
-"@kyberswap/ks-sdk-core@^0.0.12", "@kyberswap/ks-sdk-core@^0.0.15-beta-1":
-  version "0.0.15-beta-1"
-  resolved "https://registry.yarnpkg.com/@kyberswap/ks-sdk-core/-/ks-sdk-core-0.0.15-beta-1.tgz#6217b487a4464d2bbbb9387867292d8d8b8d53fb"
-  integrity sha512-mM7G/02o0kIr5H2kYW5WtwYsKPRd7pPcFhV9TdQuzFrX9faqEEzJa7Fi1kXowermmjKGS2oEtG4gYdGMYwiIZA==
+"@kyberswap/ks-sdk-core@^0.0.12", "@kyberswap/ks-sdk-core@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@kyberswap/ks-sdk-core/-/ks-sdk-core-0.0.16.tgz#3d0f3d69423b3943a449f4d5f3d6c585b68995fb"
+  integrity sha512-7hrK4IHCCf9C32RvZIgOeGy/6b0vQAw/Gx77GNoZPzPIQqH1mwWorZ7PYOEJb8xThJ3d6jjvbZjSng/KHfXhwA==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     big.js "^5.2.2"


### PR DESCRIPTION
# Description
- Config for Live Chart on EthPoW (add params so that it can fetch data from DexTool)
- Update token addresses on EthPoW that were hard-coded
- Upgrade KS SDK to 0.0.16 to have the latest WETHW address
- Fix common bases on EthPoW
- Remove fallback for token logo url. Display the exact url returned from KS Settings