### PR TITLE
Improve slippage settings

### DIFF
--- a/src/components/MenuFlyout/index.tsx
+++ b/src/components/MenuFlyout/index.tsx
@@ -177,7 +177,7 @@ const CloseIcon = styled.div`
   position: absolute;
   right: 20px;
   top: 17px;
-  color: ${({ theme }) => theme.text4};
+  color: ${({ theme }) => theme.subText};
   &:hover {
     cursor: pointer;
     opacity: 0.6;

--- a/src/components/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/SlippageControl/CustomSlippageInput.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Text } from 'rebass'
 import styled, { css } from 'styled-components'
 
-import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+import { DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
 import { formatSlippage } from 'utils/slippage'
 
 export const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
@@ -114,8 +114,9 @@ export type Props = {
   rawSlippage: number
   setRawSlippage: (value: number) => void
   isWarning: boolean
+  defaultRawSlippage: number
 }
-const CustomSlippageInput: React.FC<Props> = ({ rawSlippage, setRawSlippage, isWarning }) => {
+const CustomSlippageInput: React.FC<Props> = ({ rawSlippage, setRawSlippage, isWarning, defaultRawSlippage }) => {
   const inputRef = useRef<HTMLInputElement>(null)
 
   // rawSlippage = 10
@@ -129,7 +130,7 @@ const CustomSlippageInput: React.FC<Props> = ({ rawSlippage, setRawSlippage, isW
 
     if (value === '') {
       setRawText(value)
-      setRawSlippage(DEFAULT_SLIPPAGE)
+      setRawSlippage(defaultRawSlippage)
       return
     }
 

--- a/src/components/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/SlippageControl/CustomSlippageInput.tsx
@@ -4,9 +4,7 @@ import { Text } from 'rebass'
 import styled, { css } from 'styled-components'
 
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
-import { useCheckStablePairSwap } from 'state/swap/hooks'
-import { useUserSlippageTolerance } from 'state/user/hooks'
-import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
+import { formatSlippage } from 'utils/slippage'
 
 export const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
 const getSlippageText = (rawSlippage: number) => {
@@ -15,7 +13,7 @@ const getSlippageText = (rawSlippage: number) => {
     return ''
   }
 
-  return formatSlippage(rawSlippage)
+  return formatSlippage(rawSlippage, false)
 }
 
 const EmojiContainer = styled.span`
@@ -112,19 +110,19 @@ const CustomInput = styled.input`
   }
 `
 
-const CustomSlippageInput: React.FC = () => {
+export type Props = {
+  rawSlippage: number
+  setRawSlippage: (value: number) => void
+  isWarning: boolean
+}
+const CustomSlippageInput: React.FC<Props> = ({ rawSlippage, setRawSlippage, isWarning }) => {
   const inputRef = useRef<HTMLInputElement>(null)
 
   // rawSlippage = 10
-  // slippage = 10 / 10_000 = 0.001 = 0.1%
-  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+  // slippage shown to user: = 10 / 10_000 = 0.001 = 0.1%
   const [rawText, setRawText] = useState(getSlippageText(rawSlippage))
-  const isStablePairSwap = useCheckStablePairSwap()
 
   const isCustomOptionActive = !DEFAULT_SLIPPAGES.includes(rawSlippage)
-
-  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
-  const isWarning = isValid && !!message
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value

--- a/src/components/SlippageControl/index.tsx
+++ b/src/components/SlippageControl/index.tsx
@@ -2,13 +2,12 @@ import React from 'react'
 import { Flex } from 'rebass'
 import styled, { css } from 'styled-components'
 
-import CustomSlippageInput from 'components/swapv2/SlippageControl/CustomSlippageInput'
+import CustomSlippageInput from 'components/SlippageControl/CustomSlippageInput'
 import { DEFAULT_SLIPPAGES } from 'constants/index'
 import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
 import useTheme from 'hooks/useTheme'
-import { useCheckStablePairSwap } from 'state/swap/hooks'
-import { useUserSlippageTolerance } from 'state/user/hooks'
-import { checkRangeSlippage } from 'utils/slippage'
+
+import { Props as CustomSlippageInputProps } from './CustomSlippageInput'
 
 export const slippageOptionCSS = css`
   height: 100%;
@@ -57,17 +56,13 @@ const DefaultSlippageOption = styled.button`
   }
 `
 
-const SlippageControl: React.FC = () => {
+type Props = CustomSlippageInputProps
+// rawSlippage = 10
+// slippage = 10 / 10_000 = 0.001 = 0.1%
+const SlippageControl: React.FC<Props> = props => {
+  const { rawSlippage, setRawSlippage, isWarning } = props
   const theme = useTheme()
   const { mixpanelHandler } = useMixpanel()
-
-  // rawSlippage = 10
-  // slippage = 10 / 10_000 = 0.001 = 0.1%
-  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-  const isStablePairSwap = useCheckStablePairSwap()
-  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
-  const shouldWarning = isValid && !!message
-
   return (
     <Flex
       sx={{
@@ -88,13 +83,13 @@ const SlippageControl: React.FC = () => {
             mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: slp / 100 })
           }}
           data-active={rawSlippage === slp}
-          data-warning={rawSlippage === slp && shouldWarning}
+          data-warning={rawSlippage === slp && isWarning}
         >
           {slp / 100}%
         </DefaultSlippageOption>
       ))}
 
-      <CustomSlippageInput />
+      <CustomSlippageInput {...props} />
     </Flex>
   )
 }

--- a/src/components/SwapForm/PriceImpactNote.tsx
+++ b/src/components/SwapForm/PriceImpactNote.tsx
@@ -1,5 +1,4 @@
 import { Trans, t } from '@lingui/macro'
-import { CSSProperties } from 'react'
 import { AlertTriangle } from 'react-feather'
 import styled, { useTheme } from 'styled-components'
 
@@ -22,9 +21,8 @@ type Props = {
   isAdvancedMode?: boolean
   priceImpact: number | undefined
   hasTooltip: boolean
-  style?: CSSProperties
 }
-const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTooltip, style }) => {
+const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTooltip }) => {
   const theme = useTheme()
   const priceImpactResult = checkPriceImpact(priceImpact)
 
@@ -35,7 +33,7 @@ const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTool
   // invalid
   if (priceImpactResult.isInvalid) {
     return (
-      <Wrapper style={style}>
+      <Wrapper>
         <AlertTriangle color={theme.warning} size={16} style={{ marginRight: '10px' }} />
         <Trans>Unable to calculate Price Impact</Trans>
         <InfoHelper text={t`Turn on Advanced Mode to trade`} color={theme.text} />
@@ -45,7 +43,7 @@ const PriceImpactNote: React.FC<Props> = ({ isAdvancedMode, priceImpact, hasTool
 
   if (priceImpactResult.isHigh) {
     return (
-      <Wrapper style={style} veryHigh={priceImpactResult.isVeryHigh}>
+      <Wrapper veryHigh={priceImpactResult.isVeryHigh}>
         <AlertTriangle size={16} style={{ marginRight: '10px' }} />
         {priceImpactResult.isVeryHigh ? <Trans>Price Impact is Very High</Trans> : <Trans>Price Impact is High</Trans>}
 

--- a/src/components/SwapForm/SlippageNote.tsx
+++ b/src/components/SwapForm/SlippageNote.tsx
@@ -1,8 +1,9 @@
 import { rgba } from 'polished'
-import { CSSProperties } from 'react'
 import { AlertTriangle } from 'react-feather'
+import { Flex } from 'rebass'
 import styled from 'styled-components'
 
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -11,6 +12,7 @@ const Wrapper = styled.div`
 
   display: flex;
   align-items: center;
+  gap: 8px;
 
   border-radius: 999px;
   color: ${({ theme }) => theme.warning};
@@ -18,20 +20,20 @@ const Wrapper = styled.div`
   font-size: 12px;
 `
 
-type Props = {
-  style?: CSSProperties
-}
-const SlippageNote: React.FC<Props> = ({ style }) => {
+const SlippageNote: React.FC = () => {
   const [rawSlippage] = useUserSlippageTolerance()
-  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const isStablePairSwap = useCheckStablePairSwap()
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
 
   if (!isValid || !message) {
     return null
   }
 
   return (
-    <Wrapper style={style}>
-      <AlertTriangle size={16} style={{ marginRight: '10px' }} />
+    <Wrapper>
+      <Flex flex="0 0 16px" height="16px" alignItems="center" justifyContent="center">
+        <AlertTriangle size={16} />
+      </Flex>
       {message}
     </Wrapper>
   )

--- a/src/components/SwapForm/SlippageNote.tsx
+++ b/src/components/SwapForm/SlippageNote.tsx
@@ -1,0 +1,40 @@
+import { rgba } from 'polished'
+import { CSSProperties } from 'react'
+import { AlertTriangle } from 'react-feather'
+import styled from 'styled-components'
+
+import { useUserSlippageTolerance } from 'state/user/hooks'
+import { checkRangeSlippage } from 'utils/slippage'
+
+const Wrapper = styled.div`
+  padding: 12px 16px;
+
+  display: flex;
+  align-items: center;
+
+  border-radius: 999px;
+  color: ${({ theme }) => theme.warning};
+  background: ${({ theme }) => rgba(theme.warning, 0.2)};
+  font-size: 12px;
+`
+
+type Props = {
+  style?: CSSProperties
+}
+const SlippageNote: React.FC<Props> = ({ style }) => {
+  const [rawSlippage] = useUserSlippageTolerance()
+  const { isValid, message } = checkRangeSlippage(rawSlippage)
+
+  if (!isValid || !message) {
+    return null
+  }
+
+  return (
+    <Wrapper style={style}>
+      <AlertTriangle size={16} style={{ marginRight: '10px' }} />
+      {message}
+    </Wrapper>
+  )
+}
+
+export default SlippageNote

--- a/src/components/SwapForm/SlippageNote.tsx
+++ b/src/components/SwapForm/SlippageNote.tsx
@@ -20,8 +20,8 @@ const Wrapper = styled.div`
 `
 
 const SlippageNote: React.FC = () => {
-  const { slippage } = useSwapFormContext()
-  const { isValid, message } = checkRangeSlippage(slippage)
+  const { slippage, isStablePairSwap } = useSwapFormContext()
+  const { isValid, message } = checkRangeSlippage(slippage, isStablePairSwap)
 
   if (!isValid || !message) {
     return null

--- a/src/components/SwapForm/SlippageNote.tsx
+++ b/src/components/SwapForm/SlippageNote.tsx
@@ -3,8 +3,7 @@ import { AlertTriangle } from 'react-feather'
 import { Flex } from 'rebass'
 import styled from 'styled-components'
 
-import { useCheckStablePairSwap } from 'state/swap/hooks'
-import { useUserSlippageTolerance } from 'state/user/hooks'
+import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import { checkRangeSlippage } from 'utils/slippage'
 
 const Wrapper = styled.div`
@@ -21,9 +20,8 @@ const Wrapper = styled.div`
 `
 
 const SlippageNote: React.FC = () => {
-  const [rawSlippage] = useUserSlippageTolerance()
-  const isStablePairSwap = useCheckStablePairSwap()
-  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
+  const { slippage } = useSwapFormContext()
+  const { isValid, message } = checkRangeSlippage(slippage)
 
   if (!isValid || !message) {
     return null

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -5,7 +5,7 @@ import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
-import QuestionHelper from 'components/QuestionHelper'
+import InfoHelper from 'components/InfoHelper'
 import SlippageControl from 'components/SlippageControl'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
@@ -52,7 +52,7 @@ const SlippageSetting: React.FC = () => {
           sx={{
             alignItems: 'center',
             color: theme.subText,
-            fontSize: isMobile ? '14px' : '12px',
+            fontSize: '12px',
             fontWeight: 500,
             lineHeight: '1',
           }}
@@ -60,7 +60,8 @@ const SlippageSetting: React.FC = () => {
           <Text as="span">
             <Trans>Max Slippage</Trans>
           </Text>
-          <QuestionHelper
+          <InfoHelper
+            size={14}
             placement="top"
             text={t`Transaction will revert if there is an adverse rate change that is higher than this %. You can hide this control in Settings.`}
           />

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -15,8 +15,6 @@ import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkWarningSlippage, formatSlippage } from 'utils/slippage'
 
 const DropdownIcon = styled(DropdownSVG)`
-  cursor: pointer;
-
   transition: transform 300ms;
   color: ${({ theme }) => theme.subText};
   &[data-flip='true'] {
@@ -71,18 +69,28 @@ const SlippageSetting: React.FC = () => {
           </Text>
         </Flex>
 
-        <Text
+        <Flex
           sx={{
-            fontSize: isMobile ? '16px' : '14px',
-            fontWeight: 500,
-            lineHeight: '1',
-            color: theme.text,
+            alignItems: 'center',
+            gap: '4px',
+            cursor: 'pointer',
           }}
+          role="button"
+          onClick={() => setExpanded(e => !e)}
         >
-          {formatSlippage(rawSlippage)}
-        </Text>
+          <Text
+            sx={{
+              fontSize: isMobile ? '16px' : '14px',
+              fontWeight: 500,
+              lineHeight: '1',
+              color: theme.text,
+            }}
+          >
+            {formatSlippage(rawSlippage)}
+          </Text>
 
-        <DropdownIcon data-flip={expanded} onClick={() => setExpanded(e => !e)} />
+          <DropdownIcon data-flip={expanded} />
+        </Flex>
       </Flex>
 
       <Flex

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -1,0 +1,110 @@
+import { Trans, t } from '@lingui/macro'
+import React, { useState } from 'react'
+import { isMobile } from 'react-device-detect'
+import { Flex, Text } from 'rebass'
+import styled from 'styled-components'
+
+import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
+import QuestionHelper from 'components/QuestionHelper'
+import SlippageControl from 'components/swapv2/SlippageControl'
+import useTheme from 'hooks/useTheme'
+import { useAppSelector } from 'state/hooks'
+import { useUserSlippageTolerance } from 'state/user/hooks'
+
+const getSlippageText = (slp: number) => {
+  if (slp % 100 === 0) {
+    return String(slp / 100)
+  }
+
+  if (slp % 10 === 0) {
+    return (slp / 100).toFixed(1)
+  }
+
+  return (slp / 100).toFixed(2)
+}
+
+const DropdownIcon = styled(DropdownSVG)`
+  cursor: pointer;
+
+  transition: transform 300ms;
+  color: ${({ theme }) => theme.subText};
+  &[data-flip='true'] {
+    transform: rotate(180deg);
+  }
+`
+
+const SlippageSetting: React.FC = () => {
+  const theme = useTheme()
+  const [rawSlippage] = useUserSlippageTolerance()
+
+  const [expanded, setExpanded] = useState(false)
+
+  const isSlippageControlPinned = useAppSelector(state => state.swap.isSlippageControlPinned)
+
+  if (!isSlippageControlPinned) {
+    return null
+  }
+
+  return (
+    <Flex
+      sx={{
+        flexDirection: 'column',
+      }}
+    >
+      <Flex
+        sx={{
+          alignItems: 'center',
+          color: theme.subText,
+          gap: '4px',
+        }}
+      >
+        <Flex
+          sx={{
+            alignItems: 'center',
+            color: theme.subText,
+            fontSize: isMobile ? '14px' : '12px',
+            fontWeight: 500,
+            lineHeight: '1',
+          }}
+        >
+          <Text as="span">
+            <Trans>Max Slippage</Trans>
+          </Text>
+          <QuestionHelper
+            placement="top"
+            text={t`Transaction will revert if there is an adverse rate change that is higher than this %. You can hide this control in Settings.`}
+          />
+          <Text as="span" marginLeft="4px">
+            :
+          </Text>
+        </Flex>
+
+        <Text
+          sx={{
+            fontSize: isMobile ? '16px' : '14px',
+            fontWeight: 500,
+            lineHeight: '1',
+            color: theme.text,
+          }}
+        >
+          {getSlippageText(rawSlippage)}%
+        </Text>
+
+        <DropdownIcon data-flip={expanded} onClick={() => setExpanded(e => !e)} />
+      </Flex>
+
+      <Flex
+        sx={{
+          transition: 'all 100ms linear',
+          paddingTop: expanded ? '8px' : '0px',
+          height: expanded ? '36px' : '0px',
+          overflow: 'hidden',
+        }}
+      >
+        <SlippageControl />
+      </Flex>
+    </Flex>
+  )
+}
+
+export default SlippageSetting

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -7,6 +7,8 @@ import styled from 'styled-components'
 import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
 import InfoHelper from 'components/InfoHelper'
 import SlippageControl from 'components/SlippageControl'
+import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
+import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP } from 'constants/index'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
@@ -24,12 +26,11 @@ const DropdownIcon = styled(DropdownSVG)`
 
 const SlippageSetting: React.FC = () => {
   const theme = useTheme()
-  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-  const isWarningSlippage = checkWarningSlippage(rawSlippage)
-
-  const [expanded, setExpanded] = useState(false)
-
   const isSlippageControlPinned = useAppSelector(state => state.swap.isSlippageControlPinned)
+  const [expanded, setExpanded] = useState(false)
+  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+  const { isStablePairSwap } = useSwapFormContext()
+  const isWarningSlippage = checkWarningSlippage(rawSlippage, isStablePairSwap)
 
   if (!isSlippageControlPinned) {
     return null
@@ -92,7 +93,12 @@ const SlippageSetting: React.FC = () => {
           overflow: 'hidden',
         }}
       >
-        <SlippageControl rawSlippage={rawSlippage} setRawSlippage={setRawSlippage} isWarning={isWarningSlippage} />
+        <SlippageControl
+          rawSlippage={rawSlippage}
+          setRawSlippage={setRawSlippage}
+          isWarning={isWarningSlippage}
+          defaultRawSlippage={isStablePairSwap ? DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP : DEFAULT_SLIPPAGE}
+        />
       </Flex>
     </Flex>
   )

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -10,18 +10,7 @@ import SlippageControl from 'components/swapv2/SlippageControl'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-
-const getSlippageText = (slp: number) => {
-  if (slp % 100 === 0) {
-    return String(slp / 100)
-  }
-
-  if (slp % 10 === 0) {
-    return (slp / 100).toFixed(1)
-  }
-
-  return (slp / 100).toFixed(2)
-}
+import { formatSlippage } from 'utils/slippage'
 
 const DropdownIcon = styled(DropdownSVG)`
   cursor: pointer;
@@ -87,7 +76,7 @@ const SlippageSetting: React.FC = () => {
             color: theme.text,
           }}
         >
-          {getSlippageText(rawSlippage)}%
+          {formatSlippage(rawSlippage, true)}
         </Text>
 
         <DropdownIcon data-flip={expanded} onClick={() => setExpanded(e => !e)} />

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -6,11 +6,11 @@ import styled from 'styled-components'
 
 import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
 import QuestionHelper from 'components/QuestionHelper'
-import SlippageControl from 'components/swapv2/SlippageControl'
+import SlippageControl from 'components/SlippageControl'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-import { formatSlippage } from 'utils/slippage'
+import { checkWarningSlippage, formatSlippage } from 'utils/slippage'
 
 const DropdownIcon = styled(DropdownSVG)`
   cursor: pointer;
@@ -24,7 +24,8 @@ const DropdownIcon = styled(DropdownSVG)`
 
 const SlippageSetting: React.FC = () => {
   const theme = useTheme()
-  const [rawSlippage] = useUserSlippageTolerance()
+  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+  const isWarningSlippage = checkWarningSlippage(rawSlippage)
 
   const [expanded, setExpanded] = useState(false)
 
@@ -76,7 +77,7 @@ const SlippageSetting: React.FC = () => {
             color: theme.text,
           }}
         >
-          {formatSlippage(rawSlippage, true)}
+          {formatSlippage(rawSlippage)}
         </Text>
 
         <DropdownIcon data-flip={expanded} onClick={() => setExpanded(e => !e)} />
@@ -90,7 +91,7 @@ const SlippageSetting: React.FC = () => {
           overflow: 'hidden',
         }}
       >
-        <SlippageControl />
+        <SlippageControl rawSlippage={rawSlippage} setRawSlippage={setRawSlippage} isWarning={isWarningSlippage} />
       </Flex>
     </Flex>
   )

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -64,7 +64,7 @@ const SlippageSetting: React.FC = () => {
           <InfoHelper
             size={14}
             placement="top"
-            text={t`Transaction will revert if there is an adverse rate change that is higher than this %. You can hide this control in Settings.`}
+            text={t`During your swap if the price changes by more than this %, your transaction will revert. You can hide this control in Settings.`}
           />
           <Text as="span" marginLeft="4px">
             :

--- a/src/components/SwapForm/SwapActionButton/index.tsx
+++ b/src/components/SwapForm/SwapActionButton/index.tsx
@@ -1,6 +1,7 @@
 import { Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
 import { useEffect, useState } from 'react'
+import { Flex } from 'rebass'
 import styled from 'styled-components'
 
 import { ButtonConfirmed, ButtonLight, ButtonPrimary } from 'components/Button'
@@ -174,7 +175,12 @@ const SwapActionButton: React.FC<Props> = ({
 
     if (showApproveFlow) {
       return (
-        <>
+        <Flex
+          sx={{
+            flexDirection: 'column',
+            gap: '0.75rem',
+          }}
+        >
           <RowBetween>
             <ButtonConfirmed
               onClick={approveCallback}
@@ -199,10 +205,10 @@ const SwapActionButton: React.FC<Props> = ({
 
             <SwapOnlyButton minimal {...swapOnlyButtonProps} />
           </RowBetween>
-          <Column style={{ marginTop: '1rem' }}>
+          <Column>
             <ProgressSteps steps={[approval === ApprovalState.APPROVED]} />
           </Column>
-        </>
+        </Flex>
       )
     }
 

--- a/src/components/SwapForm/SwapFormContext.tsx
+++ b/src/components/SwapForm/SwapFormContext.tsx
@@ -9,6 +9,7 @@ type SwapFormContextProps = {
   typedValue: string
   isSaveGas: boolean
   recipient: string | null
+  isStablePairSwap: boolean
 }
 
 const SwapFormContext = createContext<SwapFormContextProps>({
@@ -18,6 +19,7 @@ const SwapFormContext = createContext<SwapFormContextProps>({
   typedValue: '',
   isSaveGas: false,
   recipient: null,
+  isStablePairSwap: false,
 })
 
 const SwapFormContextProvider: React.FC<

--- a/src/components/SwapForm/SwapModal/ConfirmSwapModalContent.tsx
+++ b/src/components/SwapForm/SwapModal/ConfirmSwapModalContent.tsx
@@ -1,13 +1,15 @@
 import { Price } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
 import React from 'react'
-import { Text } from 'rebass'
+import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import { ButtonPrimary } from 'components/Button'
 import { GreyCard } from 'components/Card'
 import { AutoColumn } from 'components/Column'
 import { AutoRow, RowBetween } from 'components/Row'
+import PriceImpactNote from 'components/SwapForm/PriceImpactNote'
+import SlippageNote from 'components/SwapForm/SlippageNote'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import { BuildRouteResult } from 'components/SwapForm/hooks/useBuildRoute'
 import { Dots } from 'components/swapv2/styleds'
@@ -124,6 +126,16 @@ const ConfirmSwapModalContent: React.FC<Props> = ({
       </AutoColumn>
 
       <SwapDetails {...getSwapDetailsProps()} />
+
+      <Flex
+        sx={{
+          flexDirection: 'column',
+          gap: '0.75rem',
+        }}
+      >
+        <SlippageNote />
+        <PriceImpactNote priceImpact={routeSummary?.priceImpact} hasTooltip={false} />
+      </Flex>
 
       <AutoRow>
         {isSolana && !encodeSolana ? (

--- a/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
@@ -1,0 +1,20 @@
+import useTheme from 'hooks/useTheme'
+import { TYPE } from 'theme'
+import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
+
+type Props = {
+  value: number
+}
+
+const SlippageValue: React.FC<Props> = ({ value }) => {
+  const theme = useTheme()
+  const { isValid, message } = checkRangeSlippage(value)
+  const isWarning = isValid && !!message
+  return (
+    <TYPE.black fontSize={14} color={isWarning ? theme.warning : undefined}>
+      {formatSlippage(value, true)}
+    </TYPE.black>
+  )
+}
+
+export default SlippageValue

--- a/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
@@ -1,19 +1,15 @@
+import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import useTheme from 'hooks/useTheme'
 import { TYPE } from 'theme'
-import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
+import { checkWarningSlippage, formatSlippage } from 'utils/slippage'
 
-type Props = {
-  value: number
-  isStableCoinSwap: boolean
-}
-
-const SlippageValue: React.FC<Props> = ({ value, isStableCoinSwap }) => {
+const SlippageValue: React.FC = () => {
   const theme = useTheme()
-  const { isValid, message } = checkRangeSlippage(value, isStableCoinSwap)
-  const isWarning = isValid && !!message
+  const { slippage } = useSwapFormContext()
+  const isWarning = checkWarningSlippage(slippage)
   return (
     <TYPE.black fontSize={14} color={isWarning ? theme.warning : undefined}>
-      {formatSlippage(value, true)}
+      {formatSlippage(slippage)}
     </TYPE.black>
   )
 }

--- a/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
@@ -5,8 +5,8 @@ import { checkWarningSlippage, formatSlippage } from 'utils/slippage'
 
 const SlippageValue: React.FC = () => {
   const theme = useTheme()
-  const { slippage } = useSwapFormContext()
-  const isWarning = checkWarningSlippage(slippage)
+  const { slippage, isStablePairSwap } = useSwapFormContext()
+  const isWarning = checkWarningSlippage(slippage, isStablePairSwap)
   return (
     <TYPE.black fontSize={14} color={isWarning ? theme.warning : undefined}>
       {formatSlippage(slippage)}

--- a/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/SlippageValue.tsx
@@ -4,11 +4,12 @@ import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
 
 type Props = {
   value: number
+  isStableCoinSwap: boolean
 }
 
-const SlippageValue: React.FC<Props> = ({ value }) => {
+const SlippageValue: React.FC<Props> = ({ value, isStableCoinSwap }) => {
   const theme = useTheme()
-  const { isValid, message } = checkRangeSlippage(value)
+  const { isValid, message } = checkRangeSlippage(value, isStableCoinSwap)
   const isWarning = isValid && !!message
   return (
     <TYPE.black fontSize={14} color={isWarning ? theme.warning : undefined}>

--- a/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
@@ -17,7 +17,6 @@ import ValueWithLoadingSkeleton from 'components/SwapForm/SwapModal/SwapDetails/
 import { StyledBalanceMaxMini } from 'components/swapv2/styleds'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
-import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { TYPE } from 'theme'
 import { DetailedRouteSummary } from 'types/route'
 import { formattedNum, toK } from 'utils'
@@ -92,7 +91,6 @@ const SwapDetails: React.FC<Props> = ({
   const [showInverted, setShowInverted] = useState<boolean>(false)
   const theme = useTheme()
   const { feeConfig, slippage } = useSwapFormContext()
-  const isStablePairSwap = useCheckStablePairSwap()
 
   const formattedFeeAmountUsd = getFormattedFeeAmountUsdV2(Number(amountInUsd || 0), feeConfig?.feeAmount)
 
@@ -264,7 +262,7 @@ const SwapDetails: React.FC<Props> = ({
             </TYPE.black>
           </RowFixed>
 
-          <SlippageValue value={slippage} isStableCoinSwap={isStablePairSwap} />
+          <SlippageValue />
         </RowBetween>
 
         {feeConfig && (

--- a/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
@@ -12,6 +12,7 @@ import InfoHelper from 'components/InfoHelper'
 import Loader from 'components/Loader'
 import { RowBetween, RowFixed } from 'components/Row'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
+import SlippageValue from 'components/SwapForm/SwapModal/SwapDetails/SlippageValue'
 import ValueWithLoadingSkeleton from 'components/SwapForm/SwapModal/SwapDetails/ValueWithLoadingSkeleton'
 import { StyledBalanceMaxMini } from 'components/swapv2/styleds'
 import { useActiveWeb3React } from 'hooks'
@@ -261,7 +262,7 @@ const SwapDetails: React.FC<Props> = ({
             </TYPE.black>
           </RowFixed>
 
-          <TYPE.black fontSize={14}>{slippage / 100}%</TYPE.black>
+          <SlippageValue value={slippage} />
         </RowBetween>
 
         {feeConfig && (

--- a/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
@@ -17,6 +17,7 @@ import ValueWithLoadingSkeleton from 'components/SwapForm/SwapModal/SwapDetails/
 import { StyledBalanceMaxMini } from 'components/swapv2/styleds'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { TYPE } from 'theme'
 import { DetailedRouteSummary } from 'types/route'
 import { formattedNum, toK } from 'utils'
@@ -91,6 +92,7 @@ const SwapDetails: React.FC<Props> = ({
   const [showInverted, setShowInverted] = useState<boolean>(false)
   const theme = useTheme()
   const { feeConfig, slippage } = useSwapFormContext()
+  const isStablePairSwap = useCheckStablePairSwap()
 
   const formattedFeeAmountUsd = getFormattedFeeAmountUsdV2(Number(amountInUsd || 0), feeConfig?.feeAmount)
 
@@ -262,7 +264,7 @@ const SwapDetails: React.FC<Props> = ({
             </TYPE.black>
           </RowFixed>
 
-          <SlippageValue value={slippage} />
+          <SlippageValue value={slippage} isStableCoinSwap={isStablePairSwap} />
         </RowBetween>
 
         {feeConfig && (

--- a/src/components/SwapForm/hooks/useCheckStablePairSwap.ts
+++ b/src/components/SwapForm/hooks/useCheckStablePairSwap.ts
@@ -10,8 +10,6 @@ const useCheckStablePairSwap = (currencyIn: Currency | undefined, currencyOut: C
     chainId &&
       currencyIn &&
       currencyOut &&
-      currencyIn.wrapped.address &&
-      currencyOut.wrapped.address &&
       STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
       STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address),
   )

--- a/src/components/SwapForm/hooks/useCheckStablePairSwap.ts
+++ b/src/components/SwapForm/hooks/useCheckStablePairSwap.ts
@@ -1,0 +1,22 @@
+import { Currency } from '@kyberswap/ks-sdk-core'
+
+import { STABLE_COINS_ADDRESS } from 'constants/tokens'
+import { useActiveWeb3React } from 'hooks'
+
+const useCheckStablePairSwap = (currencyIn: Currency | undefined, currencyOut: Currency | undefined) => {
+  const { chainId } = useActiveWeb3React()
+
+  const isStablePairSwap = Boolean(
+    chainId &&
+      currencyIn &&
+      currencyOut &&
+      currencyIn.wrapped.address &&
+      currencyOut.wrapped.address &&
+      STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
+      STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address),
+  )
+
+  return isStablePairSwap
+}
+
+export default useCheckStablePairSwap

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -1,10 +1,11 @@
 import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
-import { Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { useEffect, useMemo, useState } from 'react'
-import { Box, Flex } from 'rebass'
+import { Box, Flex, Text } from 'rebass'
 import { parseGetRouteResponse } from 'services/route/utils'
 
 import AddressInputPanel from 'components/AddressInputPanel'
+import QuestionHelper from 'components/QuestionHelper'
 import { AutoRow } from 'components/Row'
 import InputCurrencyPanel from 'components/SwapForm/InputCurrencyPanel'
 import OutputCurrencyPanel from 'components/SwapForm/OutputCurrencyPanel'
@@ -17,6 +18,7 @@ import TrendingSoonTokenBanner from 'components/TrendingSoonTokenBanner'
 import { TutorialIds } from 'components/Tutorial/TutorialSwap/constant'
 import TradePrice from 'components/swapv2/TradePrice'
 import { Wrapper } from 'components/swapv2/styleds'
+import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
@@ -80,6 +82,12 @@ const SwapForm: React.FC<SwapFormProps> = props => {
   const parsedAmount = useParsedAmount(currencyIn, typedValue)
   const { wrapType, inputError: wrapInputError, execute: onWrap } = useWrapCallback(currencyIn, currencyOut, typedValue)
   const isWrapOrUnwrap = wrapType !== WrapType.NOT_APPLICABLE
+  const isStableCoinSwap =
+    chainId &&
+    currencyIn &&
+    currencyOut &&
+    STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
+    STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address)
 
   const { fetcher: getRoute, result } = useGetRoute({
     currencyIn,
@@ -197,12 +205,22 @@ const SwapForm: React.FC<SwapFormProps> = props => {
                 fontSize={12}
                 color={theme.subText}
                 onClick={goToSettingsView}
-                width="fit-content"
+                width="max-content"
               >
                 <ClickableText color={theme.subText} fontWeight={500}>
                   <Trans>Max Slippage:</Trans>&nbsp;
-                  {slippage / 100}%
+                  <Text as="span" color={isStableCoinSwap ? theme.text : theme.subText}>
+                    {slippage / 100}%
+                  </Text>
                 </ClickableText>
+
+                {isStableCoinSwap ? (
+                  <QuestionHelper
+                    placement="top"
+                    color={theme.text}
+                    text={t`Slippage for stable coin swap should be less than or equal to 0.1%`}
+                  />
+                ) : null}
               </Flex>
             )}
           </Flex>

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -18,9 +18,7 @@ import TrendingSoonTokenBanner from 'components/TrendingSoonTokenBanner'
 import { TutorialIds } from 'components/Tutorial/TutorialSwap/constant'
 import TradePrice from 'components/swapv2/TradePrice'
 import { Wrapper } from 'components/swapv2/styleds'
-import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
-import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
 import { DetailedRouteSummary, FeeConfig } from 'types/route'
 
@@ -71,7 +69,6 @@ const SwapForm: React.FC<SwapFormProps> = props => {
 
   const { chainId, isEVM, isSolana } = useActiveWeb3React()
 
-  const theme = useTheme()
   const [isProcessingSwap, setProcessingSwap] = useState(false)
   const [typedValue, setTypedValue] = useState('1')
   const [recipient, setRecipient] = useState<string | null>(null)
@@ -80,12 +77,6 @@ const SwapForm: React.FC<SwapFormProps> = props => {
   const parsedAmount = useParsedAmount(currencyIn, typedValue)
   const { wrapType, inputError: wrapInputError, execute: onWrap } = useWrapCallback(currencyIn, currencyOut, typedValue)
   const isWrapOrUnwrap = wrapType !== WrapType.NOT_APPLICABLE
-  const isStableCoinSwap =
-    chainId &&
-    currencyIn &&
-    currencyOut &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address)
 
   const { fetcher: getRoute, result } = useGetRoute({
     currencyIn,

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -1,14 +1,14 @@
 import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
-import { Trans, t } from '@lingui/macro'
 import { useEffect, useMemo, useState } from 'react'
-import { Box, Flex, Text } from 'rebass'
+import { Box, Flex } from 'rebass'
 import { parseGetRouteResponse } from 'services/route/utils'
 
 import AddressInputPanel from 'components/AddressInputPanel'
-import QuestionHelper from 'components/QuestionHelper'
 import { AutoRow } from 'components/Row'
 import InputCurrencyPanel from 'components/SwapForm/InputCurrencyPanel'
 import OutputCurrencyPanel from 'components/SwapForm/OutputCurrencyPanel'
+import SlippageNote from 'components/SwapForm/SlippageNote'
+import SlippageSetting from 'components/SwapForm/SlippageSetting'
 import { SwapFormContextProvider } from 'components/SwapForm/SwapFormContext'
 import useBuildRoute from 'components/SwapForm/hooks/useBuildRoute'
 import useGetInputError from 'components/SwapForm/hooks/useGetInputError'
@@ -22,7 +22,6 @@ import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
-import { ClickableText } from 'pages/Pool/styleds'
 import { DetailedRouteSummary, FeeConfig } from 'types/route'
 
 import PriceImpactNote from './PriceImpactNote'
@@ -68,7 +67,6 @@ const SwapForm: React.FC<SwapFormProps> = props => {
     transactionTimeout,
     onChangeCurrencyIn,
     onChangeCurrencyOut,
-    goToSettingsView,
   } = props
 
   const { chainId, isEVM, isSolana } = useActiveWeb3React()
@@ -199,30 +197,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
               <AddressInputPanel id="recipient" value={recipient} onChange={setRecipient} />
             )}
 
-            {!isWrapOrUnwrap && (
-              <Flex
-                alignItems="center"
-                fontSize={12}
-                color={theme.subText}
-                onClick={goToSettingsView}
-                width="max-content"
-              >
-                <ClickableText color={theme.subText} fontWeight={500}>
-                  <Trans>Max Slippage:</Trans>&nbsp;
-                  <Text as="span" color={isStableCoinSwap ? theme.text : theme.subText}>
-                    {slippage / 100}%
-                  </Text>
-                </ClickableText>
-
-                {isStableCoinSwap ? (
-                  <QuestionHelper
-                    placement="top"
-                    color={theme.text}
-                    text={t`Slippage for stable coin swap should be less than or equal to 0.1%`}
-                  />
-                ) : null}
-              </Flex>
-            )}
+            {!isWrapOrUnwrap && <SlippageSetting />}
           </Flex>
         </Wrapper>
         <Flex flexDirection="column" style={{ gap: '1.25rem' }}>
@@ -232,14 +207,9 @@ const SwapForm: React.FC<SwapFormProps> = props => {
             <TrendingSoonTokenBanner currencyIn={currencyIn} currencyOut={currencyOut} style={{ marginTop: '24px' }} />
           )}
 
-          <PriceImpactNote
-            priceImpact={routeSummary?.priceImpact}
-            isAdvancedMode={isAdvancedMode}
-            hasTooltip
-            style={{
-              marginTop: '28px',
-            }}
-          />
+          <SlippageNote />
+
+          <PriceImpactNote priceImpact={routeSummary?.priceImpact} isAdvancedMode={isAdvancedMode} hasTooltip />
 
           <SwapActionButton
             isGettingRoute={isGettingRoute}

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -11,6 +11,7 @@ import SlippageNote from 'components/SwapForm/SlippageNote'
 import SlippageSetting from 'components/SwapForm/SlippageSetting'
 import { SwapFormContextProvider } from 'components/SwapForm/SwapFormContext'
 import useBuildRoute from 'components/SwapForm/hooks/useBuildRoute'
+import useCheckStablePairSwap from 'components/SwapForm/hooks/useCheckStablePairSwap'
 import useGetInputError from 'components/SwapForm/hooks/useGetInputError'
 import useGetRoute from 'components/SwapForm/hooks/useGetRoute'
 import useParsedAmount from 'components/SwapForm/hooks/useParsedAmount'
@@ -78,6 +79,8 @@ const SwapForm: React.FC<SwapFormProps> = props => {
   const { wrapType, inputError: wrapInputError, execute: onWrap } = useWrapCallback(currencyIn, currencyOut, typedValue)
   const isWrapOrUnwrap = wrapType !== WrapType.NOT_APPLICABLE
 
+  const isStablePairSwap = useCheckStablePairSwap(currencyIn, currencyOut)
+
   const { fetcher: getRoute, result } = useGetRoute({
     currencyIn,
     currencyOut,
@@ -144,6 +147,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
       typedValue={typedValue}
       isSaveGas={isSaveGas}
       recipient={recipient}
+      isStablePairSwap={isStablePairSwap}
     >
       <Box sx={{ flexDirection: 'column', gap: '16px', display: hidden ? 'none' : 'flex' }}>
         <Wrapper id={TutorialIds.SWAP_FORM_CONTENT}>

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -1,119 +1,24 @@
-import { parseUnits } from '@ethersproject/units'
 import { Trans, t } from '@lingui/macro'
-import { darken } from 'polished'
-import React, { useCallback, useRef, useState } from 'react'
-import { isMobile } from 'react-device-detect'
+import { rgba } from 'polished'
+import { useCallback, useState } from 'react'
+import { Flex } from 'rebass'
 import styled, { css } from 'styled-components'
 
-import { AutoColumn } from 'components/Column'
 import TransactionSettingsIcon from 'components/Icons/TransactionSettingsIcon'
+import InfoHelper from 'components/InfoHelper'
 import MenuFlyout from 'components/MenuFlyout'
-import QuestionHelper from 'components/QuestionHelper'
-import { RowBetween, RowFixed } from 'components/Row'
-import LegacyToggle from 'components/Toggle/LegacyToggle'
+import Toggle from 'components/Toggle'
 import Tooltip from 'components/Tooltip'
-import useTopTrendingSoonTokensInCurrentNetwork from 'components/TopTrendingSoonTokensInCurrentNetwork/useTopTrendingSoonTokensInCurrentNetwork'
+import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
+import SlippageSetting from 'components/swapv2/SwapSettingsPanel/SlippageSetting'
+import TransactionTimeLimitSetting from 'components/swapv2/SwapSettingsPanel/TransactionTimeLimitSetting'
 import { StyledActionButtonSwapForm } from 'components/swapv2/styleds'
-import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
-import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
 import useTheme from 'hooks/useTheme'
 import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useToggleTransactionSettingsMenu } from 'state/application/hooks'
-import {
-  useExpertModeManager,
-  useShowLiveChart,
-  useShowTokenInfo,
-  useShowTopTrendingSoonTokens,
-  useShowTradeRoutes,
-  useToggleLiveChart,
-  useToggleTokenInfo,
-  useToggleTopTrendingTokens,
-  useToggleTradeRoutes,
-  useUserSlippageTolerance,
-  useUserTransactionTTL,
-} from 'state/user/hooks'
-import { TYPE } from 'theme'
-import { isEqual } from 'utils/numbers'
+import { useExpertModeManager } from 'state/user/hooks'
 
 import AdvanceModeModal from './AdvanceModeModal'
-
-enum SlippageError {
-  InvalidInput = 'InvalidInput',
-  RiskyLow = 'RiskyLow',
-  RiskyHigh = 'RiskyHigh',
-}
-
-enum DeadlineError {
-  InvalidInput = 'InvalidInput',
-}
-
-const FancyButton = styled.button`
-  color: ${({ theme }) => theme.text};
-  padding: 0;
-  text-align: center;
-  height: 2rem;
-  border-radius: 36px;
-  width: auto;
-  min-width: 3.5rem;
-  border: 1px solid transparent;
-  outline: none;
-  font-size: 16px;
-  background: ${({ theme }) => theme.buttonBlack};
-  :hover {
-    border: 1px solid ${({ theme }) => theme.bg4};
-  }
-  :focus {
-    border: 1px solid ${({ theme }) => theme.primary};
-  }
-`
-
-const Option = styled(FancyButton)<{ active: boolean }>`
-  margin-right: 6px;
-  :hover {
-    cursor: pointer;
-  }
-  background-color: ${({ active, theme }) => (active ? theme.primary : theme.buttonBlack)};
-  color: ${({ active, theme }) => (active ? theme.textReverse : theme.text)};
-`
-
-const Input = styled.input`
-  background: transparent;
-  font-size: 16px;
-  width: auto;
-  outline: none;
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-  }
-  color: ${({ theme, color }) => (color === 'red' ? theme.red1 : theme.text)};
-  text-align: right;
-`
-
-const OptionCustom = styled(FancyButton)<{ active?: boolean; warning?: boolean }>`
-  position: relative;
-  padding: 0 0.75rem;
-  flex: 1;
-  min-width: 70px;
-  border: ${({ theme, active, warning }) => active && `1px solid ${warning ? theme.red1 : theme.primary}`};
-  :hover {
-    border: ${({ theme, active, warning }) =>
-      active && `1px solid ${warning ? darken(0.1, theme.red1) : darken(0.1, theme.primary)}`};
-  }
-
-  input {
-    width: 100%;
-    height: 100%;
-    border: 0px;
-    border-radius: 2rem;
-  }
-`
-
-const SlippageEmojiContainer = styled.span`
-  color: #f3841e;
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    display: none;
-  `}
-`
 
 const StyledMenu = styled.div`
   display: flex;
@@ -122,6 +27,20 @@ const StyledMenu = styled.div`
   position: relative;
   border: none;
   text-align: left;
+`
+
+const SettingsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+
+  ${Toggle} {
+    background: ${({ theme }) => theme.buttonBlack};
+    &[data-active='true'] {
+      background: ${({ theme }) => rgba(theme.primary, 0.2)};
+    }
+  }
 `
 
 const MenuFlyoutBrowserStyle = css`
@@ -142,203 +61,11 @@ const MenuFlyoutBrowserStyle = css`
   `};
 `
 
-const StyledTitle = styled.div`
-  font-size: ${isMobile ? '16px' : '16px'};
-  font-weight: 500;
-`
-const StyledLabel = styled.div`
-  font-size: ${isMobile ? '14px' : '12px'};
-  color: ${({ theme }) => theme.text};
-  font-weight: 400;
-  line-height: 20px;
-`
-
-interface SlippageTabsProps {
-  rawSlippage: number
-  setRawSlippage: (rawSlippage: number) => void
-  deadline: number
-  setDeadline: (deadline: number) => void
-}
-
-function SlippageTabs({ rawSlippage, setRawSlippage, deadline, setDeadline }: SlippageTabsProps) {
-  const theme = useTheme()
-
-  const inputRef = useRef<HTMLInputElement>()
-
-  const [slippageInput, setSlippageInput] = useState('')
-  const [deadlineInput, setDeadlineInput] = useState('')
-
-  const slippageInputIsValid =
-    slippageInput === '' || isEqual(rawSlippage / 100, Number.parseFloat(slippageInput), 0.01)
-  const deadlineInputIsValid = deadlineInput === '' || (deadline / 60).toString() === deadlineInput
-
-  let slippageError: SlippageError | undefined
-  if (slippageInput !== '' && !slippageInputIsValid) {
-    slippageError = SlippageError.InvalidInput
-  } else if (slippageInputIsValid && rawSlippage < 50) {
-    slippageError = SlippageError.RiskyLow
-  } else if (slippageInputIsValid && rawSlippage > 500) {
-    slippageError = SlippageError.RiskyHigh
-  } else {
-    slippageError = undefined
-  }
-
-  let deadlineError: DeadlineError | undefined
-  if (deadlineInput !== '' && !deadlineInputIsValid) {
-    deadlineError = DeadlineError.InvalidInput
-  } else {
-    deadlineError = undefined
-  }
-
-  function parseCustomSlippage(value: string) {
-    setSlippageInput(value)
-
-    try {
-      /*
-      const valueAsIntFromRoundedFloat = Number.parseInt((Number.parseFloat(value) * 100).toString())
-      This above code will cause unexpected bug when value = 4.1
-      => Number.parseFloat(4.1) * 100 = 409.99999999999994
-      => Number.parseInt(409.99999999999994) = 409
-      => Wrong, expected 410.
-      => Use parseUnits(value, 2) is safe.
-      */
-      const valueAsIntFromRoundedFloat = Number.parseInt(parseUnits(value, 2).toString())
-      if (!Number.isNaN(valueAsIntFromRoundedFloat) && valueAsIntFromRoundedFloat <= MAX_SLIPPAGE_IN_BIPS) {
-        setRawSlippage(valueAsIntFromRoundedFloat)
-      }
-    } catch {}
-  }
-
-  function parseCustomDeadline(value: string) {
-    setDeadlineInput(value)
-
-    try {
-      const valueAsInt: number = Number.parseInt(value) * 60
-      if (!Number.isNaN(valueAsInt) && valueAsInt > 0 && valueAsInt <= 9999 * 60) {
-        setDeadline(valueAsInt)
-      }
-    } catch {}
-  }
-
-  return (
-    <AutoColumn gap="md">
-      <AutoColumn gap="md" style={{ padding: '6px 0' }}>
-        <RowFixed>
-          <StyledLabel>
-            <Trans>Max Slippage</Trans>
-          </StyledLabel>
-          <QuestionHelper
-            text={t`Transaction will revert if there is an adverse rate change that is higher than this %`}
-          />
-        </RowFixed>
-        <RowBetween>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(10)
-            }}
-            active={rawSlippage === 10}
-          >
-            0.1%
-          </Option>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(50)
-            }}
-            active={rawSlippage === 50}
-          >
-            0.5%
-          </Option>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(100)
-            }}
-            active={rawSlippage === 100}
-          >
-            1.0%
-          </Option>
-          <OptionCustom active={![10, 50, 100].includes(rawSlippage)} warning={!slippageInputIsValid} tabIndex={-1}>
-            <RowBetween>
-              {!!slippageInput &&
-              (slippageError === SlippageError.RiskyLow || slippageError === SlippageError.RiskyHigh) ? (
-                <SlippageEmojiContainer>
-                  <span role="img" aria-label="warning">
-                    ⚠️
-                  </span>
-                </SlippageEmojiContainer>
-              ) : null}
-              {/* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451 */}
-              <Input
-                ref={inputRef as any}
-                placeholder={(rawSlippage / 100).toFixed(2)}
-                value={slippageInput}
-                onBlur={() => {
-                  parseCustomSlippage((rawSlippage / 100).toFixed(2))
-                }}
-                onChange={e => parseCustomSlippage(e.target.value)}
-                color={!slippageInputIsValid ? 'red' : ''}
-              />
-              %
-            </RowBetween>
-          </OptionCustom>
-        </RowBetween>
-        {!!slippageError && (
-          <RowBetween
-            style={{
-              fontSize: '14px',
-              paddingTop: '7px',
-              color: slippageError === SlippageError.InvalidInput ? 'red' : '#F3841E',
-            }}
-          >
-            {slippageError === SlippageError.InvalidInput
-              ? t`Enter a valid slippage percentage`
-              : slippageError === SlippageError.RiskyLow
-              ? t`Your transaction may fail`
-              : t`Your transaction may be frontrun`}
-          </RowBetween>
-        )}
-      </AutoColumn>
-
-      <AutoColumn gap="sm">
-        <RowFixed>
-          <StyledLabel>
-            <Trans>Transaction time limit</Trans>
-          </StyledLabel>
-          <QuestionHelper text={t`Transaction will revert if it is pending for longer than the indicated time`} />
-        </RowFixed>
-        <RowFixed>
-          <OptionCustom style={{ width: '100px' }} tabIndex={-1}>
-            <Input
-              color={!!deadlineError ? 'red' : undefined}
-              onBlur={() => {
-                parseCustomDeadline((deadline / 60).toString())
-              }}
-              placeholder={(deadline / 60).toString()}
-              value={deadlineInput}
-              onChange={e => parseCustomDeadline(e.target.value)}
-            />
-          </OptionCustom>
-          <TYPE.body style={{ paddingLeft: '8px' }} fontSize={12} color={theme.text11}>
-            <Trans>minutes</Trans>
-          </TYPE.body>
-        </RowFixed>
-      </AutoColumn>
-    </AutoColumn>
-  )
-}
-
-export default function TransactionSettings({
-  isShowDisplaySettings = false,
-  hoverBg,
-}: {
-  isShowDisplaySettings?: boolean
+type Props = {
   hoverBg?: string
-}) {
+}
+export default function TransactionSettings({ hoverBg }: Props) {
   const theme = useTheme()
-  const [userSlippageTolerance, setUserSlippageTolerance] = useUserSlippageTolerance()
-  const [ttl, setTtl] = useUserTransactionTTL()
   const [expertMode, toggleExpertMode] = useExpertModeManager()
   const toggle = useToggleTransactionSettingsMenu()
   // show confirmation view before turning on
@@ -349,22 +76,16 @@ export default function TransactionSettings({
   const showTooltip = useCallback(() => setIsShowTooltip(true), [setIsShowTooltip])
   const hideTooltip = useCallback(() => setIsShowTooltip(false), [setIsShowTooltip])
 
-  const isShowLiveChart = useShowLiveChart()
+  const handleToggleAdvancedMode = () => {
+    if (expertMode /* is already ON */) {
+      toggleExpertMode()
+      setShowConfirmation(false)
+      return
+    }
 
-  const isShowTradeRoutes = useShowTradeRoutes()
-  const isShowTokenInfo = useShowTokenInfo()
-
-  const toggleLiveChart = useToggleLiveChart()
-
-  const toggleTradeRoutes = useToggleTradeRoutes()
-  const toggleTokenInfo = useToggleTokenInfo()
-
-  const isShowTrendingSoonTokens = useShowTopTrendingSoonTokens()
-  const toggleTopTrendingTokens = useToggleTopTrendingTokens()
-  const { mixpanelHandler } = useMixpanel()
-
-  const { data: topTrendingSoonTokens } = useTopTrendingSoonTokensInCurrentNetwork()
-  const isShowTrendingSoonSetting = topTrendingSoonTokens.length > 0
+    toggle()
+    setShowConfirmation(true)
+  }
 
   return (
     <>
@@ -394,105 +115,23 @@ export default function TransactionSettings({
           mobileCustomStyle={{ paddingBottom: '40px' }}
           hasArrow
         >
-          <>
-            <SlippageTabs
-              rawSlippage={userSlippageTolerance}
-              setRawSlippage={setUserSlippageTolerance}
-              deadline={ttl}
-              setDeadline={setTtl}
-            />
+          <SettingsWrapper>
+            <SlippageSetting shouldShowPinButton={false} />
+            <TransactionTimeLimitSetting />
 
-            <RowBetween margin="14px 0">
-              <RowFixed>
-                <StyledLabel>
+            <Flex justifyContent="space-between">
+              <Flex width="fit-content" alignItems="center">
+                <SettingLabel>
                   <Trans>Advanced Mode</Trans>
-                </StyledLabel>
-                <QuestionHelper text={t`Enables high slippage trades. Use at your own risk`} />
-              </RowFixed>
-              <LegacyToggle
-                id="toggle-expert-mode-button"
-                isActive={expertMode}
-                toggle={
-                  expertMode
-                    ? () => {
-                        toggleExpertMode()
-                        setShowConfirmation(false)
-                      }
-                    : () => {
-                        toggle()
-                        setShowConfirmation(true)
-                      }
-                }
-                size={isMobile ? 'md' : 'sm'}
-              />
-            </RowBetween>
-            {isShowDisplaySettings && (
-              <>
-                <StyledTitle style={{ borderTop: '1px solid ' + theme.border, padding: '16px 0' }}>
-                  <Trans>Display Settings</Trans>
-                </StyledTitle>
-                <AutoColumn gap="md">
-                  {isShowTrendingSoonSetting && (
-                    <RowBetween>
-                      <RowFixed>
-                        <StyledLabel>Trending Soon</StyledLabel>
-                        <QuestionHelper text={t`Turn on to display tokens that could be trending soon`} />
-                      </RowFixed>
-                      <LegacyToggle
-                        isActive={isShowTrendingSoonTokens}
-                        toggle={() => {
-                          toggleTopTrendingTokens()
-                        }}
-                        size={isMobile ? 'md' : 'sm'}
-                      />
-                    </RowBetween>
-                  )}
-                  <RowBetween>
-                    <RowFixed>
-                      <StyledLabel>Live Chart</StyledLabel>
-                      <QuestionHelper text={t`Turn on to display live chart`} />
-                    </RowFixed>
-                    <LegacyToggle
-                      isActive={isShowLiveChart}
-                      toggle={() => {
-                        mixpanelHandler(MIXPANEL_TYPE.LIVE_CHART_ON_OFF, { live_chart_on_or_off: !isShowLiveChart })
-                        toggleLiveChart()
-                      }}
-                      size={isMobile ? 'md' : 'sm'}
-                    />
-                  </RowBetween>
-                  <RowBetween>
-                    <RowFixed>
-                      <StyledLabel>
-                        <Trans>Trade Route</Trans>
-                      </StyledLabel>
-                      <QuestionHelper text={t`Turn on to display trade route`} />
-                    </RowFixed>
-                    <LegacyToggle
-                      isActive={isShowTradeRoutes}
-                      toggle={() => {
-                        mixpanelHandler(MIXPANEL_TYPE.TRADING_ROUTE_ON_OFF, {
-                          trading_route_on_or_off: !isShowTradeRoutes,
-                        })
-                        toggleTradeRoutes()
-                      }}
-                      size={isMobile ? 'md' : 'sm'}
-                    />
-                  </RowBetween>
-
-                  <RowBetween>
-                    <RowFixed>
-                      <StyledLabel>
-                        <Trans>Token Info</Trans>
-                      </StyledLabel>
-                      <QuestionHelper text={t`Turn on to display token info`} />
-                    </RowFixed>
-                    <LegacyToggle isActive={isShowTokenInfo} toggle={toggleTokenInfo} size={isMobile ? 'md' : 'sm'} />
-                  </RowBetween>
-                </AutoColumn>
-              </>
-            )}
-          </>
+                </SettingLabel>
+                <InfoHelper
+                  size={14}
+                  text={t`You can make trades with high price impact and without any confirmation prompts. Enable at your own risk`}
+                />
+              </Flex>
+              <Toggle id="toggle-expert-mode-button" isActive={expertMode} toggle={handleToggleAdvancedMode} />
+            </Flex>
+          </SettingsWrapper>
         </MenuFlyout>
       </StyledMenu>
     </>

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -4,6 +4,7 @@ import { Text } from 'rebass'
 import styled, { css } from 'styled-components'
 
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
 
@@ -118,10 +119,11 @@ const CustomSlippageInput: React.FC = () => {
   // slippage = 10 / 10_000 = 0.001 = 0.1%
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
   const [rawText, setRawText] = useState(getSlippageText(rawSlippage))
+  const isStablePairSwap = useCheckStablePairSwap()
 
   const isCustomOptionActive = !DEFAULT_SLIPPAGES.includes(rawSlippage)
 
-  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
   const isWarning = isValid && !!message
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -1,0 +1,215 @@
+import { t } from '@lingui/macro'
+import React, { useEffect, useRef, useState } from 'react'
+import { Text } from 'rebass'
+import styled, { css } from 'styled-components'
+
+import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+import { useUserSlippageTolerance } from 'state/user/hooks'
+import { checkRangeSlippage } from 'utils/slippage'
+
+export const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
+export const getSlippageText = (rawSlippage: number) => {
+  const isCustom = !DEFAULT_SLIPPAGES.includes(rawSlippage)
+  if (!isCustom) {
+    return ''
+  }
+
+  if (rawSlippage % 100 === 0) {
+    return String(rawSlippage / 100)
+  }
+
+  return (rawSlippage / 100).toFixed(2)
+}
+
+const EmojiContainer = styled.span`
+  flex: 0 0 12px;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+        display: none;
+  `}
+`
+
+const slippageOptionCSS = css`
+  height: 100%;
+  padding: 0;
+  border-radius: 20px;
+  border: 1px solid transparent;
+
+  background-color: ${({ theme }) => theme.tabBackgound};
+  color: ${({ theme }) => theme.subText};
+  text-align: center;
+
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+
+  outline: none;
+  cursor: pointer;
+
+  :hover {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+  :focus {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+
+  &[data-active='true'] {
+    background-color: ${({ theme }) => theme.tabActive};
+    color: ${({ theme }) => theme.text};
+    border-color: ${({ theme }) => theme.primary};
+
+    font-weight: 500;
+  }
+
+  &[data-warning='true'] {
+    border-color: ${({ theme }) => theme.warning};
+  }
+`
+
+const CustomSlippageOption = styled.div`
+  ${slippageOptionCSS};
+
+  flex: 0 0 24%;
+
+  display: inline-flex;
+  align-items: center;
+  padding: 0 4px;
+  column-gap: 2px;
+  flex: 1;
+
+  transition: all 150ms linear;
+
+  &[data-active='true'] {
+    color: ${({ theme }) => theme.text};
+    font-weight: 500;
+  }
+
+  &[data-warning='true'] {
+    border-color: ${({ theme }) => theme.warning};
+
+    ${EmojiContainer} {
+      color: ${({ theme }) => theme.warning};
+    }
+  }
+`
+
+const CustomInput = styled.input`
+  width: 100%;
+  height: 100%;
+  border: 0px;
+  border-radius: inherit;
+
+  color: inherit;
+  background: transparent;
+  outline: none;
+  text-align: right;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
+  &::placeholder {
+    font-size: 12px;
+  }
+  @media only screen and (max-width: 375px) {
+    font-size: 10px;
+  }
+`
+
+const CustomSlippageInput: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // rawSlippage = 10
+  // slippage = 10 / 10_000 = 0.001 = 0.1%
+  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+  const [rawText, setRawText] = useState(getSlippageText(rawSlippage))
+
+  const isCustomOptionActive = !DEFAULT_SLIPPAGES.includes(rawSlippage)
+
+  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const isWarning = isValid && !!message
+
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+
+    if (value === '') {
+      setRawText(value)
+      setRawSlippage(DEFAULT_SLIPPAGE)
+      return
+    }
+
+    const numberRegex = /^(\d+)\.?(\d{1,2})?$/
+    if (!value.match(numberRegex)) {
+      e.preventDefault()
+      return
+    }
+
+    const parsedValue = parseSlippageInput(value)
+    if (Number.isNaN(parsedValue)) {
+      e.preventDefault()
+      return
+    }
+
+    if (parsedValue > MAX_SLIPPAGE_IN_BIPS) {
+      e.preventDefault()
+      return
+    }
+
+    setRawText(value)
+    setRawSlippage(parsedValue)
+  }
+
+  const handleCommitChange = () => {
+    setRawText(getSlippageText(rawSlippage))
+  }
+
+  const handleKeyPressInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const key = e.key
+    if (key === '.' || ('0' <= key && key <= '9')) {
+      return
+    }
+
+    if (key === 'Enter') {
+      handleCommitChange()
+      inputRef.current?.blur()
+      return
+    }
+
+    e.preventDefault()
+  }
+
+  useEffect(() => {
+    if (inputRef.current !== document.activeElement) {
+      setRawText(getSlippageText(rawSlippage))
+    }
+  }, [rawSlippage])
+
+  return (
+    <CustomSlippageOption data-active={isCustomOptionActive} data-warning={isCustomOptionActive && isWarning}>
+      {isCustomOptionActive && isWarning && (
+        <EmojiContainer>
+          <span role="img" aria-label="warning">
+            ⚠️
+          </span>
+        </EmojiContainer>
+      )}
+      <CustomInput
+        ref={inputRef}
+        placeholder={t`Custom`}
+        value={rawText}
+        onChange={handleChangeInput}
+        onKeyPress={handleKeyPressInput}
+        onBlur={handleCommitChange}
+      />
+      <Text
+        as="span"
+        sx={{
+          flex: '0 0 12px',
+        }}
+      >
+        %
+      </Text>
+    </CustomSlippageOption>
+  )
+}
+
+export default CustomSlippageInput

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -5,24 +5,16 @@ import styled, { css } from 'styled-components'
 
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-import { checkRangeSlippage } from 'utils/slippage'
+import { checkRangeSlippage, formatSlippage } from 'utils/slippage'
 
 export const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
-export const getSlippageText = (rawSlippage: number) => {
+const getSlippageText = (rawSlippage: number) => {
   const isCustom = !DEFAULT_SLIPPAGES.includes(rawSlippage)
   if (!isCustom) {
     return ''
   }
 
-  if (rawSlippage % 100 === 0) {
-    return String(rawSlippage / 100)
-  }
-
-  if (rawSlippage % 10 === 0) {
-    return (rawSlippage / 100).toFixed(1)
-  }
-
-  return (rawSlippage / 100).toFixed(2)
+  return formatSlippage(rawSlippage)
 }
 
 const EmojiContainer = styled.span`

--- a/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/swapv2/SlippageControl/CustomSlippageInput.tsx
@@ -18,6 +18,10 @@ export const getSlippageText = (rawSlippage: number) => {
     return String(rawSlippage / 100)
   }
 
+  if (rawSlippage % 10 === 0) {
+    return (rawSlippage / 100).toFixed(1)
+  }
+
   return (rawSlippage / 100).toFixed(2)
 }
 

--- a/src/components/swapv2/SlippageControl/index.tsx
+++ b/src/components/swapv2/SlippageControl/index.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { Flex } from 'rebass'
+import styled, { css } from 'styled-components'
+
+import CustomSlippageInput from 'components/swapv2/SlippageControl/CustomSlippageInput'
+import { DEFAULT_SLIPPAGES } from 'constants/index'
+import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
+import useTheme from 'hooks/useTheme'
+import { useUserSlippageTolerance } from 'state/user/hooks'
+import { checkRangeSlippage } from 'utils/slippage'
+
+const shouldWarnSlippage = (slp: number) => {
+  const { isValid, message } = checkRangeSlippage(slp)
+  return isValid && !!message
+}
+
+export const slippageOptionCSS = css`
+  height: 100%;
+  padding: 0;
+  border-radius: 20px;
+  border: 1px solid transparent;
+
+  background-color: ${({ theme }) => theme.tabBackgound};
+  color: ${({ theme }) => theme.subText};
+  text-align: center;
+
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+
+  outline: none;
+  cursor: pointer;
+
+  :hover {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+  :focus {
+    border-color: ${({ theme }) => theme.bg4};
+  }
+
+  &[data-active='true'] {
+    background-color: ${({ theme }) => theme.tabActive};
+    color: ${({ theme }) => theme.text};
+    border-color: ${({ theme }) => theme.primary};
+
+    font-weight: 500;
+  }
+
+  &[data-warning='true'] {
+    border-color: ${({ theme }) => theme.warning};
+  }
+`
+
+const DefaultSlippageOption = styled.button`
+  ${slippageOptionCSS};
+  flex: 0 0 18%;
+
+  @media only screen and (max-width: 375px) {
+    font-size: 10px;
+    flex: 0 0 15%;
+  }
+`
+
+const SlippageControl: React.FC = () => {
+  const theme = useTheme()
+
+  // rawSlippage = 10
+  // slippage = 10 / 10_000 = 0.001 = 0.1%
+  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+
+  const { mixpanelHandler } = useMixpanel()
+
+  return (
+    <Flex
+      sx={{
+        justifyContent: 'space-between',
+        width: '100%',
+        maxWidth: '100%',
+        height: '28px',
+        borderRadius: '20px',
+        background: theme.tabBackgound,
+        padding: '2px',
+      }}
+    >
+      {DEFAULT_SLIPPAGES.map(slp => (
+        <DefaultSlippageOption
+          key={slp}
+          onClick={() => {
+            setRawSlippage(slp)
+            mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: slp / 100 })
+          }}
+          data-active={rawSlippage === slp}
+          data-warning={rawSlippage === slp && shouldWarnSlippage(slp)}
+        >
+          {slp / 100}%
+        </DefaultSlippageOption>
+      ))}
+
+      <CustomSlippageInput />
+    </Flex>
+  )
+}
+
+export default SlippageControl

--- a/src/components/swapv2/SlippageControl/index.tsx
+++ b/src/components/swapv2/SlippageControl/index.tsx
@@ -6,13 +6,9 @@ import CustomSlippageInput from 'components/swapv2/SlippageControl/CustomSlippag
 import { DEFAULT_SLIPPAGES } from 'constants/index'
 import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
 import useTheme from 'hooks/useTheme'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
-
-const shouldWarnSlippage = (slp: number) => {
-  const { isValid, message } = checkRangeSlippage(slp)
-  return isValid && !!message
-}
 
 export const slippageOptionCSS = css`
   height: 100%;
@@ -63,12 +59,14 @@ const DefaultSlippageOption = styled.button`
 
 const SlippageControl: React.FC = () => {
   const theme = useTheme()
+  const { mixpanelHandler } = useMixpanel()
 
   // rawSlippage = 10
   // slippage = 10 / 10_000 = 0.001 = 0.1%
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-
-  const { mixpanelHandler } = useMixpanel()
+  const isStablePairSwap = useCheckStablePairSwap()
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
+  const shouldWarning = isValid && !!message
 
   return (
     <Flex
@@ -90,7 +88,7 @@ const SlippageControl: React.FC = () => {
             mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: slp / 100 })
           }}
           data-active={rawSlippage === slp}
-          data-warning={rawSlippage === slp && shouldWarnSlippage(slp)}
+          data-warning={rawSlippage === slp && shouldWarning}
         >
           {slp / 100}%
         </DefaultSlippageOption>

--- a/src/components/swapv2/SwapSettingsPanel/AdvancedModeSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/AdvancedModeSetting.tsx
@@ -1,13 +1,19 @@
 import { Trans, t } from '@lingui/macro'
+import { rgba } from 'polished'
 import { useState } from 'react'
 import { Flex } from 'rebass'
+import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
 import Toggle from 'components/Toggle'
 import AdvanceModeModal from 'components/TransactionSettings/AdvanceModeModal'
+import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
 import { useExpertModeManager } from 'state/user/hooks'
 
-const AdvancedModeSetting = () => {
+type Props = {
+  className?: string
+}
+const AdvancedModeSetting: React.FC<Props> = ({ className }) => {
   const [expertMode, toggleExpertMode] = useExpertModeManager()
   const [showConfirmation, setShowConfirmation] = useState(false)
 
@@ -24,11 +30,11 @@ const AdvancedModeSetting = () => {
 
   return (
     <>
-      <Flex justifyContent="space-between">
+      <Flex justifyContent="space-between" className={className}>
         <Flex width="fit-content" alignItems="center">
-          <span className="settingLabel">
+          <SettingLabel>
             <Trans>Advanced Mode</Trans>
-          </span>
+          </SettingLabel>
           <QuestionHelper
             text={t`You can make trades with high price impact and without any confirmation prompts. Enable at your own risk`}
           />
@@ -41,4 +47,11 @@ const AdvancedModeSetting = () => {
   )
 }
 
-export default AdvancedModeSetting
+export default styled(AdvancedModeSetting)`
+  ${Toggle} {
+    background: ${({ theme }) => theme.buttonBlack};
+    &[data-active='true'] {
+      background: ${({ theme }) => rgba(theme.primary, 0.2)};
+    }
+  }
+`

--- a/src/components/swapv2/SwapSettingsPanel/GasPriceTrackerSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/GasPriceTrackerSetting.tsx
@@ -4,6 +4,7 @@ import { isMobile } from 'react-device-detect'
 import { ChevronRight } from 'react-feather'
 import styled from 'styled-components'
 
+import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
 import useGasPriceFromDeBank, { GasLevel } from 'hooks/useGasPriceFromDeBank'
 import useTheme from 'hooks/useTheme'
 
@@ -17,13 +18,6 @@ const Container = styled.div`
   align-items: center;
 
   cursor: pointer;
-`
-
-const SettingLabel = styled.span`
-  font-size: ${isMobile ? '14px' : '12px'};
-  color: ${({ theme }) => theme.text};
-  font-weight: 400;
-  line-height: 16px;
 `
 
 const Group = styled.div`

--- a/src/components/swapv2/SwapSettingsPanel/LiquiditySourcesSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/LiquiditySourcesSetting.tsx
@@ -6,19 +6,13 @@ import { Flex } from 'rebass'
 import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
+import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
 import useTheme from 'hooks/useTheme'
 import { useAllDexes, useExcludeDexes } from 'state/customizeDexes/hooks'
 
 type Props = {
   onClick: () => void
 }
-
-const SettingLabel = styled.span`
-  font-size: ${isMobile ? '14px' : '12px'};
-  color: ${({ theme }) => theme.text};
-  font-weight: 400;
-  line-height: 16px;
-`
 
 const Group = styled.div`
   display: flex;

--- a/src/components/swapv2/SwapSettingsPanel/PinButton.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/PinButton.tsx
@@ -1,0 +1,32 @@
+import { Flex } from 'rebass'
+
+import { ReactComponent as PinIcon } from 'assets/svg/pin_icon.svg'
+import { ReactComponent as PinSolidIcon } from 'assets/svg/pin_solid_icon.svg'
+import useTheme from 'hooks/useTheme'
+
+type Props = {
+  isActive: boolean
+  onClick: () => void
+}
+const PinButton: React.FC<Props> = ({ isActive, onClick }) => {
+  const theme = useTheme()
+
+  return (
+    <Flex
+      sx={{
+        width: '16px',
+        height: '16px',
+        justifyContent: 'center',
+        alignItems: 'center',
+        cursor: 'pointer',
+        marginLeft: '8px',
+      }}
+      role="button"
+      onClick={onClick}
+    >
+      {isActive ? <PinSolidIcon height="16px" color={theme.text} /> : <PinIcon height="16px" color={theme.subText} />}
+    </Flex>
+  )
+}
+
+export default PinButton

--- a/src/components/swapv2/SwapSettingsPanel/SettingLabel.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SettingLabel.tsx
@@ -1,0 +1,12 @@
+import { isMobile } from 'react-device-detect'
+import styled from 'styled-components'
+
+const SettingLabel = styled.span`
+  font-size: ${isMobile ? '14px' : '12px'};
+  color: ${({ theme }) => theme.text};
+  font-weight: 400;
+  line-height: 16px;
+  white-space: nowrap;
+`
+
+export default SettingLabel

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -1,164 +1,14 @@
 import { Trans, t } from '@lingui/macro'
-import React, { useRef, useState } from 'react'
+import React from 'react'
 import { isMobile } from 'react-device-detect'
 import { Flex, Text } from 'rebass'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
-import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
-import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
+import SlippageControl from 'components/swapv2/SlippageControl'
 import useTheme from 'hooks/useTheme'
 import { useUserSlippageTolerance } from 'state/user/hooks'
-
-const DefaultSlippages = [5, 10, 50, 100]
-
-const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
-
-// isValid = true means it's OK to process with the number with an extra parse
-// isValid = true with message means warning
-// isValid = false with/without message means error
-const validateSlippageInput = (str: string): { isValid: boolean; message?: string } => {
-  if (str === '') {
-    return {
-      isValid: true,
-    }
-  }
-
-  const numberRegex = /^\s*([0-9]+)(\.\d+)?\s*$/
-  if (!str.match(numberRegex)) {
-    return {
-      isValid: false,
-      message: t`Enter a valid slippage percentage`,
-    }
-  }
-
-  const rawSlippage = parseSlippageInput(str)
-  if (Number.isNaN(rawSlippage)) {
-    return {
-      isValid: false,
-      message: t`Enter a valid slippage percentage`,
-    }
-  }
-
-  if (rawSlippage < 0) {
-    return {
-      isValid: false,
-      message: t`Enter a valid slippage percentage`,
-    }
-  } else if (rawSlippage < 50) {
-    return {
-      isValid: true,
-      message: t`Your transaction may fail`,
-    }
-  } else if (rawSlippage > MAX_SLIPPAGE_IN_BIPS) {
-    return {
-      isValid: false,
-      message: t`Enter a smaller slippage percentage`,
-    }
-  } else if (rawSlippage > 500) {
-    return {
-      isValid: true,
-      message: t`Your transaction may be frontrun`,
-    }
-  }
-
-  return {
-    isValid: true,
-  }
-}
-
-const EmojiContainer = styled.span`
-  flex: 0 0 12px;
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-        display: none;
-  `}
-`
-
-const SlippageOptionCSS = css`
-  flex: 0 0 24%;
-  height: 100%;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: 20px;
-
-  background-color: ${({ theme }) => theme.tabBackgound};
-  color: ${({ theme }) => theme.subText};
-  text-align: center;
-
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 16px;
-
-  outline: none;
-  cursor: pointer;
-
-  :hover {
-    border: 1px solid ${({ theme }) => theme.bg4};
-  }
-  :focus {
-    border: 1px solid ${({ theme }) => theme.primary};
-  }
-
-  &[data-active='true'] {
-    background-color: ${({ theme }) => theme.tabActive};
-    color: ${({ theme }) => theme.text};
-
-    font-weight: 500;
-  }
-`
-const DefaultSlippageOption = styled.button`
-  ${SlippageOptionCSS}
-  flex: 0 0 18%;
-  @media only screen and (max-width: 375px) {
-    font-size: 10px;
-    flex: 0 0 15%;
-  }
-`
-
-const CustomSlippageOption = styled.div`
-  ${SlippageOptionCSS}
-
-  display: inline-flex;
-  align-items: center;
-  padding: 0 4px;
-  column-gap: 2px;
-  flex: 1;
-  input {
-    width: 100%;
-    height: 100%;
-    border: 0px;
-    border-radius: inherit;
-
-    color: inherit;
-    background: transparent;
-    outline: none;
-    text-align: right;
-
-    &::-webkit-outer-spin-button,
-    &::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-    }
-  }
-
-  &[data-active='true'] {
-    color: ${({ theme }) => theme.text};
-    font-weight: 500;
-  }
-
-  &[data-warning='true'] {
-    border: 1px solid;
-    border-color: ${({ theme }) => theme.warning};
-
-    ${EmojiContainer} {
-      color: ${({ theme }) => theme.warning};
-    }
-  }
-
-  &[data-error='true'] {
-    border: 1px solid;
-    border-color: ${({ theme }) => theme.red1};
-  }
-`
+import { checkRangeSlippage } from 'utils/slippage'
 
 const Message = styled.div`
   font-size: 12px;
@@ -174,69 +24,12 @@ const Message = styled.div`
   }
 `
 
-const CustomInput = styled.input`
-  ::placeholder {
-    font-size: 12px;
-  }
-  @media only screen and (max-width: 375px) {
-    font-size: 10px;
-  }
-`
-
-const getSlippageText = (rawSlippage: number) => {
-  const isCustom = !DefaultSlippages.includes(rawSlippage)
-  if (!isCustom) {
-    return ''
-  }
-
-  if (rawSlippage % 100 === 0) {
-    return String(rawSlippage / 100)
-  }
-
-  return (rawSlippage / 100).toFixed(2)
-}
-
 const SlippageSetting: React.FC = () => {
   const theme = useTheme()
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  // rawSlippage = 10
-  // slippage = 10 / 10_000 = 0.001 = 0.1%
-  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-
-  const isCustomOptionActive = !DefaultSlippages.includes(rawSlippage)
-  const [slippageInput, setSlippageInput] = useState(getSlippageText(rawSlippage))
-  const { isValid, message } = validateSlippageInput(slippageInput)
-
+  const [rawSlippage] = useUserSlippageTolerance()
+  const { isValid, message } = checkRangeSlippage(rawSlippage)
   const isWarning = isValid && !!message
   const isError = !isValid
-  const { mixpanelHandler } = useMixpanel()
-  const handleCommitChange = () => {
-    if (!isValid) {
-      return
-    }
-
-    if (slippageInput === '') {
-      setSlippageInput(getSlippageText(rawSlippage))
-      return
-    }
-
-    const newRawSlippage = parseSlippageInput(slippageInput)
-    if (Number.isNaN(newRawSlippage)) {
-      return
-    }
-    mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: newRawSlippage / 100 })
-
-    setRawSlippage(newRawSlippage)
-    setSlippageInput(getSlippageText(newRawSlippage))
-  }
-
-  const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleCommitChange()
-      inputRef.current?.blur()
-    }
-  }
 
   return (
     <Flex
@@ -265,61 +58,7 @@ const SlippageSetting: React.FC = () => {
         />
       </Flex>
 
-      <Flex
-        sx={{
-          justifyContent: 'space-between',
-          width: '100%',
-          maxWidth: '100%',
-          height: '28px',
-          borderRadius: '20px',
-          background: theme.tabBackgound,
-          padding: '2px',
-        }}
-      >
-        {DefaultSlippages.map(slp => (
-          <DefaultSlippageOption
-            key={slp}
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(slp)
-              mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: slp / 100 })
-            }}
-            data-active={rawSlippage === slp}
-          >
-            {slp / 100}%
-          </DefaultSlippageOption>
-        ))}
-
-        <CustomSlippageOption
-          data-active={isCustomOptionActive}
-          data-warning={isCustomOptionActive && isWarning}
-          data-error={isCustomOptionActive && isError}
-        >
-          {isCustomOptionActive && isWarning && (
-            <EmojiContainer>
-              <span role="img" aria-label="warning">
-                ⚠️
-              </span>
-            </EmojiContainer>
-          )}
-          <CustomInput
-            ref={inputRef}
-            placeholder={t`Custom`}
-            value={slippageInput}
-            onChange={e => setSlippageInput(e.target.value)}
-            onBlur={handleCommitChange}
-            onKeyUp={handleKeyUp}
-          />
-          <Text
-            as="span"
-            sx={{
-              flex: '0 0 12px',
-            }}
-          >
-            %
-          </Text>
-        </CustomSlippageOption>
-      </Flex>
+      <SlippageControl />
 
       {!!message && (
         <Message data-warning={isWarning} data-error={isError}>

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -6,12 +6,11 @@ import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
-import SlippageControl from 'components/swapv2/SlippageControl'
+import SlippageControl from 'components/SlippageControl'
 import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
 import { pinSlippageControl } from 'state/swap/actions'
-import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -32,9 +31,8 @@ const Message = styled.div`
 const SlippageSetting: React.FC = () => {
   const dispatch = useDispatch()
   const theme = useTheme()
-  const [rawSlippage] = useUserSlippageTolerance()
-  const isStablePairSwap = useCheckStablePairSwap()
-  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
+  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+  const { isValid, message } = checkRangeSlippage(rawSlippage)
   const isWarning = isValid && !!message
   const isError = !isValid
 
@@ -74,7 +72,7 @@ const SlippageSetting: React.FC = () => {
         <PinButton isActive={isSlippageControlPinned} onClick={handleClickPinSlippageControl} />
       </Flex>
 
-      <SlippageControl />
+      <SlippageControl rawSlippage={rawSlippage} setRawSlippage={setRawSlippage} isWarning={isWarning} />
 
       {!!message && (
         <Message data-warning={isWarning} data-error={isError}>

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -1,12 +1,16 @@
 import { Trans, t } from '@lingui/macro'
 import React from 'react'
 import { isMobile } from 'react-device-detect'
+import { useDispatch } from 'react-redux'
 import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
 import SlippageControl from 'components/swapv2/SlippageControl'
+import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
 import useTheme from 'hooks/useTheme'
+import { useAppSelector } from 'state/hooks'
+import { pinSlippageControl } from 'state/swap/actions'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -25,11 +29,18 @@ const Message = styled.div`
 `
 
 const SlippageSetting: React.FC = () => {
+  const dispatch = useDispatch()
   const theme = useTheme()
   const [rawSlippage] = useUserSlippageTolerance()
   const { isValid, message } = checkRangeSlippage(rawSlippage)
   const isWarning = isValid && !!message
   const isError = !isValid
+
+  const isSlippageControlPinned = useAppSelector(state => state.swap.isSlippageControlPinned)
+
+  const handleClickPinSlippageControl = () => {
+    dispatch(pinSlippageControl(!isSlippageControlPinned))
+  }
 
   return (
     <Flex
@@ -54,8 +65,11 @@ const SlippageSetting: React.FC = () => {
           <Trans>Max Slippage</Trans>
         </Text>
         <QuestionHelper
-          text={t`Transaction will revert if there is an adverse rate change that is higher than this %`}
+          placement="top"
+          text={t`Transaction will revert if there is an adverse rate change that is higher than this %. This control will appear in Swap form if pinned.`}
         />
+
+        <PinButton isActive={isSlippageControlPinned} onClick={handleClickPinSlippageControl} />
       </Flex>
 
       <SlippageControl />

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -11,6 +11,7 @@ import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
 import { pinSlippageControl } from 'state/swap/actions'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -32,7 +33,8 @@ const SlippageSetting: React.FC = () => {
   const dispatch = useDispatch()
   const theme = useTheme()
   const [rawSlippage] = useUserSlippageTolerance()
-  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const isStablePairSwap = useCheckStablePairSwap()
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
   const isWarning = isValid && !!message
   const isError = !isValid
 

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -8,8 +8,10 @@ import QuestionHelper from 'components/QuestionHelper'
 import SlippageControl from 'components/SlippageControl'
 import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
 import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
+import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP } from 'constants/index'
 import { useAppSelector } from 'state/hooks'
 import { pinSlippageControl } from 'state/swap/actions'
+import { useCheckStablePairSwap } from 'state/swap/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -34,7 +36,8 @@ type Props = {
 const SlippageSetting: React.FC<Props> = ({ shouldShowPinButton = true }) => {
   const dispatch = useDispatch()
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-  const { isValid, message } = checkRangeSlippage(rawSlippage)
+  const isStablePairSwap = useCheckStablePairSwap()
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
   const isWarning = isValid && !!message
   const isError = !isValid
 
@@ -69,7 +72,12 @@ const SlippageSetting: React.FC<Props> = ({ shouldShowPinButton = true }) => {
         )}
       </Flex>
 
-      <SlippageControl rawSlippage={rawSlippage} setRawSlippage={setRawSlippage} isWarning={isWarning} />
+      <SlippageControl
+        rawSlippage={rawSlippage}
+        setRawSlippage={setRawSlippage}
+        isWarning={isWarning}
+        defaultRawSlippage={isStablePairSwap ? DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP : DEFAULT_SLIPPAGE}
+      />
 
       {!!message && (
         <Message data-warning={isWarning} data-error={isError}>

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -1,14 +1,13 @@
 import { Trans, t } from '@lingui/macro'
 import React from 'react'
-import { isMobile } from 'react-device-detect'
 import { useDispatch } from 'react-redux'
-import { Flex, Text } from 'rebass'
+import { Flex } from 'rebass'
 import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
 import SlippageControl from 'components/SlippageControl'
 import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
-import useTheme from 'hooks/useTheme'
+import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
 import { useAppSelector } from 'state/hooks'
 import { pinSlippageControl } from 'state/swap/actions'
 import { useUserSlippageTolerance } from 'state/user/hooks'
@@ -28,9 +27,12 @@ const Message = styled.div`
   }
 `
 
-const SlippageSetting: React.FC = () => {
+type Props = {
+  shouldShowPinButton?: boolean
+}
+
+const SlippageSetting: React.FC<Props> = ({ shouldShowPinButton = true }) => {
   const dispatch = useDispatch()
-  const theme = useTheme()
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
   const { isValid, message } = checkRangeSlippage(rawSlippage)
   const isWarning = isValid && !!message
@@ -54,22 +56,17 @@ const SlippageSetting: React.FC = () => {
           alignItems: 'center',
         }}
       >
-        <Text
-          sx={{
-            fontSize: isMobile ? '14px' : '12px',
-            color: theme.text,
-            fontWeight: 400,
-            lineHeight: '16px',
-          }}
-        >
+        <SettingLabel>
           <Trans>Max Slippage</Trans>
-        </Text>
+        </SettingLabel>
         <QuestionHelper
           placement="top"
           text={t`Transaction will revert if there is an adverse rate change that is higher than this %. This control will appear in Swap form if pinned.`}
         />
 
-        <PinButton isActive={isSlippageControlPinned} onClick={handleClickPinSlippageControl} />
+        {shouldShowPinButton && (
+          <PinButton isActive={isSlippageControlPinned} onClick={handleClickPinSlippageControl} />
+        )}
       </Flex>
 
       <SlippageControl rawSlippage={rawSlippage} setRawSlippage={setRawSlippage} isWarning={isWarning} />

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -182,6 +182,20 @@ const CustomInput = styled.input`
     font-size: 10px;
   }
 `
+
+const getSlippageText = (rawSlippage: number) => {
+  const isCustom = !DefaultSlippages.includes(rawSlippage)
+  if (!isCustom) {
+    return ''
+  }
+
+  if (rawSlippage % 100 === 0) {
+    return String(rawSlippage / 100)
+  }
+
+  return (rawSlippage / 100).toFixed(2)
+}
+
 const SlippageSetting: React.FC = () => {
   const theme = useTheme()
   const inputRef = useRef<HTMLInputElement>(null)
@@ -191,14 +205,19 @@ const SlippageSetting: React.FC = () => {
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
 
   const isCustomOptionActive = !DefaultSlippages.includes(rawSlippage)
-  const [slippageInput, setSlippageInput] = useState(isCustomOptionActive ? (rawSlippage / 100).toFixed(2) : '')
-  const { isValid, message } = validateSlippageInput(slippageInput || String(rawSlippage / 100))
+  const [slippageInput, setSlippageInput] = useState(getSlippageText(rawSlippage))
+  const { isValid, message } = validateSlippageInput(slippageInput)
 
   const isWarning = isValid && !!message
   const isError = !isValid
   const { mixpanelHandler } = useMixpanel()
   const handleCommitChange = () => {
-    if (!isValid || slippageInput === '') {
+    if (!isValid) {
+      return
+    }
+
+    if (slippageInput === '') {
+      setSlippageInput(getSlippageText(rawSlippage))
       return
     }
 
@@ -209,6 +228,7 @@ const SlippageSetting: React.FC = () => {
     mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: newRawSlippage / 100 })
 
     setRawSlippage(newRawSlippage)
+    setSlippageInput(getSlippageText(newRawSlippage))
   }
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/swapv2/SwapSettingsPanel/TransactionTimeLimitSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/TransactionTimeLimitSetting.tsx
@@ -1,10 +1,10 @@
 import { Trans, t } from '@lingui/macro'
 import React, { useEffect, useRef, useState } from 'react'
-import { isMobile } from 'react-device-detect'
 import { Box, Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import QuestionHelper from 'components/QuestionHelper'
+import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
 import useTheme from 'hooks/useTheme'
 import { useUserTransactionTTL } from 'state/user/hooks'
 
@@ -65,18 +65,9 @@ const TransactionTimeLimitSetting: React.FC<Props> = ({ className }) => {
   return (
     <Flex justifyContent={'space-between'} alignItems="center" className={className}>
       <Flex alignItems="center">
-        <Text
-          className="label"
-          sx={{
-            fontSize: isMobile ? '14px' : '12px',
-            color: theme.text,
-            fontWeight: 400,
-            lineHeight: '16px',
-            whiteSpace: 'nowrap',
-          }}
-        >
+        <SettingLabel>
           <Trans>Transaction time limit</Trans>
-        </Text>
+        </SettingLabel>
         <QuestionHelper text={t`Transaction will revert if it is pending for longer than the indicated time`} />
       </Flex>
 

--- a/src/components/swapv2/SwapSettingsPanel/index.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/index.tsx
@@ -1,9 +1,8 @@
 import { Trans, t } from '@lingui/macro'
 import { rgba } from 'polished'
 import React from 'react'
-import { isMobile } from 'react-device-detect'
 import { ArrowLeft } from 'react-feather'
-import { Box, Flex } from 'rebass'
+import { Box, Flex, Text } from 'rebass'
 import styled from 'styled-components'
 
 import { AutoColumn } from 'components/Column'
@@ -28,6 +27,7 @@ import {
 import AdvancedModeSetting from './AdvancedModeSetting'
 import GasPriceTrackerSetting from './GasPriceTrackerSetting'
 import LiquiditySourcesSetting from './LiquiditySourcesSetting'
+import SettingLabel from './SettingLabel'
 import SlippageSetting from './SlippageSetting'
 import TransactionTimeLimitSetting from './TransactionTimeLimitSetting'
 
@@ -120,11 +120,8 @@ const SettingsPanel: React.FC<Props> = ({
 
               <SlippageSetting />
               <TransactionTimeLimitSetting />
-
               <AdvancedModeSetting />
-
               <GasPriceTrackerSetting onClick={onClickGasPriceTracker} />
-
               <LiquiditySourcesSetting onClick={onClickLiquiditySources} />
             </>
           )}
@@ -136,14 +133,22 @@ const SettingsPanel: React.FC<Props> = ({
               borderTop: `1px solid ${theme.border}`,
             }}
           >
-            <span className="settingTitle">
+            <Text
+              as="span"
+              sx={{
+                fontSize: '16px',
+                fontWeight: 500,
+              }}
+            >
               <Trans>Display Settings</Trans>
-            </span>
+            </Text>
             <AutoColumn gap="md">
               {shouldShowTrendingSoonSetting && (
                 <RowBetween>
                   <RowFixed>
-                    <span className="settingLabel">Trending Soon</span>
+                    <SettingLabel>
+                      <Trans>Trending Soon</Trans>
+                    </SettingLabel>
                     <QuestionHelper text={t`Turn on to display tokens that could be trending soon`} />
                   </RowFixed>
                   <Toggle isActive={isShowTrendingSoonTokens} toggle={toggleTopTrendingTokens} />
@@ -151,7 +156,9 @@ const SettingsPanel: React.FC<Props> = ({
               )}
               <RowBetween>
                 <RowFixed>
-                  <span className="settingLabel">Live Chart</span>
+                  <SettingLabel>
+                    <Trans>Live Chart</Trans>
+                  </SettingLabel>
                   <QuestionHelper text={t`Turn on to display live chart`} />
                 </RowFixed>
                 <Toggle isActive={isShowLiveChart} toggle={handleToggleLiveChart} />
@@ -160,18 +167,18 @@ const SettingsPanel: React.FC<Props> = ({
                 <>
                   <RowBetween>
                     <RowFixed>
-                      <span className="settingLabel">
+                      <SettingLabel>
                         <Trans>Trade Route</Trans>
-                      </span>
+                      </SettingLabel>
                       <QuestionHelper text={t`Turn on to display trade route`} />
                     </RowFixed>
                     <Toggle isActive={isShowTradeRoutes} toggle={handleToggleTradeRoute} />
                   </RowBetween>
                   <RowBetween>
                     <RowFixed>
-                      <span className="settingLabel">
+                      <SettingLabel>
                         <Trans>Token Info</Trans>
-                      </span>
+                      </SettingLabel>
                       <QuestionHelper text={t`Turn on to display token info`} />
                     </RowFixed>
                     <Toggle isActive={isShowTokenInfo} toggle={toggleTokenInfo} />
@@ -187,18 +194,6 @@ const SettingsPanel: React.FC<Props> = ({
 }
 
 export default styled(SettingsPanel)`
-  .settingTitle {
-    font-size: 16px;
-    font-weight: 500;
-  }
-
-  .settingLabel {
-    font-size: ${isMobile ? '14px' : '12px'};
-    color: ${({ theme }) => theme.text};
-    font-weight: 400;
-    line-height: 20px;
-  }
-
   ${Toggle} {
     background: ${({ theme }) => theme.buttonBlack};
     &[data-active='true'] {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -251,6 +251,8 @@ export const EPSILON = 0.000000000008854
 
 // https://www.nasdaq.com/glossary/b/bip
 export const MAX_SLIPPAGE_IN_BIPS = 2000
+export const DEFAULT_SLIPPAGES = [5, 10, 50, 100]
+export const DEFAULT_SLIPPAGE = 50
 
 export const AGGREGATOR_WAITING_TIME = 1700 // 1700 means that we at least show '.' '..' '...' '.' '..' '...'
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -253,6 +253,7 @@ export const EPSILON = 0.000000000008854
 export const MAX_SLIPPAGE_IN_BIPS = 2000
 export const DEFAULT_SLIPPAGES = [5, 10, 50, 100]
 export const DEFAULT_SLIPPAGE = 50
+export const DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP = 5
 
 export const AGGREGATOR_WAITING_TIME = 1700 // 1700 means that we at least show '.' '..' '...' '.' '..' '...'
 

--- a/src/pages/SwapV3/PopulatedSwapForm.tsx
+++ b/src/pages/SwapV3/PopulatedSwapForm.tsx
@@ -34,7 +34,7 @@ const PopulatedSwapForm: React.FC<Props> = ({ routeSummary, setRouteSummary, goT
   const { feeConfig } = useSwapState()
   const { onUserInput, onCurrencySelection, onResetSelectCurrency } = useSwapActionHandlers()
 
-  useUpdateSlippageInStableCoinSwap(currencyIn, currencyOut)
+  useUpdateSlippageInStableCoinSwap()
 
   const onSelectSuggestedPair = useCallback(
     (fromToken: Currency | undefined, toToken: Currency | undefined, amount?: string) => {

--- a/src/pages/SwapV3/useUpdateSlippageInStableCoinSwap.tsx
+++ b/src/pages/SwapV3/useUpdateSlippageInStableCoinSwap.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 
+import { DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP } from 'constants/index'
 import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import { AppState } from 'state'
@@ -24,8 +25,8 @@ const useUpdateSlippageInStableCoinSwap = () => {
       STABLE_COINS_ADDRESS[chainId].includes(inputCurrencyId) &&
       STABLE_COINS_ADDRESS[chainId].includes(outputCurrencyId)
 
-    if (isStableCoinSwap && rawSlippageRef.current > 10) {
-      setSlippage(10)
+    if (isStableCoinSwap && rawSlippageRef.current > DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP) {
+      setSlippage(DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP)
     }
   }, [chainId, inputCurrencyId, outputCurrencyId, setSlippage])
 }

--- a/src/pages/SwapV3/useUpdateSlippageInStableCoinSwap.tsx
+++ b/src/pages/SwapV3/useUpdateSlippageInStableCoinSwap.tsx
@@ -1,29 +1,33 @@
-import { Currency } from '@kyberswap/ks-sdk-core'
 import { useEffect, useRef } from 'react'
+import { useSelector } from 'react-redux'
 
 import { STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
+import { AppState } from 'state'
+import { Field } from 'state/swap/actions'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 
-const useUpdateSlippageInStableCoinSwap = (currencyIn?: Currency, currencyOut?: Currency) => {
+const useUpdateSlippageInStableCoinSwap = () => {
   const { chainId } = useActiveWeb3React()
+  const inputCurrencyId = useSelector((state: AppState) => state.swap[Field.INPUT].currencyId)
+  const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
   const [slippage, setSlippage] = useUserSlippageTolerance()
-  const isStableCoinSwap =
-    chainId &&
-    currencyIn &&
-    currencyOut &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyIn.wrapped.address) &&
-    STABLE_COINS_ADDRESS[chainId].includes(currencyOut.wrapped.address)
+
   const rawSlippageRef = useRef(slippage)
   rawSlippageRef.current = slippage
+
   useEffect(() => {
+    const isStableCoinSwap =
+      chainId &&
+      inputCurrencyId &&
+      outputCurrencyId &&
+      STABLE_COINS_ADDRESS[chainId].includes(inputCurrencyId) &&
+      STABLE_COINS_ADDRESS[chainId].includes(outputCurrencyId)
+
     if (isStableCoinSwap && rawSlippageRef.current > 10) {
       setSlippage(10)
     }
-    if (!isStableCoinSwap && rawSlippageRef.current === 10) {
-      setSlippage(50)
-    }
-  }, [isStableCoinSwap, setSlippage])
+  }, [chainId, inputCurrencyId, outputCurrencyId, setSlippage])
 }
 
 export default useUpdateSlippageInStableCoinSwap

--- a/src/state/swap/actions.ts
+++ b/src/state/swap/actions.ts
@@ -31,3 +31,4 @@ export const encodedSolana = createAction<{
 export const setRecipient = createAction<{ recipient: string | null }>('swap/setRecipient')
 export const setTrendingSoonShowed = createAction('swap/setTrendingSoonShowed')
 export const setTrade = createAction<{ trade: Aggregator | undefined }>('swap/setTrade')
+export const pinSlippageControl = createAction<boolean>('swap/pinSlippageControl')

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { APP_PATHS, BAD_RECIPIENT_ADDRESSES } from 'constants/index'
-import { DEFAULT_OUTPUT_TOKEN_BY_CHAIN, NativeCurrencies, STABLE_COINS_ADDRESS } from 'constants/tokens'
+import { DEFAULT_OUTPUT_TOKEN_BY_CHAIN, NativeCurrencies } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import { useCurrencyV2 } from 'hooks/Tokens'
 import { useTradeExactIn } from 'hooks/Trades'
@@ -440,20 +440,4 @@ export const useOutputCurrency = () => {
   const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
   const outputCurrency = useCurrencyV2(outputCurrencyId)
   return outputCurrency || undefined
-}
-
-export const useCheckStablePairSwap = () => {
-  const { chainId } = useActiveWeb3React()
-  const inputCurrencyId = useSelector((state: AppState) => state.swap[Field.INPUT].currencyId)
-  const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
-
-  const isStablePairSwap = Boolean(
-    chainId &&
-      inputCurrencyId &&
-      outputCurrencyId &&
-      STABLE_COINS_ADDRESS[chainId].includes(inputCurrencyId) &&
-      STABLE_COINS_ADDRESS[chainId].includes(outputCurrencyId),
-  )
-
-  return isStablePairSwap
 }

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -308,7 +308,7 @@ export function queryParametersToSwapState(
   parsedQs: ParsedUrlQuery,
   chainId: ChainId,
   isMatchPath: boolean,
-): Omit<SwapState, 'saveGas' | 'typedValue'> {
+): Omit<SwapState, 'saveGas' | 'typedValue' | 'isSlippageControlPinned'> {
   let inputCurrency = parseCurrencyFromURLParameter(isMatchPath ? parsedQs.inputCurrency : null, chainId)
   let outputCurrency = parseCurrencyFromURLParameter(isMatchPath ? parsedQs.outputCurrency : null, chainId)
   if (inputCurrency === outputCurrency) {

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { APP_PATHS, BAD_RECIPIENT_ADDRESSES } from 'constants/index'
-import { DEFAULT_OUTPUT_TOKEN_BY_CHAIN, NativeCurrencies } from 'constants/tokens'
+import { DEFAULT_OUTPUT_TOKEN_BY_CHAIN, NativeCurrencies, STABLE_COINS_ADDRESS } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import { useCurrencyV2 } from 'hooks/Tokens'
 import { useTradeExactIn } from 'hooks/Trades'
@@ -440,4 +440,20 @@ export const useOutputCurrency = () => {
   const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
   const outputCurrency = useCurrencyV2(outputCurrencyId)
   return outputCurrency || undefined
+}
+
+export const useCheckStablePairSwap = () => {
+  const { chainId } = useActiveWeb3React()
+  const inputCurrencyId = useSelector((state: AppState) => state.swap[Field.INPUT].currencyId)
+  const outputCurrencyId = useSelector((state: AppState) => state.swap[Field.OUTPUT].currencyId)
+
+  const isStablePairSwap = Boolean(
+    chainId &&
+      inputCurrencyId &&
+      outputCurrencyId &&
+      STABLE_COINS_ADDRESS[chainId].includes(inputCurrencyId) &&
+      STABLE_COINS_ADDRESS[chainId].includes(outputCurrencyId),
+  )
+
+  return isStablePairSwap
 }

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -98,6 +98,7 @@ export default createReducer<SwapState>(initialState, builder =>
           typedValue: typedValue || state.typedValue || '1',
           recipient,
           feeConfig,
+          isSlippageControlPinned: state.isSlippageControlPinned ?? initialState.isSlippageControlPinned,
         }
       },
     )

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -9,6 +9,7 @@ import {
   Field,
   chooseToSaveGas,
   encodedSolana,
+  pinSlippageControl,
   replaceSwapState,
   resetSelectCurrency,
   selectCurrency,
@@ -45,6 +46,7 @@ export interface SwapState {
   readonly txHash: string | undefined
 
   readonly isSelectTokenManually: boolean
+  readonly isSlippageControlPinned: boolean
 }
 
 const { search, pathname } = window.location
@@ -76,6 +78,7 @@ const initialState: SwapState = {
   txHash: undefined,
 
   isSelectTokenManually: false,
+  isSlippageControlPinned: true,
 }
 
 export default createReducer<SwapState>(initialState, builder =>
@@ -165,5 +168,8 @@ export default createReducer<SwapState>(initialState, builder =>
     .addCase(setTrade, (state, { payload: { trade } }) => {
       state.trade = trade
       state.encodeSolana = undefined
+    })
+    .addCase(pinSlippageControl, (state, { payload }) => {
+      state.isSlippageControlPinned = payload
     }),
 )

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -5,11 +5,38 @@ import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
 // isValid = true means it's OK to process with the number with an extra parse
 // isValid = true with message means warning
 // isValid = false with/without message means error
-export const checkRangeSlippage = (slippage: number) => {
+export const checkRangeSlippage = (slippage: number, isStablePairSwap: boolean) => {
   if (slippage < 0) {
     return {
       isValid: false,
       message: t`Enter a valid slippage percentage`,
+    }
+  }
+
+  if (slippage > MAX_SLIPPAGE_IN_BIPS) {
+    return {
+      isValid: false,
+      message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
+    }
+  }
+
+  if (isStablePairSwap) {
+    if (slippage < 5) {
+      return {
+        isValid: true,
+        message: t`Slippage is low. Your transaction may fail`,
+      }
+    }
+
+    if (10 < slippage && slippage <= MAX_SLIPPAGE_IN_BIPS) {
+      return {
+        isValid: true,
+        message: t`Slippage for stable tokens swap should be <= 0.1%. Your transaction may be front-run`,
+      }
+    }
+
+    return {
+      isValid: true,
     }
   }
 
@@ -24,13 +51,6 @@ export const checkRangeSlippage = (slippage: number) => {
     return {
       isValid: true,
       message: t`Slippage is high. Your transaction may be front-run`,
-    }
-  }
-
-  if (slippage > MAX_SLIPPAGE_IN_BIPS) {
-    return {
-      isValid: false,
-      message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
     }
   }
 

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -38,3 +38,20 @@ export const checkRangeSlippage = (slippage: number) => {
     isValid: true,
   }
 }
+
+export const formatSlippage = (slp: number, withPercent = false) => {
+  let text = ''
+  if (slp % 100 === 0) {
+    text = String(slp / 100)
+  } else if (slp % 10 === 0) {
+    text = (slp / 100).toFixed(1)
+  } else {
+    text = (slp / 100).toFixed(2)
+  }
+
+  if (withPercent) {
+    text += '%'
+  }
+
+  return text
+}

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -5,7 +5,7 @@ import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
 // isValid = true means it's OK to process with the number with an extra parse
 // isValid = true with message means warning
 // isValid = false with/without message means error
-export const checkRangeSlippage = (slippage: number, isStablePairSwap: boolean) => {
+export const checkRangeSlippage = (slippage: number) => {
   if (slippage < 0) {
     return {
       isValid: false,
@@ -17,26 +17,6 @@ export const checkRangeSlippage = (slippage: number, isStablePairSwap: boolean) 
     return {
       isValid: false,
       message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
-    }
-  }
-
-  if (isStablePairSwap) {
-    if (slippage < 5) {
-      return {
-        isValid: true,
-        message: t`Slippage is low. Your transaction may fail`,
-      }
-    }
-
-    if (10 < slippage && slippage <= MAX_SLIPPAGE_IN_BIPS) {
-      return {
-        isValid: true,
-        message: t`Slippage for stable tokens swap should be <= 0.1%. Your transaction may be front-run`,
-      }
-    }
-
-    return {
-      isValid: true,
     }
   }
 
@@ -59,7 +39,12 @@ export const checkRangeSlippage = (slippage: number, isStablePairSwap: boolean) 
   }
 }
 
-export const formatSlippage = (slp: number, withPercent = false) => {
+export const checkWarningSlippage = (slippage: number) => {
+  const { isValid, message } = checkRangeSlippage(slippage)
+  return isValid && !!message
+}
+
+export const formatSlippage = (slp: number, withPercent = true) => {
   let text = ''
   if (slp % 100 === 0) {
     text = String(slp / 100)

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -5,7 +5,7 @@ import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
 // isValid = true means it's OK to process with the number with an extra parse
 // isValid = true with message means warning
 // isValid = false with/without message means error
-export const checkRangeSlippage = (slippage: number) => {
+export const checkRangeSlippage = (slippage: number, isStablePairSwap: boolean) => {
   if (slippage < 0) {
     return {
       isValid: false,
@@ -17,6 +17,19 @@ export const checkRangeSlippage = (slippage: number) => {
     return {
       isValid: false,
       message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
+    }
+  }
+
+  if (isStablePairSwap) {
+    if (slippage > 100) {
+      return {
+        isValid: true,
+        message: t`Slippage is high. Your transaction may be front-run`,
+      }
+    }
+
+    return {
+      isValid: true,
     }
   }
 
@@ -39,8 +52,8 @@ export const checkRangeSlippage = (slippage: number) => {
   }
 }
 
-export const checkWarningSlippage = (slippage: number) => {
-  const { isValid, message } = checkRangeSlippage(slippage)
+export const checkWarningSlippage = (slippage: number, isStablePairSwap: boolean) => {
+  const { isValid, message } = checkRangeSlippage(slippage, isStablePairSwap)
   return isValid && !!message
 }
 

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -1,0 +1,40 @@
+import { t } from '@lingui/macro'
+
+import { MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+
+// isValid = true means it's OK to process with the number with an extra parse
+// isValid = true with message means warning
+// isValid = false with/without message means error
+export const checkRangeSlippage = (slippage: number) => {
+  if (slippage < 0) {
+    return {
+      isValid: false,
+      message: t`Enter a valid slippage percentage`,
+    }
+  }
+
+  if (slippage < 50) {
+    return {
+      isValid: true,
+      message: t`Slippage is low. Your transaction may fail`,
+    }
+  }
+
+  if (500 < slippage && slippage <= MAX_SLIPPAGE_IN_BIPS) {
+    return {
+      isValid: true,
+      message: t`Slippage is high. Your transaction may be front-run`,
+    }
+  }
+
+  if (slippage > MAX_SLIPPAGE_IN_BIPS) {
+    return {
+      isValid: false,
+      message: t`Slippage is restricted to at most 20%. Please enter a smaller number`,
+    }
+  }
+
+  return {
+    isValid: true,
+  }
+}


### PR DESCRIPTION
1. Only automatically set slippage to 0.1% if it's stable coin swap. **No** the other way around.
2. Prevent and restrict custom slippage input while user's typing. User can't enter
    a. non-digit characters, except `.`
    b. numbers that are > 20%
    c. more than 2 decimals
3. Slippage falls back to default if the custom input is erased
4. Allow users to pin the slippage control to Swap form, it's pinned by default
5. Show a warning note if slippage is low or high than it should be (in both Swap form and Swap confirmation modal)
6. The same slippage setting control is used across pages such as Swap/Add Liquidity/Increase Liquidity