### PR TITLE
Improve slippage settings

### DIFF
--- a/src/components/SwapForm/PriceImpactNote.tsx
+++ b/src/components/SwapForm/PriceImpactNote.tsx
@@ -1,5 +1,4 @@
 import { Trans, t } from '@lingui/macro'
-import { CSSProperties } from 'react'
 import { AlertTriangle } from 'react-feather'
 import styled, { useTheme } from 'styled-components'
 
@@ -22,9 +21,8 @@ type Props = {
   isAdvancedMode?: boolean
   priceImpact: number | undefined
   hasTooltip: boolean
-  style?: CSSProperties
 }
-const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTooltip, style }) => {
+const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTooltip }) => {
   const theme = useTheme()
   const priceImpactResult = checkPriceImpact(priceImpact)
 
@@ -35,7 +33,7 @@ const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTool
   // invalid
   if (priceImpactResult.isInvalid) {
     return (
-      <Wrapper style={style}>
+      <Wrapper>
         <AlertTriangle color={theme.warning} size={16} style={{ marginRight: '10px' }} />
         <Trans>Unable to calculate Price Impact</Trans>
         <InfoHelper text={t`Turn on Advanced Mode to trade`} color={theme.text} />
@@ -45,7 +43,7 @@ const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTool
 
   if (priceImpactResult.isHigh) {
     return (
-      <Wrapper style={style} veryHigh={priceImpactResult.isVeryHigh}>
+      <Wrapper veryHigh={priceImpactResult.isVeryHigh}>
         <AlertTriangle size={16} style={{ marginRight: '10px' }} />
         {priceImpactResult.isVeryHigh ? <Trans>Price Impact is Very High</Trans> : <Trans>Price Impact is High</Trans>}
 

--- a/src/components/SwapForm/SlippageNote.tsx
+++ b/src/components/SwapForm/SlippageNote.tsx
@@ -1,8 +1,9 @@
 import { rgba } from 'polished'
-import { CSSProperties } from 'react'
 import { AlertTriangle } from 'react-feather'
+import { Flex } from 'rebass'
 import styled from 'styled-components'
 
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -11,6 +12,7 @@ const Wrapper = styled.div`
 
   display: flex;
   align-items: center;
+  gap: 8px;
 
   border-radius: 999px;
   color: ${({ theme }) => theme.warning};
@@ -18,20 +20,20 @@ const Wrapper = styled.div`
   font-size: 12px;
 `
 
-type Props = {
-  style?: CSSProperties
-}
-const SlippageNote: React.FC<Props> = ({ style }) => {
+const SlippageNote: React.FC = () => {
   const [rawSlippage] = useUserSlippageTolerance()
-  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const isStablePairSwap = useCheckStablePairSwap()
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
 
   if (!isValid || !message) {
     return null
   }
 
   return (
-    <Wrapper style={style}>
-      <AlertTriangle size={16} style={{ marginRight: '10px' }} />
+    <Wrapper>
+      <Flex flex="0 0 16px" height="16px" alignItems="center" justifyContent="center">
+        <AlertTriangle size={16} />
+      </Flex>
       {message}
     </Wrapper>
   )

--- a/src/components/SwapForm/SlippageNote.tsx
+++ b/src/components/SwapForm/SlippageNote.tsx
@@ -1,0 +1,40 @@
+import { rgba } from 'polished'
+import { CSSProperties } from 'react'
+import { AlertTriangle } from 'react-feather'
+import styled from 'styled-components'
+
+import { useUserSlippageTolerance } from 'state/user/hooks'
+import { checkRangeSlippage } from 'utils/slippage'
+
+const Wrapper = styled.div`
+  padding: 12px 16px;
+
+  display: flex;
+  align-items: center;
+
+  border-radius: 999px;
+  color: ${({ theme }) => theme.warning};
+  background: ${({ theme }) => rgba(theme.warning, 0.2)};
+  font-size: 12px;
+`
+
+type Props = {
+  style?: CSSProperties
+}
+const SlippageNote: React.FC<Props> = ({ style }) => {
+  const [rawSlippage] = useUserSlippageTolerance()
+  const { isValid, message } = checkRangeSlippage(rawSlippage)
+
+  if (!isValid || !message) {
+    return null
+  }
+
+  return (
+    <Wrapper style={style}>
+      <AlertTriangle size={16} style={{ marginRight: '10px' }} />
+      {message}
+    </Wrapper>
+  )
+}
+
+export default SlippageNote

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -1,0 +1,110 @@
+import { Trans, t } from '@lingui/macro'
+import React, { useState } from 'react'
+import { isMobile } from 'react-device-detect'
+import { Flex, Text } from 'rebass'
+import styled from 'styled-components'
+
+import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
+import QuestionHelper from 'components/QuestionHelper'
+import SlippageControl from 'components/swapv2/SlippageControl'
+import useTheme from 'hooks/useTheme'
+import { useAppSelector } from 'state/hooks'
+import { useUserSlippageTolerance } from 'state/user/hooks'
+
+const getSlippageText = (slp: number) => {
+  if (slp % 100 === 0) {
+    return String(slp / 100)
+  }
+
+  if (slp % 10 === 0) {
+    return (slp / 100).toFixed(1)
+  }
+
+  return (slp / 100).toFixed(2)
+}
+
+const DropdownIcon = styled(DropdownSVG)`
+  cursor: pointer;
+
+  transition: transform 300ms;
+  color: ${({ theme }) => theme.subText};
+  &[data-flip='true'] {
+    transform: rotate(180deg);
+  }
+`
+
+const SlippageSetting: React.FC = () => {
+  const theme = useTheme()
+  const [rawSlippage] = useUserSlippageTolerance()
+
+  const [expanded, setExpanded] = useState(false)
+
+  const isSlippageControlPinned = useAppSelector(state => state.swap.isSlippageControlPinned)
+
+  if (!isSlippageControlPinned) {
+    return null
+  }
+
+  return (
+    <Flex
+      sx={{
+        flexDirection: 'column',
+      }}
+    >
+      <Flex
+        sx={{
+          alignItems: 'center',
+          color: theme.subText,
+          gap: '4px',
+        }}
+      >
+        <Flex
+          sx={{
+            alignItems: 'center',
+            color: theme.subText,
+            fontSize: isMobile ? '14px' : '12px',
+            fontWeight: 500,
+            lineHeight: '1',
+          }}
+        >
+          <Text as="span">
+            <Trans>Max Slippage</Trans>
+          </Text>
+          <QuestionHelper
+            placement="top"
+            text={t`Transaction will revert if there is an adverse rate change that is higher than this %. You can hide this control in Settings.`}
+          />
+          <Text as="span" marginLeft="4px">
+            :
+          </Text>
+        </Flex>
+
+        <Text
+          sx={{
+            fontSize: isMobile ? '16px' : '14px',
+            fontWeight: 500,
+            lineHeight: '1',
+            color: theme.text,
+          }}
+        >
+          {getSlippageText(rawSlippage)}%
+        </Text>
+
+        <DropdownIcon data-flip={expanded} onClick={() => setExpanded(e => !e)} />
+      </Flex>
+
+      <Flex
+        sx={{
+          transition: 'all 100ms linear',
+          paddingTop: expanded ? '8px' : '0px',
+          height: expanded ? '36px' : '0px',
+          overflow: 'hidden',
+        }}
+      >
+        <SlippageControl />
+      </Flex>
+    </Flex>
+  )
+}
+
+export default SlippageSetting

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -10,18 +10,7 @@ import SlippageControl from 'components/swapv2/SlippageControl'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-
-const getSlippageText = (slp: number) => {
-  if (slp % 100 === 0) {
-    return String(slp / 100)
-  }
-
-  if (slp % 10 === 0) {
-    return (slp / 100).toFixed(1)
-  }
-
-  return (slp / 100).toFixed(2)
-}
+import { formatSlippage } from 'utils/slippage'
 
 const DropdownIcon = styled(DropdownSVG)`
   cursor: pointer;
@@ -87,7 +76,7 @@ const SlippageSetting: React.FC = () => {
             color: theme.text,
           }}
         >
-          {getSlippageText(rawSlippage)}%
+          {formatSlippage(rawSlippage, true)}
         </Text>
 
         <DropdownIcon data-flip={expanded} onClick={() => setExpanded(e => !e)} />

--- a/src/components/SwapForm/SwapActionButton/index.tsx
+++ b/src/components/SwapForm/SwapActionButton/index.tsx
@@ -1,6 +1,7 @@
 import { Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
 import { useEffect, useState } from 'react'
+import { Flex } from 'rebass'
 import styled from 'styled-components'
 
 import { ButtonConfirmed, ButtonLight, ButtonPrimary } from 'components/Button'
@@ -174,7 +175,12 @@ const SwapActionButton: React.FC<Props> = ({
 
     if (showApproveFlow) {
       return (
-        <>
+        <Flex
+          sx={{
+            flexDirection: 'column',
+            gap: '0.75rem',
+          }}
+        >
           <RowBetween>
             <ButtonConfirmed
               onClick={approveCallback}
@@ -199,10 +205,10 @@ const SwapActionButton: React.FC<Props> = ({
 
             <SwapOnlyButton minimal {...swapOnlyButtonProps} />
           </RowBetween>
-          <Column style={{ marginTop: '1rem' }}>
+          <Column>
             <ProgressSteps steps={[approval === ApprovalState.APPROVED]} />
           </Column>
-        </>
+        </Flex>
       )
     }
 

--- a/src/components/SwapForm/SwapModal/ConfirmSwapModalContent.tsx
+++ b/src/components/SwapForm/SwapModal/ConfirmSwapModalContent.tsx
@@ -1,13 +1,15 @@
 import { Price } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
 import React from 'react'
-import { Text } from 'rebass'
+import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import { ButtonPrimary } from 'components/Button'
 import { GreyCard } from 'components/Card'
 import { AutoColumn } from 'components/Column'
 import { AutoRow, RowBetween } from 'components/Row'
+import PriceImpactNote from 'components/SwapForm/PriceImpactNote'
+import SlippageNote from 'components/SwapForm/SlippageNote'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import { BuildRouteResult } from 'components/SwapForm/hooks/useBuildRoute'
 import { Dots } from 'components/swapv2/styleds'
@@ -124,6 +126,16 @@ const ConfirmSwapModalContent: React.FC<Props> = ({
       </AutoColumn>
 
       <SwapDetails {...getSwapDetailsProps()} />
+
+      <Flex
+        sx={{
+          flexDirection: 'column',
+          gap: '0.75rem',
+        }}
+      >
+        <SlippageNote />
+        <PriceImpactNote priceImpact={routeSummary?.priceImpact} hasTooltip={false} />
+      </Flex>
 
       <AutoRow>
         {isSolana && !encodeSolana ? (

--- a/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
@@ -1,0 +1,20 @@
+import useTheme from 'hooks/useTheme'
+import { TYPE } from 'theme'
+import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
+
+type Props = {
+  value: number
+}
+
+const SlippageValue: React.FC<Props> = ({ value }) => {
+  const theme = useTheme()
+  const { isValid, message } = checkRangeSlippage(value)
+  const isWarning = isValid && !!message
+  return (
+    <TYPE.black fontSize={14} color={isWarning ? theme.warning : undefined}>
+      {formatSlippage(value, true)}
+    </TYPE.black>
+  )
+}
+
+export default SlippageValue

--- a/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
@@ -4,11 +4,12 @@ import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
 
 type Props = {
   value: number
+  isStableCoinSwap: boolean
 }
 
-const SlippageValue: React.FC<Props> = ({ value }) => {
+const SlippageValue: React.FC<Props> = ({ value, isStableCoinSwap }) => {
   const theme = useTheme()
-  const { isValid, message } = checkRangeSlippage(value)
+  const { isValid, message } = checkRangeSlippage(value, isStableCoinSwap)
   const isWarning = isValid && !!message
   return (
     <TYPE.black fontSize={14} color={isWarning ? theme.warning : undefined}>

--- a/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
@@ -12,6 +12,7 @@ import InfoHelper from 'components/InfoHelper'
 import Loader from 'components/Loader'
 import { RowBetween, RowFixed } from 'components/Row'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
+import SlippageValue from 'components/SwapForm/SwapModal/SwapDetails/SlippageValue'
 import ValueWithLoadingSkeleton from 'components/SwapForm/SwapModal/SwapDetails/ValueWithLoadingSkeleton'
 import { StyledBalanceMaxMini } from 'components/swapv2/styleds'
 import { useActiveWeb3React } from 'hooks'
@@ -261,7 +262,7 @@ const SwapDetails: React.FC<Props> = ({
             </TYPE.black>
           </RowFixed>
 
-          <TYPE.black fontSize={14}>{slippage / 100}%</TYPE.black>
+          <SlippageValue value={slippage} />
         </RowBetween>
 
         {feeConfig && (

--- a/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
@@ -17,6 +17,7 @@ import ValueWithLoadingSkeleton from 'components/SwapForm/SwapModal/SwapDetails/
 import { StyledBalanceMaxMini } from 'components/swapv2/styleds'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { TYPE } from 'theme'
 import { DetailedRouteSummary } from 'types/route'
 import { formattedNum, toK } from 'utils'
@@ -91,6 +92,7 @@ const SwapDetails: React.FC<Props> = ({
   const [showInverted, setShowInverted] = useState<boolean>(false)
   const theme = useTheme()
   const { feeConfig, slippage } = useSwapFormContext()
+  const isStablePairSwap = useCheckStablePairSwap()
 
   const formattedFeeAmountUsd = getFormattedFeeAmountUsdV2(Number(amountInUsd || 0), feeConfig?.feeAmount)
 
@@ -262,7 +264,7 @@ const SwapDetails: React.FC<Props> = ({
             </TYPE.black>
           </RowFixed>
 
-          <SlippageValue value={slippage} />
+          <SlippageValue value={slippage} isStableCoinSwap={isStablePairSwap} />
         </RowBetween>
 
         {feeConfig && (

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -1,10 +1,11 @@
 import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
-import { Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { useEffect, useMemo, useState } from 'react'
-import { Box, Flex } from 'rebass'
+import { Box, Flex, Text } from 'rebass'
 import { parseGetRouteResponse } from 'services/route/utils'
 
 import AddressInputPanel from 'components/AddressInputPanel'
+import QuestionHelper from 'components/QuestionHelper'
 import { AutoRow } from 'components/Row'
 import InputCurrencyPanel from 'components/SwapForm/InputCurrencyPanel'
 import OutputCurrencyPanel from 'components/SwapForm/OutputCurrencyPanel'
@@ -17,6 +18,7 @@ import TrendingSoonTokenBanner from 'components/TrendingSoonTokenBanner'
 import { TutorialIds } from 'components/Tutorial/TutorialSwap/constant'
 import TradePrice from 'components/swapv2/TradePrice'
 import { Wrapper } from 'components/swapv2/styleds'
+import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
@@ -80,6 +82,12 @@ const SwapForm: React.FC<SwapFormProps> = props => {
   const parsedAmount = useParsedAmount(currencyIn, typedValue)
   const { wrapType, inputError: wrapInputError, execute: onWrap } = useWrapCallback(currencyIn, currencyOut, typedValue)
   const isWrapOrUnwrap = wrapType !== WrapType.NOT_APPLICABLE
+  const isStableCoinSwap =
+    chainId &&
+    currencyIn &&
+    currencyOut &&
+    STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
+    STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address)
 
   const { fetcher: getRoute, result } = useGetRoute({
     currencyIn,
@@ -197,12 +205,22 @@ const SwapForm: React.FC<SwapFormProps> = props => {
                 fontSize={12}
                 color={theme.subText}
                 onClick={goToSettingsView}
-                width="fit-content"
+                width="max-content"
               >
                 <ClickableText color={theme.subText} fontWeight={500}>
                   <Trans>Max Slippage:</Trans>&nbsp;
-                  {slippage / 100}%
+                  <Text as="span" color={isStableCoinSwap ? theme.text : theme.subText}>
+                    {slippage / 100}%
+                  </Text>
                 </ClickableText>
+
+                {isStableCoinSwap ? (
+                  <QuestionHelper
+                    placement="top"
+                    color={theme.text}
+                    text={t`Slippage for stable coin swap should be less than or equal to 0.1%`}
+                  />
+                ) : null}
               </Flex>
             )}
           </Flex>

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -18,9 +18,7 @@ import TrendingSoonTokenBanner from 'components/TrendingSoonTokenBanner'
 import { TutorialIds } from 'components/Tutorial/TutorialSwap/constant'
 import TradePrice from 'components/swapv2/TradePrice'
 import { Wrapper } from 'components/swapv2/styleds'
-import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
-import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
 import { DetailedRouteSummary, FeeConfig } from 'types/route'
 
@@ -71,7 +69,6 @@ const SwapForm: React.FC<SwapFormProps> = props => {
 
   const { chainId, isEVM, isSolana } = useActiveWeb3React()
 
-  const theme = useTheme()
   const [isProcessingSwap, setProcessingSwap] = useState(false)
   const [typedValue, setTypedValue] = useState('1')
   const [recipient, setRecipient] = useState<string | null>(null)
@@ -80,12 +77,6 @@ const SwapForm: React.FC<SwapFormProps> = props => {
   const parsedAmount = useParsedAmount(currencyIn, typedValue)
   const { wrapType, inputError: wrapInputError, execute: onWrap } = useWrapCallback(currencyIn, currencyOut, typedValue)
   const isWrapOrUnwrap = wrapType !== WrapType.NOT_APPLICABLE
-  const isStableCoinSwap =
-    chainId &&
-    currencyIn &&
-    currencyOut &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address)
 
   const { fetcher: getRoute, result } = useGetRoute({
     currencyIn,

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -1,14 +1,14 @@
 import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
-import { Trans, t } from '@lingui/macro'
 import { useEffect, useMemo, useState } from 'react'
-import { Box, Flex, Text } from 'rebass'
+import { Box, Flex } from 'rebass'
 import { parseGetRouteResponse } from 'services/route/utils'
 
 import AddressInputPanel from 'components/AddressInputPanel'
-import QuestionHelper from 'components/QuestionHelper'
 import { AutoRow } from 'components/Row'
 import InputCurrencyPanel from 'components/SwapForm/InputCurrencyPanel'
 import OutputCurrencyPanel from 'components/SwapForm/OutputCurrencyPanel'
+import SlippageNote from 'components/SwapForm/SlippageNote'
+import SlippageSetting from 'components/SwapForm/SlippageSetting'
 import { SwapFormContextProvider } from 'components/SwapForm/SwapFormContext'
 import useBuildRoute from 'components/SwapForm/hooks/useBuildRoute'
 import useGetInputError from 'components/SwapForm/hooks/useGetInputError'
@@ -22,7 +22,6 @@ import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
-import { ClickableText } from 'pages/Pool/styleds'
 import { DetailedRouteSummary, FeeConfig } from 'types/route'
 
 import PriceImpactNote from './PriceImpactNote'
@@ -68,7 +67,6 @@ const SwapForm: React.FC<SwapFormProps> = props => {
     transactionTimeout,
     onChangeCurrencyIn,
     onChangeCurrencyOut,
-    goToSettingsView,
   } = props
 
   const { chainId, isEVM, isSolana } = useActiveWeb3React()
@@ -199,30 +197,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
               <AddressInputPanel id="recipient" value={recipient} onChange={setRecipient} />
             )}
 
-            {!isWrapOrUnwrap && (
-              <Flex
-                alignItems="center"
-                fontSize={12}
-                color={theme.subText}
-                onClick={goToSettingsView}
-                width="max-content"
-              >
-                <ClickableText color={theme.subText} fontWeight={500}>
-                  <Trans>Max Slippage:</Trans>&nbsp;
-                  <Text as="span" color={isStableCoinSwap ? theme.text : theme.subText}>
-                    {slippage / 100}%
-                  </Text>
-                </ClickableText>
-
-                {isStableCoinSwap ? (
-                  <QuestionHelper
-                    placement="top"
-                    color={theme.text}
-                    text={t`Slippage for stable coin swap should be less than or equal to 0.1%`}
-                  />
-                ) : null}
-              </Flex>
-            )}
+            {!isWrapOrUnwrap && <SlippageSetting />}
           </Flex>
         </Wrapper>
         <Flex flexDirection="column" style={{ gap: '1.25rem' }}>
@@ -232,14 +207,9 @@ const SwapForm: React.FC<SwapFormProps> = props => {
             <TrendingSoonTokenBanner currencyIn={currencyIn} currencyOut={currencyOut} style={{ marginTop: '24px' }} />
           )}
 
-          <PriceImpactNote
-            priceImpact={routeSummary?.priceImpact}
-            isAdvancedMode={isAdvancedMode}
-            hasTooltip
-            style={{
-              marginTop: '28px',
-            }}
-          />
+          <SlippageNote />
+
+          <PriceImpactNote priceImpact={routeSummary?.priceImpact} isAdvancedMode={isAdvancedMode} hasTooltip />
 
           <SwapActionButton
             isGettingRoute={isGettingRoute}

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -4,6 +4,7 @@ import { Text } from 'rebass'
 import styled, { css } from 'styled-components'
 
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
 
@@ -118,10 +119,11 @@ const CustomSlippageInput: React.FC = () => {
   // slippage = 10 / 10_000 = 0.001 = 0.1%
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
   const [rawText, setRawText] = useState(getSlippageText(rawSlippage))
+  const isStablePairSwap = useCheckStablePairSwap()
 
   const isCustomOptionActive = !DEFAULT_SLIPPAGES.includes(rawSlippage)
 
-  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
   const isWarning = isValid && !!message
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -1,0 +1,215 @@
+import { t } from '@lingui/macro'
+import React, { useEffect, useRef, useState } from 'react'
+import { Text } from 'rebass'
+import styled, { css } from 'styled-components'
+
+import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+import { useUserSlippageTolerance } from 'state/user/hooks'
+import { checkRangeSlippage } from 'utils/slippage'
+
+export const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
+export const getSlippageText = (rawSlippage: number) => {
+  const isCustom = !DEFAULT_SLIPPAGES.includes(rawSlippage)
+  if (!isCustom) {
+    return ''
+  }
+
+  if (rawSlippage % 100 === 0) {
+    return String(rawSlippage / 100)
+  }
+
+  return (rawSlippage / 100).toFixed(2)
+}
+
+const EmojiContainer = styled.span`
+  flex: 0 0 12px;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+        display: none;
+  `}
+`
+
+const slippageOptionCSS = css`
+  height: 100%;
+  padding: 0;
+  border-radius: 20px;
+  border: 1px solid transparent;
+
+  background-color: ${({ theme }) => theme.tabBackgound};
+  color: ${({ theme }) => theme.subText};
+  text-align: center;
+
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+
+  outline: none;
+  cursor: pointer;
+
+  :hover {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+  :focus {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+
+  &[data-active='true'] {
+    background-color: ${({ theme }) => theme.tabActive};
+    color: ${({ theme }) => theme.text};
+    border-color: ${({ theme }) => theme.primary};
+
+    font-weight: 500;
+  }
+
+  &[data-warning='true'] {
+    border-color: ${({ theme }) => theme.warning};
+  }
+`
+
+const CustomSlippageOption = styled.div`
+  ${slippageOptionCSS};
+
+  flex: 0 0 24%;
+
+  display: inline-flex;
+  align-items: center;
+  padding: 0 4px;
+  column-gap: 2px;
+  flex: 1;
+
+  transition: all 150ms linear;
+
+  &[data-active='true'] {
+    color: ${({ theme }) => theme.text};
+    font-weight: 500;
+  }
+
+  &[data-warning='true'] {
+    border-color: ${({ theme }) => theme.warning};
+
+    ${EmojiContainer} {
+      color: ${({ theme }) => theme.warning};
+    }
+  }
+`
+
+const CustomInput = styled.input`
+  width: 100%;
+  height: 100%;
+  border: 0px;
+  border-radius: inherit;
+
+  color: inherit;
+  background: transparent;
+  outline: none;
+  text-align: right;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
+  &::placeholder {
+    font-size: 12px;
+  }
+  @media only screen and (max-width: 375px) {
+    font-size: 10px;
+  }
+`
+
+const CustomSlippageInput: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // rawSlippage = 10
+  // slippage = 10 / 10_000 = 0.001 = 0.1%
+  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+  const [rawText, setRawText] = useState(getSlippageText(rawSlippage))
+
+  const isCustomOptionActive = !DEFAULT_SLIPPAGES.includes(rawSlippage)
+
+  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const isWarning = isValid && !!message
+
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+
+    if (value === '') {
+      setRawText(value)
+      setRawSlippage(DEFAULT_SLIPPAGE)
+      return
+    }
+
+    const numberRegex = /^(\d+)\.?(\d{1,2})?$/
+    if (!value.match(numberRegex)) {
+      e.preventDefault()
+      return
+    }
+
+    const parsedValue = parseSlippageInput(value)
+    if (Number.isNaN(parsedValue)) {
+      e.preventDefault()
+      return
+    }
+
+    if (parsedValue > MAX_SLIPPAGE_IN_BIPS) {
+      e.preventDefault()
+      return
+    }
+
+    setRawText(value)
+    setRawSlippage(parsedValue)
+  }
+
+  const handleCommitChange = () => {
+    setRawText(getSlippageText(rawSlippage))
+  }
+
+  const handleKeyPressInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const key = e.key
+    if (key === '.' || ('0' <= key && key <= '9')) {
+      return
+    }
+
+    if (key === 'Enter') {
+      handleCommitChange()
+      inputRef.current?.blur()
+      return
+    }
+
+    e.preventDefault()
+  }
+
+  useEffect(() => {
+    if (inputRef.current !== document.activeElement) {
+      setRawText(getSlippageText(rawSlippage))
+    }
+  }, [rawSlippage])
+
+  return (
+    <CustomSlippageOption data-active={isCustomOptionActive} data-warning={isCustomOptionActive && isWarning}>
+      {isCustomOptionActive && isWarning && (
+        <EmojiContainer>
+          <span role="img" aria-label="warning">
+            ⚠️
+          </span>
+        </EmojiContainer>
+      )}
+      <CustomInput
+        ref={inputRef}
+        placeholder={t`Custom`}
+        value={rawText}
+        onChange={handleChangeInput}
+        onKeyPress={handleKeyPressInput}
+        onBlur={handleCommitChange}
+      />
+      <Text
+        as="span"
+        sx={{
+          flex: '0 0 12px',
+        }}
+      >
+        %
+      </Text>
+    </CustomSlippageOption>
+  )
+}
+
+export default CustomSlippageInput

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -5,24 +5,16 @@ import styled, { css } from 'styled-components'
 
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-import { checkRangeSlippage } from 'utils/slippage'
+import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
 
 export const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
-export const getSlippageText = (rawSlippage: number) => {
+const getSlippageText = (rawSlippage: number) => {
   const isCustom = !DEFAULT_SLIPPAGES.includes(rawSlippage)
   if (!isCustom) {
     return ''
   }
 
-  if (rawSlippage % 100 === 0) {
-    return String(rawSlippage / 100)
-  }
-
-  if (rawSlippage % 10 === 0) {
-    return (rawSlippage / 100).toFixed(1)
-  }
-
-  return (rawSlippage / 100).toFixed(2)
+  return formatSlippage(rawSlippage)
 }
 
 const EmojiContainer = styled.span`

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -18,6 +18,10 @@ export const getSlippageText = (rawSlippage: number) => {
     return String(rawSlippage / 100)
   }
 
+  if (rawSlippage % 10 === 0) {
+    return (rawSlippage / 100).toFixed(1)
+  }
+
   return (rawSlippage / 100).toFixed(2)
 }
 

--- a/src/components/swapv2/SlippageControl/index.tsx
+++ b/src/components/swapv2/SlippageControl/index.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { Flex } from 'rebass'
+import styled, { css } from 'styled-components'
+
+import CustomSlippageInput from 'components/swapv2/SlippageControl/CustomSlippageInput'
+import { DEFAULT_SLIPPAGES } from 'constants/index'
+import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
+import useTheme from 'hooks/useTheme'
+import { useUserSlippageTolerance } from 'state/user/hooks'
+import { checkRangeSlippage } from 'utils/slippage'
+
+const shouldWarnSlippage = (slp: number) => {
+  const { isValid, message } = checkRangeSlippage(slp)
+  return isValid && !!message
+}
+
+export const slippageOptionCSS = css`
+  height: 100%;
+  padding: 0;
+  border-radius: 20px;
+  border: 1px solid transparent;
+
+  background-color: ${({ theme }) => theme.tabBackgound};
+  color: ${({ theme }) => theme.subText};
+  text-align: center;
+
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+
+  outline: none;
+  cursor: pointer;
+
+  :hover {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+  :focus {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+
+  &[data-active='true'] {
+    background-color: ${({ theme }) => theme.tabActive};
+    color: ${({ theme }) => theme.text};
+    border-color: ${({ theme }) => theme.primary};
+
+    font-weight: 500;
+  }
+
+  &[data-warning='true'] {
+    border-color: ${({ theme }) => theme.warning};
+  }
+`
+
+const DefaultSlippageOption = styled.button`
+  ${slippageOptionCSS};
+  flex: 0 0 18%;
+
+  @media only screen and (max-width: 375px) {
+    font-size: 10px;
+    flex: 0 0 15%;
+  }
+`
+
+const SlippageControl: React.FC = () => {
+  const theme = useTheme()
+
+  // rawSlippage = 10
+  // slippage = 10 / 10_000 = 0.001 = 0.1%
+  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+
+  const { mixpanelHandler } = useMixpanel()
+
+  return (
+    <Flex
+      sx={{
+        justifyContent: 'space-between',
+        width: '100%',
+        maxWidth: '100%',
+        height: '28px',
+        borderRadius: '20px',
+        background: theme.tabBackgound,
+        padding: '2px',
+      }}
+    >
+      {DEFAULT_SLIPPAGES.map(slp => (
+        <DefaultSlippageOption
+          key={slp}
+          onClick={() => {
+            setRawSlippage(slp)
+            mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: slp / 100 })
+          }}
+          data-active={rawSlippage === slp}
+          data-warning={rawSlippage === slp && shouldWarnSlippage(slp)}
+        >
+          {slp / 100}%
+        </DefaultSlippageOption>
+      ))}
+
+      <CustomSlippageInput />
+    </Flex>
+  )
+}
+
+export default SlippageControl

--- a/src/components/swapv2/SlippageControl/index.tsx
+++ b/src/components/swapv2/SlippageControl/index.tsx
@@ -6,13 +6,9 @@ import CustomSlippageInput from 'components/swapv2/SlippageControl/CustomSlippag
 import { DEFAULT_SLIPPAGES } from 'constants/index'
 import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
 import useTheme from 'hooks/useTheme'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
-
-const shouldWarnSlippage = (slp: number) => {
-  const { isValid, message } = checkRangeSlippage(slp)
-  return isValid && !!message
-}
 
 export const slippageOptionCSS = css`
   height: 100%;
@@ -63,12 +59,14 @@ const DefaultSlippageOption = styled.button`
 
 const SlippageControl: React.FC = () => {
   const theme = useTheme()
+  const { mixpanelHandler } = useMixpanel()
 
   // rawSlippage = 10
   // slippage = 10 / 10_000 = 0.001 = 0.1%
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-
-  const { mixpanelHandler } = useMixpanel()
+  const isStablePairSwap = useCheckStablePairSwap()
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
+  const shouldWarning = isValid && !!message
 
   return (
     <Flex
@@ -90,7 +88,7 @@ const SlippageControl: React.FC = () => {
             mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: slp / 100 })
           }}
           data-active={rawSlippage === slp}
-          data-warning={rawSlippage === slp && shouldWarnSlippage(slp)}
+          data-warning={rawSlippage === slp && shouldWarning}
         >
           {slp / 100}%
         </DefaultSlippageOption>

--- a/src/components/swapv2/SwapSettingsPanel/PinButton.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/PinButton.tsx
@@ -1,0 +1,32 @@
+import { Flex } from 'rebass'
+
+import { ReactComponent as PinIcon } from 'assets/svg/pin_icon.svg'
+import { ReactComponent as PinSolidIcon } from 'assets/svg/pin_solid_icon.svg'
+import useTheme from 'hooks/useTheme'
+
+type Props = {
+  isActive: boolean
+  onClick: () => void
+}
+const PinButton: React.FC<Props> = ({ isActive, onClick }) => {
+  const theme = useTheme()
+
+  return (
+    <Flex
+      sx={{
+        width: '16px',
+        height: '16px',
+        justifyContent: 'center',
+        alignItems: 'center',
+        cursor: 'pointer',
+        marginLeft: '8px',
+      }}
+      role="button"
+      onClick={onClick}
+    >
+      {isActive ? <PinSolidIcon height="16px" color={theme.text} /> : <PinIcon height="16px" color={theme.subText} />}
+    </Flex>
+  )
+}
+
+export default PinButton

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -1,164 +1,14 @@
 import { Trans, t } from '@lingui/macro'
-import React, { useRef, useState } from 'react'
+import React from 'react'
 import { isMobile } from 'react-device-detect'
 import { Flex, Text } from 'rebass'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
-import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
-import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
+import SlippageControl from 'components/swapv2/SlippageControl'
 import useTheme from 'hooks/useTheme'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-
-const DefaultSlippages = [5, 10, 50, 100]
-
-const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
-
-// isValid = true means it's OK to process with the number with an extra parse
-// isValid = true with message means warning
-// isValid = false with/without message means error
-const validateSlippageInput = (str: string): { isValid: boolean; message?: string } => {
-  if (str === '') {
-    return {
-      isValid: true,
-    }
-  }
-
-  const numberRegex = /^\s*([0-9]+)(\.\d+)?\s*$/
-  if (!str.match(numberRegex)) {
-    return {
-      isValid: false,
-      message: t`Enter a valid slippage percentage`,
-    }
-  }
-
-  const rawSlippage = parseSlippageInput(str)
-  if (Number.isNaN(rawSlippage)) {
-    return {
-      isValid: false,
-      message: t`Enter a valid slippage percentage`,
-    }
-  }
-
-  if (rawSlippage < 0) {
-    return {
-      isValid: false,
-      message: t`Enter a valid slippage percentage`,
-    }
-  } else if (rawSlippage < 50) {
-    return {
-      isValid: true,
-      message: t`Your transaction may fail`,
-    }
-  } else if (rawSlippage > MAX_SLIPPAGE_IN_BIPS) {
-    return {
-      isValid: false,
-      message: t`Enter a smaller slippage percentage`,
-    }
-  } else if (rawSlippage > 500) {
-    return {
-      isValid: true,
-      message: t`Your transaction may be frontrun`,
-    }
-  }
-
-  return {
-    isValid: true,
-  }
-}
-
-const EmojiContainer = styled.span`
-  flex: 0 0 12px;
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-        display: none;
-  `}
-`
-
-const SlippageOptionCSS = css`
-  flex: 0 0 24%;
-  height: 100%;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: 20px;
-
-  background-color: ${({ theme }) => theme.tabBackgound};
-  color: ${({ theme }) => theme.subText};
-  text-align: center;
-
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 16px;
-
-  outline: none;
-  cursor: pointer;
-
-  :hover {
-    border: 1px solid ${({ theme }) => theme.bg4};
-  }
-  :focus {
-    border: 1px solid ${({ theme }) => theme.primary};
-  }
-
-  &[data-active='true'] {
-    background-color: ${({ theme }) => theme.tabActive};
-    color: ${({ theme }) => theme.text};
-
-    font-weight: 500;
-  }
-`
-const DefaultSlippageOption = styled.button`
-  ${SlippageOptionCSS}
-  flex: 0 0 18%;
-  @media only screen and (max-width: 375px) {
-    font-size: 10px;
-    flex: 0 0 15%;
-  }
-`
-
-const CustomSlippageOption = styled.div`
-  ${SlippageOptionCSS}
-
-  display: inline-flex;
-  align-items: center;
-  padding: 0 4px;
-  column-gap: 2px;
-  flex: 1;
-  input {
-    width: 100%;
-    height: 100%;
-    border: 0px;
-    border-radius: inherit;
-
-    color: inherit;
-    background: transparent;
-    outline: none;
-    text-align: right;
-
-    &::-webkit-outer-spin-button,
-    &::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-    }
-  }
-
-  &[data-active='true'] {
-    color: ${({ theme }) => theme.text};
-    font-weight: 500;
-  }
-
-  &[data-warning='true'] {
-    border: 1px solid;
-    border-color: ${({ theme }) => theme.warning};
-
-    ${EmojiContainer} {
-      color: ${({ theme }) => theme.warning};
-    }
-  }
-
-  &[data-error='true'] {
-    border: 1px solid;
-    border-color: ${({ theme }) => theme.red1};
-  }
-`
+import { checkRangeSlippage } from 'utils/slippage'
 
 const Message = styled.div`
   font-size: 12px;
@@ -174,69 +24,12 @@ const Message = styled.div`
   }
 `
 
-const CustomInput = styled.input`
-  ::placeholder {
-    font-size: 12px;
-  }
-  @media only screen and (max-width: 375px) {
-    font-size: 10px;
-  }
-`
-
-const getSlippageText = (rawSlippage: number) => {
-  const isCustom = !DefaultSlippages.includes(rawSlippage)
-  if (!isCustom) {
-    return ''
-  }
-
-  if (rawSlippage % 100 === 0) {
-    return String(rawSlippage / 100)
-  }
-
-  return (rawSlippage / 100).toFixed(2)
-}
-
 const SlippageSetting: React.FC = () => {
   const theme = useTheme()
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  // rawSlippage = 10
-  // slippage = 10 / 10_000 = 0.001 = 0.1%
-  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-
-  const isCustomOptionActive = !DefaultSlippages.includes(rawSlippage)
-  const [slippageInput, setSlippageInput] = useState(getSlippageText(rawSlippage))
-  const { isValid, message } = validateSlippageInput(slippageInput)
-
+  const [rawSlippage] = useUserSlippageTolerance()
+  const { isValid, message } = checkRangeSlippage(rawSlippage)
   const isWarning = isValid && !!message
   const isError = !isValid
-  const { mixpanelHandler } = useMixpanel()
-  const handleCommitChange = () => {
-    if (!isValid) {
-      return
-    }
-
-    if (slippageInput === '') {
-      setSlippageInput(getSlippageText(rawSlippage))
-      return
-    }
-
-    const newRawSlippage = parseSlippageInput(slippageInput)
-    if (Number.isNaN(newRawSlippage)) {
-      return
-    }
-    mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: newRawSlippage / 100 })
-
-    setRawSlippage(newRawSlippage)
-    setSlippageInput(getSlippageText(newRawSlippage))
-  }
-
-  const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleCommitChange()
-      inputRef.current?.blur()
-    }
-  }
 
   return (
     <Flex
@@ -265,61 +58,7 @@ const SlippageSetting: React.FC = () => {
         />
       </Flex>
 
-      <Flex
-        sx={{
-          justifyContent: 'space-between',
-          width: '100%',
-          maxWidth: '100%',
-          height: '28px',
-          borderRadius: '20px',
-          background: theme.tabBackgound,
-          padding: '2px',
-        }}
-      >
-        {DefaultSlippages.map(slp => (
-          <DefaultSlippageOption
-            key={slp}
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(slp)
-              mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: slp / 100 })
-            }}
-            data-active={rawSlippage === slp}
-          >
-            {slp / 100}%
-          </DefaultSlippageOption>
-        ))}
-
-        <CustomSlippageOption
-          data-active={isCustomOptionActive}
-          data-warning={isCustomOptionActive && isWarning}
-          data-error={isCustomOptionActive && isError}
-        >
-          {isCustomOptionActive && isWarning && (
-            <EmojiContainer>
-              <span role="img" aria-label="warning">
-                ⚠️
-              </span>
-            </EmojiContainer>
-          )}
-          <CustomInput
-            ref={inputRef}
-            placeholder={t`Custom`}
-            value={slippageInput}
-            onChange={e => setSlippageInput(e.target.value)}
-            onBlur={handleCommitChange}
-            onKeyUp={handleKeyUp}
-          />
-          <Text
-            as="span"
-            sx={{
-              flex: '0 0 12px',
-            }}
-          >
-            %
-          </Text>
-        </CustomSlippageOption>
-      </Flex>
+      <SlippageControl />
 
       {!!message && (
         <Message data-warning={isWarning} data-error={isError}>

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -1,12 +1,16 @@
 import { Trans, t } from '@lingui/macro'
 import React from 'react'
 import { isMobile } from 'react-device-detect'
+import { useDispatch } from 'react-redux'
 import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
 import SlippageControl from 'components/swapv2/SlippageControl'
+import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
 import useTheme from 'hooks/useTheme'
+import { useAppSelector } from 'state/hooks'
+import { pinSlippageControl } from 'state/swap/actions'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -25,11 +29,18 @@ const Message = styled.div`
 `
 
 const SlippageSetting: React.FC = () => {
+  const dispatch = useDispatch()
   const theme = useTheme()
   const [rawSlippage] = useUserSlippageTolerance()
   const { isValid, message } = checkRangeSlippage(rawSlippage)
   const isWarning = isValid && !!message
   const isError = !isValid
+
+  const isSlippageControlPinned = useAppSelector(state => state.swap.isSlippageControlPinned)
+
+  const handleClickPinSlippageControl = () => {
+    dispatch(pinSlippageControl(!isSlippageControlPinned))
+  }
 
   return (
     <Flex
@@ -54,8 +65,11 @@ const SlippageSetting: React.FC = () => {
           <Trans>Max Slippage</Trans>
         </Text>
         <QuestionHelper
-          text={t`Transaction will revert if there is an adverse rate change that is higher than this %`}
+          placement="top"
+          text={t`Transaction will revert if there is an adverse rate change that is higher than this %. This control will appear in Swap form if pinned.`}
         />
+
+        <PinButton isActive={isSlippageControlPinned} onClick={handleClickPinSlippageControl} />
       </Flex>
 
       <SlippageControl />

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -11,6 +11,7 @@ import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
 import { pinSlippageControl } from 'state/swap/actions'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -32,7 +33,8 @@ const SlippageSetting: React.FC = () => {
   const dispatch = useDispatch()
   const theme = useTheme()
   const [rawSlippage] = useUserSlippageTolerance()
-  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const isStablePairSwap = useCheckStablePairSwap()
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
   const isWarning = isValid && !!message
   const isError = !isValid
 

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -182,6 +182,20 @@ const CustomInput = styled.input`
     font-size: 10px;
   }
 `
+
+const getSlippageText = (rawSlippage: number) => {
+  const isCustom = !DefaultSlippages.includes(rawSlippage)
+  if (!isCustom) {
+    return ''
+  }
+
+  if (rawSlippage % 100 === 0) {
+    return String(rawSlippage / 100)
+  }
+
+  return (rawSlippage / 100).toFixed(2)
+}
+
 const SlippageSetting: React.FC = () => {
   const theme = useTheme()
   const inputRef = useRef<HTMLInputElement>(null)
@@ -191,14 +205,19 @@ const SlippageSetting: React.FC = () => {
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
 
   const isCustomOptionActive = !DefaultSlippages.includes(rawSlippage)
-  const [slippageInput, setSlippageInput] = useState(isCustomOptionActive ? (rawSlippage / 100).toFixed(2) : '')
-  const { isValid, message } = validateSlippageInput(slippageInput || String(rawSlippage / 100))
+  const [slippageInput, setSlippageInput] = useState(getSlippageText(rawSlippage))
+  const { isValid, message } = validateSlippageInput(slippageInput)
 
   const isWarning = isValid && !!message
   const isError = !isValid
   const { mixpanelHandler } = useMixpanel()
   const handleCommitChange = () => {
-    if (!isValid || slippageInput === '') {
+    if (!isValid) {
+      return
+    }
+
+    if (slippageInput === '') {
+      setSlippageInput(getSlippageText(rawSlippage))
       return
     }
 
@@ -209,6 +228,7 @@ const SlippageSetting: React.FC = () => {
     mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: newRawSlippage / 100 })
 
     setRawSlippage(newRawSlippage)
+    setSlippageInput(getSlippageText(newRawSlippage))
   }
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -251,6 +251,8 @@ export const EPSILON = 0.000000000008854
 
 // https://www.nasdaq.com/glossary/b/bip
 export const MAX_SLIPPAGE_IN_BIPS = 2000
+export const DEFAULT_SLIPPAGES = [5, 10, 50, 100]
+export const DEFAULT_SLIPPAGE = 50
 
 export const AGGREGATOR_WAITING_TIME = 1700 // 1700 means that we at least show '.' '..' '...' '.' '..' '...'
 

--- a/src/pages/SwapV3/PopulatedSwapForm.tsx
+++ b/src/pages/SwapV3/PopulatedSwapForm.tsx
@@ -34,7 +34,7 @@ const PopulatedSwapForm: React.FC<Props> = ({ routeSummary, setRouteSummary, goT
   const { feeConfig } = useSwapState()
   const { onUserInput, onCurrencySelection, onResetSelectCurrency } = useSwapActionHandlers()
 
-  useUpdateSlippageInStableCoinSwap(currencyIn, currencyOut)
+  useUpdateSlippageInStableCoinSwap()
 
   const onSelectSuggestedPair = useCallback(
     (fromToken: Currency | undefined, toToken: Currency | undefined, amount?: string) => {

--- a/src/pages/SwapV3/useUpdateSlippageInStableCoinSwap.tsx
+++ b/src/pages/SwapV3/useUpdateSlippageInStableCoinSwap.tsx
@@ -1,29 +1,33 @@
-import { Currency } from '@kyberswap/ks-sdk-core'
 import { useEffect, useRef } from 'react'
+import { useSelector } from 'react-redux'
 
 import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
+import { AppState } from 'state'
+import { Field } from 'state/swap/actions'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 
-const useUpdateSlippageInStableCoinSwap = (currencyIn?: Currency, currencyOut?: Currency) => {
+const useUpdateSlippageInStableCoinSwap = () => {
   const { chainId } = useActiveWeb3React()
+  const inputCurrencyId = useSelector((state: AppState) => state.swap[Field.INPUT].currencyId)
+  const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
   const [slippage, setSlippage] = useUserSlippageTolerance()
-  const isStableCoinSwap =
-    chainId &&
-    currencyIn &&
-    currencyOut &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address)
+
   const rawSlippageRef = useRef(slippage)
   rawSlippageRef.current = slippage
+
   useEffect(() => {
+    const isStableCoinSwap =
+      chainId &&
+      inputCurrencyId &&
+      outputCurrencyId &&
+      STABLE_COINS_ADDRESS[chainId].includes(inputCurrencyId) &&
+      STABLE_COINS_ADDRESS[chainId].includes(outputCurrencyId)
+
     if (isStableCoinSwap && rawSlippageRef.current > 10) {
       setSlippage(10)
     }
-    if (!isStableCoinSwap && rawSlippageRef.current === 10) {
-      setSlippage(50)
-    }
-  }, [isStableCoinSwap, setSlippage])
+  }, [chainId, inputCurrencyId, outputCurrencyId, setSlippage])
 }
 
 export default useUpdateSlippageInStableCoinSwap

--- a/src/state/swap/actions.ts
+++ b/src/state/swap/actions.ts
@@ -31,3 +31,4 @@ export const encodedSolana = createAction<{
 export const setRecipient = createAction<{ recipient: string | null }>('swap/setRecipient')
 export const setTrendingSoonShowed = createAction('swap/setTrendingSoonShowed')
 export const setTrade = createAction<{ trade: Aggregator | undefined }>('swap/setTrade')
+export const pinSlippageControl = createAction<boolean>('swap/pinSlippageControl')

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -308,7 +308,7 @@ export function queryParametersToSwapState(
   parsedQs: ParsedUrlQuery,
   chainId: ChainId,
   isMatchPath: boolean,
-): Omit<SwapState, 'saveGas' | 'typedValue'> {
+): Omit<SwapState, 'saveGas' | 'typedValue' | 'isSlippageControlPinned'> {
   let inputCurrency = parseCurrencyFromURLParameter(isMatchPath ? parsedQs.inputCurrency : null, chainId)
   let outputCurrency = parseCurrencyFromURLParameter(isMatchPath ? parsedQs.outputCurrency : null, chainId)
   if (inputCurrency === outputCurrency) {

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { APP_PATHS, BAD_RECIPIENT_ADDRESSES } from 'constants/index'
-import { DEFAULT_OUTPUT_TOKEN_BY_CHAIN, NativeCurrencies } from 'constants/tokens'
+import { DEFAULT_OUTPUT_TOKEN_BY_CHAIN, NativeCurrencies, STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import { useCurrencyV2 } from 'hooks/Tokens'
 import { useTradeExactIn } from 'hooks/Trades'
@@ -440,4 +440,20 @@ export const useOutputCurrency = () => {
   const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
   const outputCurrency = useCurrencyV2(outputCurrencyId)
   return outputCurrency || undefined
+}
+
+export const useCheckStablePairSwap = () => {
+  const { chainId } = useActiveWeb3React()
+  const inputCurrencyId = useSelector((state: AppState) => state.swap[Field.INPUT].currencyId)
+  const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
+
+  const isStablePairSwap = Boolean(
+    chainId &&
+      inputCurrencyId &&
+      outputCurrencyId &&
+      STABLE_COINS_ADDRESS[chainId].includes(inputCurrencyId) &&
+      STABLE_COINS_ADDRESS[chainId].includes(outputCurrencyId),
+  )
+
+  return isStablePairSwap
 }

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -9,6 +9,7 @@ import {
   Field,
   chooseToSaveGas,
   encodedSolana,
+  pinSlippageControl,
   replaceSwapState,
   resetSelectCurrency,
   selectCurrency,
@@ -45,6 +46,7 @@ export interface SwapState {
   readonly txHash: string | undefined
 
   readonly isSelectTokenManually: boolean
+  readonly isSlippageControlPinned: boolean
 }
 
 const { search, pathname } = window.location
@@ -76,6 +78,7 @@ const initialState: SwapState = {
   txHash: undefined,
 
   isSelectTokenManually: false,
+  isSlippageControlPinned: true,
 }
 
 export default createReducer<SwapState>(initialState, builder =>
@@ -165,5 +168,8 @@ export default createReducer<SwapState>(initialState, builder =>
     .addCase(setTrade, (state, { payload: { trade } }) => {
       state.trade = trade
       state.encodeSolana = undefined
+    })
+    .addCase(pinSlippageControl, (state, { payload }) => {
+      state.isSlippageControlPinned = payload
     }),
 )

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -5,11 +5,38 @@ import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
 // isValid = true means it's OK to process with the number with an extra parse
 // isValid = true with message means warning
 // isValid = false with/without message means error
-export const checkRangeSlippage = (slippage: number) => {
+export const checkRangeSlippage = (slippage: number, isStablePairSwap: boolean) => {
   if (slippage < 0) {
     return {
       isValid: false,
       message: t`Enter a valid slippage percentage`,
+    }
+  }
+
+  if (slippage > MAX_SLIPPAGE_IN_BIPS) {
+    return {
+      isValid: false,
+      message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
+    }
+  }
+
+  if (isStablePairSwap) {
+    if (slippage < 5) {
+      return {
+        isValid: true,
+        message: t`Slippage is low. Your transaction may fail`,
+      }
+    }
+
+    if (10 < slippage && slippage <= MAX_SLIPPAGE_IN_BIPS) {
+      return {
+        isValid: true,
+        message: t`Slippage for stable tokens swap should be <= 0.1%. Your transaction may be front-run`,
+      }
+    }
+
+    return {
+      isValid: true,
     }
   }
 
@@ -24,13 +51,6 @@ export const checkRangeSlippage = (slippage: number) => {
     return {
       isValid: true,
       message: t`Slippage is high. Your transaction may be front-run`,
-    }
-  }
-
-  if (slippage > MAX_SLIPPAGE_IN_BIPS) {
-    return {
-      isValid: false,
-      message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
     }
   }
 

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -38,3 +38,20 @@ export const checkRangeSlippage = (slippage: number) => {
     isValid: true,
   }
 }
+
+export const formatSlippage = (slp: number, withPercent = false) => {
+  let text = ''
+  if (slp % 100 === 0) {
+    text = String(slp / 100)
+  } else if (slp % 10 === 0) {
+    text = (slp / 100).toFixed(1)
+  } else {
+    text = (slp / 100).toFixed(2)
+  }
+
+  if (withPercent) {
+    text += '%'
+  }
+
+  return text
+}

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -1,0 +1,40 @@
+import { t } from '@lingui/macro'
+
+import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+
+// isValid = true means it's OK to process with the number with an extra parse
+// isValid = true with message means warning
+// isValid = false with/without message means error
+export const checkRangeSlippage = (slippage: number) => {
+  if (slippage < 0) {
+    return {
+      isValid: false,
+      message: t`Enter a valid slippage percentage`,
+    }
+  }
+
+  if (slippage < 50) {
+    return {
+      isValid: true,
+      message: t`Slippage is low. Your transaction may fail`,
+    }
+  }
+
+  if (500 < slippage && slippage <= MAX_SLIPPAGE_IN_BIPS) {
+    return {
+      isValid: true,
+      message: t`Slippage is high. Your transaction may be front-run`,
+    }
+  }
+
+  if (slippage > MAX_SLIPPAGE_IN_BIPS) {
+    return {
+      isValid: false,
+      message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
+    }
+  }
+
+  return {
+    isValid: true,
+  }
+}


### PR DESCRIPTION
1. Only automatically set slippage to 0.1% in stable coin swap
2. Display a tooltip helper indicating that: slippage should be <= 0.1% for stable coin swap
3. Reset slippage input on enter and blur

https://user-images.githubusercontent.com/19758667/223052891-9a6ed739-54b1-4a97-b022-c7fe167a2837.mov
