### PR TITLE
Pair suggestion - select item on hovering

### DIFF
--- a/src/components/swapv2/PairSuggestion/ListPair.tsx
+++ b/src/components/swapv2/PairSuggestion/ListPair.tsx
@@ -56,6 +56,19 @@ const TextWithIcon = ({ text, icon, color }: { text: string; icon?: JSX.Element;
   </Container>
 )
 
+export type Props = {
+  isFullFavoritePair: boolean
+  suggestedAmount: string
+  hasShadow?: boolean
+  selectedIndex: number
+  isShowListPair: boolean
+  favoritePairs: SuggestionPairData[]
+  suggestedPairs: SuggestionPairData[]
+  isSearch: boolean
+  onSelectPair: (item: SuggestionPairData) => void
+  onClickStar: (item: SuggestionPairData) => void
+  onMouseEnterItem: (index: number) => void
+}
 export default function ListPair({
   isShowListPair,
   isFullFavoritePair,
@@ -67,18 +80,8 @@ export default function ListPair({
   selectedIndex,
   onSelectPair,
   onClickStar,
-}: {
-  isFullFavoritePair: boolean
-  suggestedAmount: string
-  hasShadow?: boolean
-  selectedIndex: number
-  isShowListPair: boolean
-  favoritePairs: SuggestionPairData[]
-  suggestedPairs: SuggestionPairData[]
-  isSearch: boolean
-  onSelectPair: (item: SuggestionPairData) => void
-  onClickStar: (item: SuggestionPairData) => void
-}) {
+  onMouseEnterItem,
+}: Props) {
   const theme = useTheme()
   const { account } = useActiveWeb3React()
   const isShowNotfound = isSearch && !suggestedPairs.length && !favoritePairs.length
@@ -124,6 +127,7 @@ export default function ListPair({
               isFavorite
               key={item.tokenIn + item.tokenOut}
               isFullFavoritePair={isFullFavoritePair}
+              onMouseEnter={() => onMouseEnterItem(i)}
             />
           ))}
           {!isSearch && <Break />}
@@ -148,6 +152,7 @@ export default function ListPair({
               key={item.tokenIn + item.tokenOut + i}
               isFavorite={isFavoritePair(favoritePairs, item)}
               isFullFavoritePair={isFullFavoritePair}
+              onMouseEnter={() => onMouseEnterItem(favoritePairs.length + i)}
             />
           ))}
         </>

--- a/src/components/swapv2/PairSuggestion/PairSuggestionItem.tsx
+++ b/src/components/swapv2/PairSuggestion/PairSuggestionItem.tsx
@@ -20,11 +20,8 @@ const ItemWrapper = styled.div<{ isActive: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: ${({ theme, isActive }) => (isActive ? rgba(theme.buttonBlack, 0.5) : 'transparent')};
+  background-color: ${({ theme, isActive }) => (isActive ? rgba(theme.buttonBlack, 0.6) : 'transparent')};
   padding: 1em;
-  &:hover {
-    background-color: ${({ theme }) => rgba(theme.buttonBlack, 0.5)};
-  }
 `
 
 const StyledLogo = styled(Logo)`
@@ -41,6 +38,7 @@ type PropsType = {
   amount: string
   isFavorite?: boolean
   isFullFavoritePair?: boolean
+  onMouseEnter: () => void
 }
 export default function SuggestItem({
   data,
@@ -50,6 +48,7 @@ export default function SuggestItem({
   amount,
   onClickStar,
   onSelectPair,
+  onMouseEnter,
 }: PropsType) {
   const theme = useTheme()
   const activeTokens = useAllTokens(true)
@@ -76,6 +75,7 @@ export default function SuggestItem({
       className={isTokenNotImport ? 'no-blur' : ''}
       onClick={onSelectPair}
       isActive={isActive && !isMobile}
+      onMouseEnter={onMouseEnter}
     >
       <Flex alignItems="center" style={{ gap: 10 }}>
         <Flex alignItems="flex-start" height="100%">

--- a/src/components/swapv2/PairSuggestion/index.tsx
+++ b/src/components/swapv2/PairSuggestion/index.tsx
@@ -17,7 +17,7 @@ import useParsedQueryString from 'hooks/useParsedQueryString'
 import { NotificationType, useNotify } from 'state/application/hooks'
 import { filterTokens } from 'utils/filtering'
 
-import ListPair from './ListPair'
+import ListPair, { Props as ListPairProps } from './ListPair'
 import SearchInput from './SearchInput'
 import { SuggestionPairData, reqAddFavoritePair, reqGetSuggestionPair, reqRemoveFavoritePair } from './request'
 import { findLogoAndSortPair, getAddressParam, isActivePair, isFavoritePair } from './utils'
@@ -57,7 +57,7 @@ export default forwardRef<PairSuggestionHandle, Props>(function PairSuggestionIn
 ) {
   const [searchQuery, setSearchQuery] = useState('')
 
-  const [selectedIndex, setSelectedIndex] = useState(0) // index selected when press up/down arrow
+  const [selectedIndex, setSelectedIndex] = useState(-1) // index selected when press up/down arrow
   const [isShowListPair, setIsShowListPair] = useState(false)
 
   const [suggestedPairs, setSuggestions] = useState<SuggestionPairData[]>([])
@@ -166,7 +166,7 @@ export default forwardRef<PairSuggestionHandle, Props>(function PairSuggestionIn
 
   const hideListView = () => {
     setIsShowListPair(false)
-    setSelectedIndex(0)
+    setSelectedIndex(-1)
     refInput.current?.blur()
   }
   const showListView = useCallback(() => {
@@ -261,7 +261,7 @@ export default forwardRef<PairSuggestionHandle, Props>(function PairSuggestionIn
     }
   }
 
-  const propsListPair = {
+  const propsListPair: ListPairProps = {
     suggestedAmount,
     selectedIndex,
     isSearch: !!searchQuery,
@@ -271,6 +271,9 @@ export default forwardRef<PairSuggestionHandle, Props>(function PairSuggestionIn
     isFullFavoritePair: totalFavoritePair === MAX_FAVORITE_PAIRS,
     onClickStar,
     onSelectPair,
+    onMouseEnterItem: (index: number) => {
+      setSelectedIndex(index)
+    },
   }
 
   const propsSearch = {


### PR DESCRIPTION
- Hovering on an item will make that item active. This is to avoid 2 active items displayed. 
- Start selectedIndex with -1 so that by default, there's no selected item. When user presses `arrow-down`, it will select the first item on the list (index 0)
- Increase opacity of the active item to 0.6 to gain better contrast