### PR TITLE
Reset pagination when changing network, in Pool pages

### DIFF
--- a/src/components/PoolList/index.tsx
+++ b/src/components/PoolList/index.tsx
@@ -331,7 +331,7 @@ const PoolList = ({
   const [currentPage, setCurrentPage] = useState(1)
   useEffect(() => {
     setCurrentPage(1)
-  }, [subgraphPoolsData, currencies, searchValue, isShowOnlyActiveFarmPools, onlyShowStable])
+  }, [chainId, subgraphPoolsData, currencies, searchValue, isShowOnlyActiveFarmPools, onlyShowStable])
 
   const sortedFilteredSubgraphPoolsObject = useMemo(() => {
     const res = new Map<string, SubgraphPoolData[]>()

--- a/src/pages/ProAmmPools/index.tsx
+++ b/src/pages/ProAmmPools/index.tsx
@@ -356,7 +356,7 @@ export default function ProAmmPoolList({
   const [page, setPage] = useState(1)
   useEffect(() => {
     setPage(1)
-  }, [currencies, searchValue, onlyShowStable])
+  }, [chainId, currencies, searchValue, onlyShowStable])
 
   const [sharedPoolId, setSharedPoolId] = useState('')
   const openShareModal = useOpenModal(ApplicationModal.SHARE)


### PR DESCRIPTION
# Description
When changing network, the pagination should be reset to page 1. Otherwise, when users are at page 5 of Avax pools and switch to Ethereum, which has only 1 page, the pagination is still at page 5.

This applies to both Elastic and Classic pool pages