### PR TITLE
update ux bridge

### DIFF
--- a/src/components/SearchModal/bridge/CurrencyListBridge.tsx
+++ b/src/components/SearchModal/bridge/CurrencyListBridge.tsx
@@ -1,5 +1,4 @@
 import { Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
-import { t } from '@lingui/macro'
 import { CSSProperties, memo, useCallback } from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { FixedSizeList } from 'react-window'
@@ -7,6 +6,7 @@ import { Flex, Text } from 'rebass'
 
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
+import { formatPoolValue } from 'pages/Bridge/helpers'
 import { MultiChainTokenInfo } from 'pages/Bridge/type'
 import { useBridgeState } from 'state/bridge/hooks'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
@@ -43,7 +43,7 @@ const CurrencyListBridge = memo(function CurrencyListV2({
       const handleSelect = () => currency && onCurrencySelect(currency)
       const { symbol } = getDisplayTokenInfo(currency)
       const { sortId, type, anytoken } = (currency?.multichainInfo || {}) as Partial<MultiChainTokenInfo>
-      const poolLiquidity = isOutput && anytoken?.address ? poolValueOut?.[anytoken?.address] ?? t`Unlimited` : 0
+      const poolLiquidity = isOutput && anytoken?.address ? formatPoolValue(poolValueOut?.[anytoken?.address]) : 0
 
       return (
         <CurrencyRow

--- a/src/components/SearchModal/bridge/CurrencyListBridge.tsx
+++ b/src/components/SearchModal/bridge/CurrencyListBridge.tsx
@@ -30,7 +30,7 @@ const CurrencyListBridge = memo(function CurrencyListV2({
   isOutput: boolean | undefined
 }) {
   const { account } = useActiveWeb3React()
-  const [{ tokenInfoIn, tokenInfoOut, poolValueOut }] = useBridgeState()
+  const [{ tokenInfoIn, tokenInfoOut, poolValueOutMap }] = useBridgeState()
   const currencyBalances = useCurrencyBalances(account || undefined, !isOutput ? currencies : [])
   const theme = useTheme()
 
@@ -43,7 +43,7 @@ const CurrencyListBridge = memo(function CurrencyListV2({
       const handleSelect = () => currency && onCurrencySelect(currency)
       const { symbol } = getDisplayTokenInfo(currency)
       const { sortId, type, anytoken } = (currency?.multichainInfo || {}) as Partial<MultiChainTokenInfo>
-      const poolLiquidity = isOutput && anytoken?.address ? formatPoolValue(poolValueOut?.[anytoken?.address]) : 0
+      const poolLiquidity = isOutput && anytoken?.address ? formatPoolValue(poolValueOutMap?.[anytoken?.address]) : 0
 
       return (
         <CurrencyRow
@@ -69,7 +69,7 @@ const CurrencyListBridge = memo(function CurrencyListV2({
         />
       )
     },
-    [onCurrencySelect, tokenInfoIn, isOutput, tokenInfoOut, theme, poolValueOut],
+    [onCurrencySelect, tokenInfoIn, isOutput, tokenInfoOut, theme, poolValueOutMap],
   )
 
   return (

--- a/src/pages/Bridge/PoolInfo.tsx
+++ b/src/pages/Bridge/PoolInfo.tsx
@@ -15,7 +15,7 @@ const PoolInfo = ({
 }: {
   chainId: ChainId | undefined
   tokenIn: MultiChainTokenInfo | undefined
-  poolValue: string | undefined
+  poolValue: string | number | undefined
 }) => {
   const theme = useTheme()
   return (

--- a/src/pages/Bridge/SwapForm.tsx
+++ b/src/pages/Bridge/SwapForm.tsx
@@ -161,8 +161,8 @@ export default function SwapForm() {
   }, [poolDataOut, listTokenOut, tokenInfoOut, setBridgePoolInfo])
 
   useEffect(() => {
-    setBridgeState({ chainIdOut: listChainOut[0] })
-  }, [setBridgeState, listChainOut])
+    if (!listChainOut.find(el => el === chainIdOut)) setBridgeState({ chainIdOut: listChainOut[0] })
+  }, [setBridgeState, listChainOut, chainIdOut])
 
   useEffect(() => {
     setBridgeState({ tokenOut: listTokenOut[0] || null })

--- a/src/pages/Bridge/SwapForm.tsx
+++ b/src/pages/Bridge/SwapForm.tsx
@@ -74,8 +74,8 @@ const calcPoolValue = (amount: string, decimals: number) => {
 }
 
 type PoolValueType = {
-  poolValueIn: string | undefined // undefined: unlimit
-  poolValueOut: string | undefined
+  poolValueIn: string | number | undefined // undefined: unlimited
+  poolValueOut: string | number | undefined
 }
 
 export default function SwapForm() {
@@ -142,31 +142,43 @@ export default function SwapForm() {
 
   useEffect(() => {
     const poolValueOutMap: PoolValueOutMap = {}
-    let poolValueOut: string | undefined
-    if (poolDataOut) {
-      Object.keys(poolDataOut).forEach(anytokenAddress => {
+    let poolValueOut: string | undefined | number
+    let tokenWithMaxPool
+    let maxPoolValue = -1
+    let hasUnlimitedPool = false
+
+    if (poolDataOut && listTokenOut.length) {
+      listTokenOut.forEach(token => {
+        const anytokenAddress = token.multichainInfo?.anytoken?.address ?? ''
         const poolInfo = poolDataOut?.[anytokenAddress]
-        const token = listTokenOut.find(e => e.multichainInfo?.anytoken?.address === anytokenAddress)
-        if (!poolInfo?.balanceOf || !token?.multichainInfo?.anytoken?.decimals) return
-        if (anytokenAddress === tokenInfoOut?.anytoken?.address) {
-          poolValueOut = calcPoolValue(poolInfo?.balanceOf, tokenInfoOut?.anytoken?.decimals)
+        if (!poolInfo) {
+          tokenWithMaxPool = token
+          hasUnlimitedPool = true
+          return
         }
-        poolValueOutMap[anytokenAddress] = formatPoolValue(
-          calcPoolValue(poolInfo?.balanceOf, token?.multichainInfo?.anytoken?.decimals),
-        )
+
+        if (!poolInfo?.balanceOf || !token?.multichainInfo?.anytoken?.decimals) return
+        const calcValue = calcPoolValue(poolInfo?.balanceOf, token?.multichainInfo?.anytoken?.decimals)
+        poolValueOutMap[anytokenAddress] = calcValue
+        if (Number(calcValue) > maxPoolValue && !hasUnlimitedPool) {
+          tokenWithMaxPool = token
+          maxPoolValue = Number(calcValue)
+        }
       })
     }
+    const tokenOut = tokenWithMaxPool || listTokenOut[0] || null
+    const anyTokenOut = tokenOut?.multichainInfo?.anytoken?.address
+    if (typeof anyTokenOut === 'string' && poolValueOutMap[anyTokenOut]) {
+      poolValueOut = poolValueOutMap[anyTokenOut]
+    }
+    setBridgeState({ tokenOut })
     setPoolValue(poolValue => ({ ...poolValue, poolValueOut }))
     setBridgePoolInfo({ poolValueOut: poolValueOutMap })
-  }, [poolDataOut, listTokenOut, tokenInfoOut, setBridgePoolInfo])
+  }, [poolDataOut, listTokenOut, setBridgePoolInfo, setBridgeState])
 
   useEffect(() => {
     if (!listChainOut.find(el => el === chainIdOut)) setBridgeState({ chainIdOut: listChainOut[0] })
   }, [setBridgeState, listChainOut, chainIdOut])
-
-  useEffect(() => {
-    setBridgeState({ tokenOut: listTokenOut[0] || null })
-  }, [setBridgeState, listTokenOut])
 
   useEffect(() => {
     setInputAmount('')

--- a/src/pages/Bridge/SwapForm.tsx
+++ b/src/pages/Bridge/SwapForm.tsx
@@ -81,8 +81,19 @@ type PoolValueType = {
 export default function SwapForm() {
   const { account, chainId } = useActiveWeb3React()
   const { changeNetwork } = useActiveNetwork()
-  const [{ tokenInfoIn, tokenInfoOut, chainIdOut, currencyIn, listTokenOut, listTokenIn, listChainIn, loadingToken }] =
-    useBridgeState()
+  const [
+    {
+      tokenInfoIn,
+      tokenInfoOut,
+      chainIdOut,
+      currencyIn,
+      listTokenOut,
+      listTokenIn,
+      listChainIn,
+      loadingToken,
+      poolValueOutMap,
+    },
+  ] = useBridgeState()
   const { resetBridgeState, setBridgeState, setBridgePoolInfo } = useBridgeStateHandler()
   const toggleWalletModal = useWalletModalToggle()
   const isDark = useIsDarkMode()
@@ -173,7 +184,7 @@ export default function SwapForm() {
     }
     setBridgeState({ tokenOut })
     setPoolValue(poolValue => ({ ...poolValue, poolValueOut }))
-    setBridgePoolInfo({ poolValueOut: poolValueOutMap })
+    setBridgePoolInfo({ poolValueOutMap })
   }, [poolDataOut, listTokenOut, setBridgePoolInfo, setBridgeState])
 
   useEffect(() => {
@@ -347,8 +358,10 @@ export default function SwapForm() {
   const onCurrencySelectDest = useCallback(
     (tokenOut: WrappedTokenInfo) => {
       setBridgeState({ tokenOut })
+      const anyToken = tokenOut?.multichainInfo?.anytoken?.address ?? ''
+      setPoolValue(state => ({ ...state, poolValueOut: poolValueOutMap[anyToken] }))
     },
-    [setBridgeState],
+    [setBridgeState, poolValueOutMap],
   )
   const onSelectDestNetwork = useCallback(
     (chainId: ChainId) => {

--- a/src/pages/Bridge/helpers.ts
+++ b/src/pages/Bridge/helpers.ts
@@ -121,10 +121,10 @@ export async function getChainlist(isStaleData: boolean) {
   }
 }
 
-export const formatPoolValue = (amount: string | undefined) => {
+export const formatPoolValue = (amount: string | number | undefined) => {
   try {
     if (amount === undefined) return t`Unlimited`
-    if (Number(amount) && amount) return formatNumberWithPrecisionRange(parseFloat(amount), 0, 2)
+    if (Number(amount) && amount) return formatNumberWithPrecisionRange(parseFloat(amount + ''), 0, 2)
   } catch (error) {}
   return '0'
 }

--- a/src/state/bridge/actions.ts
+++ b/src/state/bridge/actions.ts
@@ -16,7 +16,7 @@ export type BridgeStateParams = {
 
 export const setBridgeState = createAction<BridgeStateParams>('bridge/setBridgeState')
 
-export type BridgeStatePoolParams = { poolValueOut: PoolValueOutMap }
+export type BridgeStatePoolParams = { poolValueOutMap: PoolValueOutMap }
 export const setBridgePoolInfo = createAction<BridgeStatePoolParams>('bridge/setBridgePoolInfo')
 
 export const resetBridgeState = createAction('bridge/resetBridgeState')

--- a/src/state/bridge/reducer.ts
+++ b/src/state/bridge/reducer.ts
@@ -19,7 +19,7 @@ export interface BridgeState {
   listTokenOut: WrappedTokenInfo[]
   loadingToken: boolean
 
-  poolValueOut: PoolValueOutMap
+  poolValueOutMap: PoolValueOutMap
 
   historyURL: string
 }
@@ -36,7 +36,7 @@ const DEFAULT_STATE: BridgeState = {
   listTokenOut: [],
   loadingToken: true,
 
-  poolValueOut: {},
+  poolValueOutMap: {},
 
   historyURL: '',
 }
@@ -62,8 +62,8 @@ export default createReducer(DEFAULT_STATE, builder =>
         if (loadingToken !== undefined) state.loadingToken = loadingToken
       },
     )
-    .addCase(setBridgePoolInfo, (state, { payload: { poolValueOut } }) => {
-      state.poolValueOut = poolValueOut
+    .addCase(setBridgePoolInfo, (state, { payload: { poolValueOutMap } }) => {
+      state.poolValueOutMap = poolValueOutMap
     })
     .addCase(resetBridgeState, state => {
       state.tokenInfoIn = undefined


### PR DESCRIPTION
- auto select token out with highest liquidity
- When changing the token, should keep the same src/dest networks unless the network doesn’t support that token. Every time I change the token, it always falls back to Ethereum network. Many users may wrongly bridge their funds to Ethereum instead to a desired network