### PR TITLE
Set padding of tutorial button to 0

### DIFF
--- a/src/components/swapv2/styleds.tsx
+++ b/src/components/swapv2/styleds.tsx
@@ -377,6 +377,7 @@ export const StyledActionButtonSwapForm = styled.button<{ active?: boolean; hove
   border: none;
   background-color: transparent;
   margin: 0;
+  padding: 0;
   height: 36px;
   width: 36px;
   border-radius: 999px;


### PR DESCRIPTION
# Description
Safari (and maybe, some other browsers) has default padding, so set padding=0

| Before | After |
| --- | --- |
| ![IMG_0023](https://user-images.githubusercontent.com/19758667/194030877-0782df7a-f0ce-40aa-a8cc-3ddbacbe450e.PNG) | ![IMG_0024](https://user-images.githubusercontent.com/19758667/194030910-e6af668a-90a7-4d04-9bc5-bddba2ef976b.PNG) |