### PR TITLE
Format total fee by locale en-US

### DIFF
--- a/src/components/ProAmm/ProAmmFee.tsx
+++ b/src/components/ProAmm/ProAmmFee.tsx
@@ -23,7 +23,7 @@ import useTheme from 'hooks/useTheme'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-import { basisPointsToPercent, calculateGasMargin, formatNumberWithPrecisionRange } from 'utils'
+import { basisPointsToPercent, calculateGasMargin, formattedNumLong } from 'utils'
 import { unwrappedToken } from 'utils/wrappedCurrency'
 
 export default function ProAmmFee({
@@ -162,7 +162,7 @@ export default function ProAmmFee({
             </Text>
             <RowFixed>
               <Text fontSize={14} fontWeight={500} marginLeft={'6px'}>
-                ${formatNumberWithPrecisionRange(totalFeeRewardUSD, 0, 8)}
+                {formattedNumLong(totalFeeRewardUSD, true)}
               </Text>
             </RowFixed>
           </RowBetween>
@@ -206,7 +206,7 @@ export default function ProAmmFee({
           </Flex>
           <RowFixed>
             <Text fontSize={12} fontWeight={500}>
-              ${formatNumberWithPrecisionRange(totalFeeRewardUSD, 0, 8)}
+              {formattedNumLong(totalFeeRewardUSD, true)}
             </Text>
           </RowFixed>
         </RowBetween>

--- a/src/components/ProAmm/ProAmmFee.tsx
+++ b/src/components/ProAmm/ProAmmFee.tsx
@@ -174,7 +174,7 @@ export default function ProAmmFee({
             <RowFixed>
               <CurrencyLogo size="16px" style={{ marginLeft: '8px' }} currency={token0Shown} />
               <Text fontSize={14} fontWeight={500} marginLeft={'6px'}>
-                {feeValue0 && <FormattedCurrencyAmount currencyAmount={feeValue0} />}
+                {feeValue0 && <FormattedCurrencyAmount currencyAmount={feeValue0} />} {token0Shown.symbol}
               </Text>
             </RowFixed>
           </RowBetween>
@@ -186,7 +186,7 @@ export default function ProAmmFee({
             <RowFixed>
               <CurrencyLogo size="16px" style={{ marginLeft: '8px' }} currency={token1Shown} />
               <Text fontSize={14} fontWeight={500} marginLeft={'6px'}>
-                {feeValue1 && <FormattedCurrencyAmount currencyAmount={feeValue1} />}
+                {feeValue1 && <FormattedCurrencyAmount currencyAmount={feeValue1} />} {token1Shown.symbol}
               </Text>
             </RowFixed>
           </RowBetween>
@@ -221,7 +221,7 @@ export default function ProAmmFee({
           <RowFixed>
             <CurrencyLogo size="16px" style={{ marginLeft: '8px' }} currency={token0Shown} />
             <Text fontSize={12} fontWeight={500} marginLeft={'6px'}>
-              {feeValue0 && <FormattedCurrencyAmount currencyAmount={feeValue0} />}
+              {feeValue0 && <FormattedCurrencyAmount currencyAmount={feeValue0} />} {token0Shown.symbol}
             </Text>
           </RowFixed>
         </RowBetween>
@@ -235,7 +235,7 @@ export default function ProAmmFee({
           <RowFixed>
             <CurrencyLogo size="16px" style={{ marginLeft: '8px' }} currency={token1Shown} />
             <Text fontSize={12} fontWeight={500} marginLeft={'6px'}>
-              {feeValue1 && <FormattedCurrencyAmount currencyAmount={feeValue1} />}
+              {feeValue1 && <FormattedCurrencyAmount currencyAmount={feeValue1} />} {token1Shown.symbol}
             </Text>
           </RowFixed>
         </RowBetween>


### PR DESCRIPTION
Issue:
<img width="446" alt="image" src="https://user-images.githubusercontent.com/19758667/202999240-afc7bf5e-96fe-4302-94c5-09ceb0219e68.png">

Total Fees Earned is formatted with `,`
