### PR TITLE
Allow users to import not-yet-whitelisted tokens

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -351,9 +351,9 @@ export function CurrencySearch({
               new WrappedTokenInfo({
                 chainId: rawToken.chainId,
                 address: rawToken.address,
-                name: rawToken.name || '',
+                name: rawToken.name || 'Unknown Token',
                 decimals: rawToken.decimals,
-                symbol: rawToken.symbol || '',
+                symbol: rawToken.symbol || 'UNKNOWN',
               }),
             )
 

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -33,6 +33,7 @@ import { useRemoveUserAddedToken, useUserAddedTokens, useUserFavoriteTokens } fr
 import { ButtonText, CloseIcon, TYPE } from 'theme'
 import { filterTruthy, isAddress } from 'utils'
 import { filterTokens } from 'utils/filtering'
+import { importTokensToKsSettings } from 'utils/tokenInfo'
 
 import CommonBases from './CommonBases'
 import CurrencyList from './CurrencyList'
@@ -355,6 +356,13 @@ export function CurrencySearch({
                 symbol: rawToken.symbol || '',
               }),
             )
+
+            importTokensToKsSettings([
+              {
+                chainId: String(rawToken.chainId),
+                address: rawToken.address,
+              },
+            ])
           }
         }
       } else {

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -227,7 +227,8 @@ export function useToken(tokenAddress?: string): Token | NativeCurrency | undefi
   ])
 }
 
-export function useFetchTokenFromRPC() {
+// This function is intended to use for EVM chains only
+export function useFetchERC20TokenFromRPC() {
   const { chainId } = useActiveWeb3React()
   const multicallContract = useMulticallContract()
 

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -202,7 +202,7 @@ export function useToken(tokenAddress?: string): Token | NativeCurrency | undefi
     if (token) return token
     if (!chainId || !address) return undefined
     if (decimals.loading || symbol.loading || tokenName.loading) return null
-    if (decimalsResult) {
+    if (typeof decimalsResult === 'number') {
       return new Token(
         chainId,
         address,

--- a/src/utils/tokenInfo.ts
+++ b/src/utils/tokenInfo.ts
@@ -1,5 +1,7 @@
 import { ChainId, Currency, NativeCurrency, Token, WETH } from '@kyberswap/ks-sdk-core'
+import axios from 'axios'
 
+import { KS_SETTING_API } from 'constants/env'
 import { NETWORKS_INFO } from 'constants/networks'
 import { MAP_TOKEN_HAS_MULTI_BY_NETWORK, WHITE_LIST_TOKEN_INFO_PAIR } from 'constants/tokenLists/token-info'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
@@ -63,4 +65,14 @@ export const isTokenNative = (
         currency instanceof WrappedTokenInfo &&
         currency.multichainInfo?.tokenType === 'NATIVE'
     : false
+}
+
+export const importTokensToKsSettings = async (tokens: Array<{ chainId: string; address: string }>) => {
+  try {
+    await axios.post(`${KS_SETTING_API}/v1/tokens/import`, {
+      tokens,
+    })
+  } catch (e) {
+    console.error(e)
+  }
 }


### PR DESCRIPTION
If users enter a not-yet-whitelisted token in the Search input modal, KyberSwap will ask KS Settings and KS Settings will search around its database. 
This PR solves the issue when that token doesn't exist in KS Settings' database. 
If KS Settings doesn't find the matching token, KyberSwap will query on-chain token info (making RPC request).