### PR TITLE
chore: add replace to redirect network links

### DIFF
--- a/src/pages/AddLiquidityV2/redirects.tsx
+++ b/src/pages/AddLiquidityV2/redirects.tsx
@@ -19,7 +19,7 @@ export function RedirectDuplicateTokenIds() {
     currencyIdB &&
     (currencyIdA.toLowerCase() === currencyIdB.toLowerCase() || (isETHOrWETHA && isETHOrWETHB))
   ) {
-    return <Navigate to={`/elastic/add/${currencyIdA}`} />
+    return <Navigate to={`/elastic/add/${currencyIdA}`} replace />
   }
   return <ProAmmAddLiquidity />
 }

--- a/src/pages/CreatePool/RedirectDuplicateTokenIds.tsx
+++ b/src/pages/CreatePool/RedirectDuplicateTokenIds.tsx
@@ -7,7 +7,7 @@ import CreatePool from './index'
 export default function RedirectDuplicateTokenIds() {
   const { currencyIdA, currencyIdB } = useParams()
   if (currencyIdA?.toLowerCase() === currencyIdB?.toLowerCase()) {
-    return <Navigate to={`${APP_PATHS.CLASSIC_CREATE_POOL}/${currencyIdA}`} />
+    return <Navigate to={`${APP_PATHS.CLASSIC_CREATE_POOL}/${currencyIdA}`} replace />
   }
   return <CreatePool />
 }

--- a/src/pages/CreatePool/RedirectOldCreatePoolPathStructure.tsx
+++ b/src/pages/CreatePool/RedirectOldCreatePoolPathStructure.tsx
@@ -8,7 +8,7 @@ export default function RedirectOldCreatePoolPathStructure() {
 
   const match = currencyIdA?.match(OLD_PATH_STRUCTURE)
   if (match?.length) {
-    return <Navigate to={`/create/${match[1]}/${match[2]}`} />
+    return <Navigate to={`/create/${match[1]}/${match[2]}`} replace />
   }
 
   return <CreatePool />

--- a/src/pages/Farm/redirect.tsx
+++ b/src/pages/Farm/redirect.tsx
@@ -6,5 +6,5 @@ import { useActiveWeb3React } from 'hooks'
 export function RedirectPathToFarmNetwork() {
   const location = useLocation()
   const { networkInfo } = useActiveWeb3React()
-  return <Navigate to={{ ...location, pathname: `${APP_PATHS.FARMS}/` + networkInfo.route }} />
+  return <Navigate to={{ ...location, pathname: `${APP_PATHS.FARMS}/` + networkInfo.route }} replace />
 }

--- a/src/pages/Pool/redirect.tsx
+++ b/src/pages/Pool/redirect.tsx
@@ -6,5 +6,5 @@ import { useActiveWeb3React } from 'hooks'
 export function RedirectPathToMyPoolsNetwork() {
   const location = useLocation()
   const { networkInfo } = useActiveWeb3React()
-  return <Navigate to={{ ...location, pathname: `${APP_PATHS.MY_POOLS}/` + networkInfo.route }} />
+  return <Navigate to={{ ...location, pathname: `${APP_PATHS.MY_POOLS}/` + networkInfo.route }} replace />
 }

--- a/src/pages/Pools/redirect.tsx
+++ b/src/pages/Pools/redirect.tsx
@@ -6,5 +6,5 @@ import { useActiveWeb3React } from 'hooks'
 export function RedirectPathToPoolsNetwork() {
   const location = useLocation()
   const { networkInfo } = useActiveWeb3React()
-  return <Navigate to={{ ...location, pathname: `${APP_PATHS.POOLS}/` + networkInfo.route }} />
+  return <Navigate to={{ ...location, pathname: `${APP_PATHS.POOLS}/` + networkInfo.route }} replace />
 }

--- a/src/pages/SwapV2/redirects.tsx
+++ b/src/pages/SwapV2/redirects.tsx
@@ -16,6 +16,7 @@ export function RedirectPathToSwapNetwork() {
           pathname.startsWith(APP_PATHS.LIMIT) && getLimitOrderContract(chainId) ? APP_PATHS.LIMIT : APP_PATHS.SWAP
         }/${networkInfo.route}`,
       }}
+      replace
     />
   )
 }


### PR DESCRIPTION
### Why dis PR
For better history navigating

E.g:
1. User navigate to `/swap`
2. User navigate to `/pools`
3. App redirect user to `pools/fantom`
4. User click back
Expect: go back to `/swap`
Actual: go back to `/pools`, which then quickly redirect into `pools/fantom` again