### PR TITLE
Use Popover to avoid tooltip content being cut in Stake modal

### DIFF
--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -80,9 +80,10 @@ export interface PopoverProps {
   show: boolean
   children: React.ReactNode
   placement?: Placement
+  noArrow?: boolean
 }
 
-export default function Popover({ content, show, children, placement = 'auto' }: PopoverProps) {
+export default function Popover({ content, show, children, placement = 'auto', noArrow = false }: PopoverProps) {
   const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null)
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null)
   const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null)
@@ -105,12 +106,14 @@ export default function Popover({ content, show, children, placement = 'auto' }:
       <Portal>
         <PopoverContainer show={show} ref={setPopperElement as any} style={styles.popper} {...attributes.popper}>
           {content}
-          <Arrow
-            className={`arrow-${attributes.popper?.['data-popper-placement'] ?? ''}`}
-            ref={setArrowElement as any}
-            style={styles.arrow}
-            {...attributes.arrow}
-          />
+          {noArrow || (
+            <Arrow
+              className={`arrow-${attributes.popper?.['data-popper-placement'] ?? ''}`}
+              ref={setArrowElement as any}
+              style={styles.arrow}
+              {...attributes.arrow}
+            />
+          )}
         </PopoverContainer>
       </Portal>
     </>

--- a/src/components/YieldPools/ProMMFarmModals/StakeModal.tsx
+++ b/src/components/YieldPools/ProMMFarmModals/StakeModal.tsx
@@ -7,13 +7,14 @@ import { useMedia } from 'react-use'
 import { Flex, Text } from 'rebass'
 import styled, { css } from 'styled-components'
 
+import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
 import RangeBadge from 'components/Badge/RangeBadge'
 import { ButtonEmpty, ButtonPrimary } from 'components/Button'
 import Checkbox from 'components/CheckBox'
 import CurrencyLogo from 'components/CurrencyLogo'
 import DoubleCurrencyLogo from 'components/DoubleLogo'
-import HoverDropdown from 'components/HoverDropdown'
 import Modal from 'components/Modal'
+import { MouseoverTooltip } from 'components/Tooltip'
 import { VERSION } from 'constants/v2'
 import { useToken } from 'hooks/Tokens'
 import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
@@ -39,12 +40,21 @@ const generateCommonCSS = (isUnstake: boolean) => {
   `
 }
 
+const DropdownIcon = styled(DropdownSVG)`
+  transition: transform 300ms;
+  color: ${({ theme }) => theme.text};
+  &:hover {
+    transform: rotate(180deg);
+  }
+`
+
 const ScrollContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-height: 240px;
 
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
 
   /* width */
@@ -156,10 +166,12 @@ const PositionRow = ({
       )}
       {type === 'stake' && (
         <Flex justifyContent="flex-end" sx={{ gap: '4px' }} alignItems="center" fontSize="12px">
-          <HoverDropdown
-            placement="right"
-            content={formatDollarAmount(availableUSD)}
-            dropdownContent={
+          {formatDollarAmount(availableUSD)}
+          <MouseoverTooltip
+            noArrow
+            placement="bottom"
+            width="fit-content"
+            text={
               <>
                 <Flex alignItems="center">
                   <CurrencyLogo currency={positionAvailable?.amount0.currency} size="16px" />
@@ -175,15 +187,19 @@ const PositionRow = ({
                 </Flex>
               </>
             }
-          />
+          >
+            <DropdownIcon />
+          </MouseoverTooltip>
         </Flex>
       )}
       {(type === 'unstake' || above768) && (
         <Flex justifyContent="flex-end" sx={{ gap: '4px' }} alignItems="center" fontSize="12px">
-          <HoverDropdown
-            placement="right"
-            content={formatDollarAmount(usd)}
-            dropdownContent={
+          {formatDollarAmount(usd)}
+          <MouseoverTooltip
+            noArrow
+            placement="bottom"
+            width="fit-content"
+            text={
               <>
                 <Flex alignItems="center">
                   <CurrencyLogo currency={positionStake?.amount0.currency} size="16px" />
@@ -199,7 +215,9 @@ const PositionRow = ({
                 </Flex>
               </>
             }
-          />
+          >
+            <DropdownIcon />
+          </MouseoverTooltip>
         </Flex>
       )}
 


### PR DESCRIPTION
# Description
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19758667/192432687-d7ca02f7-4684-4d10-af9c-1e6bb66fa91e.png) | ![image](https://user-images.githubusercontent.com/19758667/192432502-0816d453-bffb-4f5c-805a-40b339becd19.png) |