### PR TITLE
Exclude ended farms in Add Liquidity page

### DIFF
--- a/src/components/FeeSelector/index.tsx
+++ b/src/components/FeeSelector/index.tsx
@@ -156,8 +156,10 @@ function FeeSelector({
     setShow(false)
   })
 
+  const now = Date.now() / 1000
   const farmingPoolAddress = Object.values(farms)
     .flat()
+    .filter(farm => farm.endTime >= now)
     .map(farm => farm.poolAddress)
 
   const poolAddresses = useProAmmPoolInfos(currencyA, currencyB, FEE_AMOUNTS)


### PR DESCRIPTION
# Description
Without filtering ended farms, the farm icon was displayed

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19758667/192420277-247e8f3d-1b5a-4bb5-babe-eb6c07554828.png) | ![image](https://user-images.githubusercontent.com/19758667/192420315-8079c821-b02a-4699-9957-2f5471facb05.png) |