### PR TITLE
Retain slippage control pin setting

### DIFF
--- a/src/components/SlippageControl/CustomSlippageInput.tsx
+++ b/src/components/SlippageControl/CustomSlippageInput.tsx
@@ -4,6 +4,7 @@ import { Text } from 'rebass'
 import styled, { css } from 'styled-components'
 
 import { DEFAULT_SLIPPAGES, MAX_SLIPPAGE_IN_BIPS } from 'constants/index'
+import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
 import { formatSlippage } from 'utils/slippage'
 
 export const parseSlippageInput = (str: string): number => Math.round(Number.parseFloat(str) * 100)
@@ -118,6 +119,7 @@ export type Props = {
 }
 const CustomSlippageInput: React.FC<Props> = ({ rawSlippage, setRawSlippage, isWarning, defaultRawSlippage }) => {
   const inputRef = useRef<HTMLInputElement>(null)
+  const { mixpanelHandler } = useMixpanel()
 
   // rawSlippage = 10
   // slippage shown to user: = 10 / 10_000 = 0.001 = 0.1%
@@ -157,6 +159,7 @@ const CustomSlippageInput: React.FC<Props> = ({ rawSlippage, setRawSlippage, isW
 
   const handleCommitChange = () => {
     setRawText(getSlippageText(rawSlippage))
+    mixpanelHandler(MIXPANEL_TYPE.SLIPPAGE_CHANGED, { new_slippage: Number(formatSlippage(rawSlippage, false)) })
   }
 
   const handleKeyPressInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -166,7 +169,6 @@ const CustomSlippageInput: React.FC<Props> = ({ rawSlippage, setRawSlippage, isW
     }
 
     if (key === 'Enter') {
-      handleCommitChange()
       inputRef.current?.blur()
       return
     }

--- a/src/components/SlippageWarningNote/index.tsx
+++ b/src/components/SlippageWarningNote/index.tsx
@@ -3,7 +3,6 @@ import { AlertTriangle } from 'react-feather'
 import { Flex } from 'rebass'
 import styled from 'styled-components'
 
-import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import useTheme from 'hooks/useTheme'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -20,9 +19,13 @@ const Wrapper = styled.div`
   font-size: 12px;
 `
 
-const SlippageNote: React.FC = () => {
-  const { slippage, isStablePairSwap } = useSwapFormContext()
-  const { isValid, message } = checkRangeSlippage(slippage, isStablePairSwap)
+type Props = {
+  rawSlippage: number
+  isStablePairSwap: boolean
+  className?: string
+}
+const SlippageWarningNote: React.FC<Props> = ({ className, rawSlippage, isStablePairSwap }) => {
+  const { isValid, message } = checkRangeSlippage(rawSlippage, isStablePairSwap)
 
   const theme = useTheme()
   if (!isValid || !message) {
@@ -30,7 +33,7 @@ const SlippageNote: React.FC = () => {
   }
 
   return (
-    <Wrapper>
+    <Wrapper className={className}>
       <Flex flex="0 0 16px" height="16px" alignItems="center" justifyContent="center">
         <AlertTriangle size={16} color={theme.warning} />
       </Flex>
@@ -39,4 +42,4 @@ const SlippageNote: React.FC = () => {
   )
 }
 
-export default SlippageNote
+export default styled(SlippageWarningNote)``

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -24,7 +24,7 @@ const DropdownIcon = styled(DropdownSVG)`
 
 const SlippageSetting: React.FC = () => {
   const theme = useTheme()
-  const isSlippageControlPinned = useAppSelector(state => state.swap.isSlippageControlPinned)
+  const isSlippageControlPinned = useAppSelector(state => state.user.isSlippageControlPinned)
   const [expanded, setExpanded] = useState(false)
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
   const { isStablePairSwap } = useSwapFormContext()

--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components'
 import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
 import InfoHelper from 'components/InfoHelper'
 import SlippageControl from 'components/SlippageControl'
-import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP } from 'constants/index'
 import useTheme from 'hooks/useTheme'
 import { useAppSelector } from 'state/hooks'
@@ -22,12 +21,14 @@ const DropdownIcon = styled(DropdownSVG)`
   }
 `
 
-const SlippageSetting: React.FC = () => {
+type Props = {
+  isStablePairSwap: boolean
+}
+const SlippageSetting: React.FC<Props> = ({ isStablePairSwap }) => {
   const theme = useTheme()
   const isSlippageControlPinned = useAppSelector(state => state.user.isSlippageControlPinned)
   const [expanded, setExpanded] = useState(false)
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
-  const { isStablePairSwap } = useSwapFormContext()
   const isWarningSlippage = checkWarningSlippage(rawSlippage, isStablePairSwap)
 
   if (!isSlippageControlPinned) {

--- a/src/components/SwapForm/SwapFormContext.tsx
+++ b/src/components/SwapForm/SwapFormContext.tsx
@@ -12,15 +12,7 @@ type SwapFormContextProps = {
   isStablePairSwap: boolean
 }
 
-const SwapFormContext = createContext<SwapFormContextProps>({
-  feeConfig: undefined,
-  slippage: 0,
-  routeSummary: undefined,
-  typedValue: '',
-  isSaveGas: false,
-  recipient: null,
-  isStablePairSwap: false,
-})
+const SwapFormContext = createContext<SwapFormContextProps | undefined>(undefined)
 
 const SwapFormContextProvider: React.FC<
   SwapFormContextProps & {
@@ -31,7 +23,7 @@ const SwapFormContextProvider: React.FC<
   return <SwapFormContext.Provider value={contextValue}>{children}</SwapFormContext.Provider>
 }
 
-const useSwapFormContext = () => {
+const useSwapFormContext = (): SwapFormContextProps => {
   const context = useContext(SwapFormContext)
   if (!context) {
     throw new Error('hook is used outside of SwapFormContext')

--- a/src/components/SwapForm/SwapModal/ConfirmSwapModalContent.tsx
+++ b/src/components/SwapForm/SwapModal/ConfirmSwapModalContent.tsx
@@ -10,8 +10,8 @@ import { ButtonPrimary } from 'components/Button'
 import { GreyCard } from 'components/Card'
 import { AutoColumn } from 'components/Column'
 import { AutoRow, RowBetween } from 'components/Row'
+import SlippageWarningNote from 'components/SlippageWarningNote'
 import PriceImpactNote from 'components/SwapForm/PriceImpactNote'
-import SlippageNote from 'components/SwapForm/SlippageNote'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import { BuildRouteResult } from 'components/SwapForm/hooks/useBuildRoute'
 import { Dots } from 'components/swapv2/styleds'
@@ -70,7 +70,7 @@ const ConfirmSwapModalContent: React.FC<Props> = ({
 }) => {
   const { isSolana } = useActiveWeb3React()
   const [encodeSolana] = useEncodeSolana()
-  const { routeSummary } = useSwapFormContext()
+  const { routeSummary, slippage, isStablePairSwap } = useSwapFormContext()
 
   const shouldDisableConfirmButton = isBuildingRoute || !!errorWhileBuildRoute
 
@@ -189,7 +189,7 @@ const ConfirmSwapModalContent: React.FC<Props> = ({
           gap: '0.75rem',
         }}
       >
-        <SlippageNote />
+        <SlippageWarningNote rawSlippage={slippage} isStablePairSwap={isStablePairSwap} />
         <PriceImpactNote priceImpact={priceImpactFromBuild} hasTooltip={false} />
       </Flex>
 

--- a/src/components/SwapForm/TradeSummary.tsx
+++ b/src/components/SwapForm/TradeSummary.tsx
@@ -68,7 +68,7 @@ const TradeSummary: React.FC<Props> = ({ feeConfig, routeSummary, slippage }) =>
   const hasTrade = !!routeSummary?.route
 
   const theme = useTheme()
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(true)
 
   const formattedFeeAmountUsd = amountInUsd ? getFormattedFeeAmountUsdV2(Number(amountInUsd), feeConfig?.feeAmount) : 0
   const minimumAmountOut = parsedAmountOut ? minimumAmountAfterSlippage(parsedAmountOut, slippage) : undefined

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -5,9 +5,9 @@ import { parseGetRouteResponse } from 'services/route/utils'
 
 import AddressInputPanel from 'components/AddressInputPanel'
 import { AutoRow } from 'components/Row'
+import SlippageWarningNote from 'components/SlippageWarningNote'
 import InputCurrencyPanel from 'components/SwapForm/InputCurrencyPanel'
 import OutputCurrencyPanel from 'components/SwapForm/OutputCurrencyPanel'
-import SlippageNote from 'components/SwapForm/SlippageNote'
 import SlippageSetting from 'components/SwapForm/SlippageSetting'
 import { SwapFormContextProvider } from 'components/SwapForm/SwapFormContext'
 import useBuildRoute from 'components/SwapForm/hooks/useBuildRoute'
@@ -192,7 +192,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
               <AddressInputPanel id="recipient" value={recipient} onChange={setRecipient} />
             )}
 
-            {!isWrapOrUnwrap && <SlippageSetting />}
+            {!isWrapOrUnwrap && <SlippageSetting isStablePairSwap={isStablePairSwap} />}
           </Flex>
         </Wrapper>
         <Flex flexDirection="column" style={{ gap: '1.25rem' }}>
@@ -202,7 +202,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
             <TrendingSoonTokenBanner currencyIn={currencyIn} currencyOut={currencyOut} style={{ marginTop: '24px' }} />
           )}
 
-          {!isWrapOrUnwrap && <SlippageNote />}
+          {!isWrapOrUnwrap && <SlippageWarningNote rawSlippage={slippage} isStablePairSwap={isStablePairSwap} />}
 
           <PriceImpactNote priceImpact={routeSummary?.priceImpact} isAdvancedMode={isAdvancedMode} hasTooltip />
 

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -225,7 +225,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
             swapInputError={swapInputError}
           />
 
-          <TradeSummary feeConfig={feeConfig} routeSummary={routeSummary} slippage={slippage} />
+          {!isWrapOrUnwrap && <TradeSummary feeConfig={feeConfig} routeSummary={routeSummary} slippage={slippage} />}
         </Flex>
       </Box>
     </SwapFormContextProvider>

--- a/src/components/swapv2/AdvancedSwapDetails.tsx
+++ b/src/components/swapv2/AdvancedSwapDetails.tsx
@@ -43,7 +43,7 @@ interface TradeSummaryProps {
 function TradeSummary({ trade, feeConfig, allowedSlippage }: TradeSummaryProps) {
   const { isEVM } = useActiveWeb3React()
   const theme = useTheme()
-  const [show, setShow] = useState(feeConfig ? true : false)
+  const [show, setShow] = useState(true)
 
   const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
   const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -10,8 +10,8 @@ import PinButton from 'components/swapv2/SwapSettingsPanel/PinButton'
 import SettingLabel from 'components/swapv2/SwapSettingsPanel/SettingLabel'
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP } from 'constants/index'
 import { useAppSelector } from 'state/hooks'
-import { pinSlippageControl } from 'state/swap/actions'
 import { useCheckStablePairSwap } from 'state/swap/hooks'
+import { pinSlippageControl } from 'state/user/actions'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 import { checkRangeSlippage } from 'utils/slippage'
 
@@ -41,7 +41,7 @@ const SlippageSetting: React.FC<Props> = ({ shouldShowPinButton = true }) => {
   const isWarning = isValid && !!message
   const isError = !isValid
 
-  const isSlippageControlPinned = useAppSelector(state => state.swap.isSlippageControlPinned)
+  const isSlippageControlPinned = useAppSelector(state => state.user.isSlippageControlPinned)
 
   const handleClickPinSlippageControl = () => {
     dispatch(pinSlippageControl(!isSlippageControlPinned))

--- a/src/components/swapv2/styleds.tsx
+++ b/src/components/swapv2/styleds.tsx
@@ -7,6 +7,7 @@ import { ReactComponent as Alert } from 'assets/images/alert.svg'
 import { ButtonEmpty } from 'components/Button'
 import { AutoColumn } from 'components/Column'
 import Modal, { ModalProps } from 'components/Modal'
+import SlippageWarningNote from 'components/SlippageWarningNote'
 import { Z_INDEXS } from 'constants/styles'
 import useTheme from 'hooks/useTheme'
 import { errorFriendly } from 'utils/dmm'
@@ -277,7 +278,7 @@ export const PriceImpactHigh = styled.div<{ veryHigh?: boolean }>`
   border-radius: 999px;
   padding: 12px 16px;
   background: ${({ theme, veryHigh }) => (veryHigh ? `${theme.red}66` : `${theme.warning}66`)};
-  margin-top: 28px;
+  margin-top: 24px;
   display: flex;
   align-items: center;
   font-size: 12px;
@@ -391,4 +392,8 @@ export const IconButton = styled(StyledActionButtonSwapForm)<{ enableClickToRefr
     cursor: default;
     background-color: transparent;
   }
+`
+
+export const CustomSlippageNote = styled(SlippageWarningNote)`
+  margin-top: 16px;
 `

--- a/src/pages/SwapV2/index.tsx
+++ b/src/pages/SwapV2/index.tsx
@@ -85,6 +85,7 @@ import useSyncTokenSymbolToUrl from 'hooks/useSyncTokenSymbolToUrl'
 import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
 import { BodyWrapper } from 'pages/AppBody'
+import useUpdateSlippageInStableCoinSwap from 'pages/SwapV3/useUpdateSlippageInStableCoinSwap'
 import { useWalletModalToggle } from 'state/application/hooks'
 import { useAllDexes } from 'state/customizeDexes/hooks'
 import { useLimitActionHandlers, useLimitState } from 'state/limit/hooks'
@@ -589,7 +590,7 @@ export default function Swap() {
     }
   }, [isExpertMode, mixpanelHandler])
 
-  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
+  const [rawSlippage] = useUserSlippageTolerance()
 
   const isStableCoinSwap = Boolean(
     INPUT?.currencyId &&
@@ -599,17 +600,7 @@ export default function Swap() {
       STABLE_COINS_ADDRESS[chainId].includes(OUTPUT?.currencyId),
   )
 
-  const rawSlippageRef = useRef(rawSlippage)
-  rawSlippageRef.current = rawSlippage
-
-  useEffect(() => {
-    if (isStableCoinSwap && rawSlippageRef.current > 10) {
-      setRawSlippage(10)
-    }
-    if (!isStableCoinSwap && rawSlippageRef.current === 10) {
-      setRawSlippage(50)
-    }
-  }, [isStableCoinSwap, setRawSlippage])
+  useUpdateSlippageInStableCoinSwap()
 
   const shareUrl = useMemo(() => {
     const tokenIn = isSwapPage ? currencyIn : limitState.currencyIn

--- a/src/pages/SwapV2/index.tsx
+++ b/src/pages/SwapV2/index.tsx
@@ -28,6 +28,8 @@ import ProgressSteps from 'components/ProgressSteps'
 import { AutoRow, RowBetween } from 'components/Row'
 import { SEOSwap } from 'components/SEO'
 import { ShareButtonWithModal } from 'components/ShareModal'
+import SlippageWarningNote from 'components/SlippageWarningNote'
+import SlippageSetting from 'components/SwapForm/SlippageSetting'
 import { SwitchLocaleLink } from 'components/SwitchLocaleLink'
 import TokenWarningModal from 'components/TokenWarningModal'
 import { MouseoverTooltip } from 'components/Tooltip'
@@ -83,8 +85,7 @@ import useSyncTokenSymbolToUrl from 'hooks/useSyncTokenSymbolToUrl'
 import useTheme from 'hooks/useTheme'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
 import { BodyWrapper } from 'pages/AppBody'
-import { ClickableText } from 'pages/Pool/styleds'
-import { useToggleTransactionSettingsMenu, useWalletModalToggle } from 'state/application/hooks'
+import { useWalletModalToggle } from 'state/application/hooks'
 import { useAllDexes } from 'state/customizeDexes/hooks'
 import { useLimitActionHandlers, useLimitState } from 'state/limit/hooks'
 import { Field } from 'state/swap/actions'
@@ -184,6 +185,10 @@ const RoutingIconWrapper = styled(RoutingIcon)`
   }
 `
 
+const CustomSlippageNote = styled(SlippageWarningNote)`
+  margin-top: 24px;
+`
+
 export default function Swap() {
   const navigateFn = useNavigate()
   const { account, chainId, networkInfo, isSolana, isEVM } = useActiveWeb3React()
@@ -239,8 +244,6 @@ export default function Swap() {
   // toggle wallet when disconnected
   const toggleWalletModal = useWalletModalToggle()
 
-  // for expert mode
-  const toggleSettings = useToggleTransactionSettingsMenu()
   const [isExpertMode] = useExpertModeManager()
 
   // get custom setting values for user
@@ -588,12 +591,13 @@ export default function Swap() {
 
   const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
 
-  const isStableCoinSwap =
+  const isStableCoinSwap = Boolean(
     INPUT?.currencyId &&
-    OUTPUT?.currencyId &&
-    chainId &&
-    STABLE_COINS_ADDRESS[chainId].includes(INPUT?.currencyId) &&
-    STABLE_COINS_ADDRESS[chainId].includes(OUTPUT?.currencyId)
+      OUTPUT?.currencyId &&
+      chainId &&
+      STABLE_COINS_ADDRESS[chainId].includes(INPUT?.currencyId) &&
+      STABLE_COINS_ADDRESS[chainId].includes(OUTPUT?.currencyId),
+  )
 
   const rawSlippageRef = useRef(rawSlippage)
   rawSlippageRef.current = rawSlippage
@@ -886,20 +890,7 @@ export default function Swap() {
                         <AddressInputPanel id="recipient" value={recipient} onChange={handleRecipientChange} />
                       )}
 
-                      {!showWrap && (
-                        <Flex
-                          alignItems="center"
-                          fontSize={12}
-                          color={theme.subText}
-                          onClick={toggleSettings}
-                          width="fit-content"
-                        >
-                          <ClickableText color={theme.subText} fontWeight={500}>
-                            <Trans>Max Slippage:</Trans>&nbsp;
-                            {allowedSlippage / 100}%
-                          </ClickableText>
-                        </Flex>
-                      )}
+                      {!showWrap && <SlippageSetting isStablePairSwap={isStableCoinSwap} />}
                     </Flex>
 
                     <TradeTypeSelection />
@@ -911,6 +902,8 @@ export default function Swap() {
                         style={{ marginTop: '24px' }}
                       />
                     )}
+
+                    {!showWrap && <CustomSlippageNote rawSlippage={rawSlippage} isStablePairSwap={isStableCoinSwap} />}
 
                     {isPriceImpactInvalid ? (
                       <PriceImpactHigh>

--- a/src/pages/SwapV3/index.tsx
+++ b/src/pages/SwapV3/index.tsx
@@ -273,7 +273,7 @@ export default function Swap() {
   const shareUrl = useMemo(() => {
     const tokenIn = isSwapPage ? currencyIn : limitState.currencyIn
     const tokenOut = isSwapPage ? currencyOut : limitState.currencyOut
-    return `${window.location.origin}${isSwapPage ? APP_PATHS.SWAP : APP_PATHS.LIMIT}}/${networkInfo.route}${
+    return `${window.location.origin}${isSwapPage ? APP_PATHS.SWAP : APP_PATHS.LIMIT}/${networkInfo.route}${
       tokenIn && tokenOut
         ? `?${stringify({
             inputCurrency: currencyId(tokenIn, chainId),

--- a/src/state/swap/actions.ts
+++ b/src/state/swap/actions.ts
@@ -31,4 +31,3 @@ export const encodedSolana = createAction<{
 export const setRecipient = createAction<{ recipient: string | null }>('swap/setRecipient')
 export const setTrendingSoonShowed = createAction('swap/setTrendingSoonShowed')
 export const setTrade = createAction<{ trade: Aggregator | undefined }>('swap/setTrade')
-export const pinSlippageControl = createAction<boolean>('swap/pinSlippageControl')

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -308,7 +308,7 @@ export function queryParametersToSwapState(
   parsedQs: ParsedUrlQuery,
   chainId: ChainId,
   isMatchPath: boolean,
-): Omit<SwapState, 'saveGas' | 'typedValue' | 'isSlippageControlPinned'> {
+): Omit<SwapState, 'saveGas' | 'typedValue'> {
   let inputCurrency = parseCurrencyFromURLParameter(isMatchPath ? parsedQs.inputCurrency : null, chainId)
   let outputCurrency = parseCurrencyFromURLParameter(isMatchPath ? parsedQs.outputCurrency : null, chainId)
   if (inputCurrency === outputCurrency) {

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -9,7 +9,6 @@ import {
   Field,
   chooseToSaveGas,
   encodedSolana,
-  pinSlippageControl,
   replaceSwapState,
   resetSelectCurrency,
   selectCurrency,
@@ -46,7 +45,6 @@ export interface SwapState {
   readonly txHash: string | undefined
 
   readonly isSelectTokenManually: boolean
-  readonly isSlippageControlPinned: boolean
 }
 
 const { search, pathname } = window.location
@@ -78,7 +76,6 @@ const initialState: SwapState = {
   txHash: undefined,
 
   isSelectTokenManually: false,
-  isSlippageControlPinned: true,
 }
 
 export default createReducer<SwapState>(initialState, builder =>
@@ -98,7 +95,6 @@ export default createReducer<SwapState>(initialState, builder =>
           typedValue: typedValue || state.typedValue || '1',
           recipient,
           feeConfig,
-          isSlippageControlPinned: state.isSlippageControlPinned ?? initialState.isSlippageControlPinned,
         }
       },
     )
@@ -169,8 +165,5 @@ export default createReducer<SwapState>(initialState, builder =>
     .addCase(setTrade, (state, { payload: { trade } }) => {
       state.trade = trade
       state.encodeSolana = undefined
-    })
-    .addCase(pinSlippageControl, (state, { payload }) => {
-      state.isSlippageControlPinned = payload
     }),
 )

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -49,3 +49,4 @@ export const updateIsUserManuallyDisconnect = createAction<boolean>('user/update
 export const updateAcceptedTermVersion = createAction<number | null>('user/updateAcceptedTermVersion')
 export const changeViewMode = createAction<VIEW_MODE>('user/changeViewMode')
 export const toggleHolidayMode = createAction<void>('user/toggleHolidayMode')
+export const pinSlippageControl = createAction<boolean>('user/pinSlippageControl')

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -12,6 +12,7 @@ import {
   addSerializedPair,
   addSerializedToken,
   changeViewMode,
+  pinSlippageControl,
   removeSerializedPair,
   removeSerializedToken,
   toggleFavoriteToken,
@@ -90,6 +91,8 @@ interface UserState {
   acceptedTermVersion: number | null
   viewMode: VIEW_MODE
   holidayMode: boolean
+
+  isSlippageControlPinned: boolean
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -143,6 +146,7 @@ const initialState: UserState = {
   acceptedTermVersion: null,
   viewMode: VIEW_MODE.GRID,
   holidayMode: true,
+  isSlippageControlPinned: true,
 }
 
 export default createReducer(initialState, builder =>
@@ -152,6 +156,10 @@ export default createReducer(initialState, builder =>
       // noinspection SuspiciousTypeOfGuard
       if (typeof state.userSlippageTolerance !== 'number') {
         state.userSlippageTolerance = INITIAL_ALLOWED_SLIPPAGE
+      }
+
+      if (typeof state.isSlippageControlPinned !== 'boolean') {
+        state.isSlippageControlPinned = initialState.isSlippageControlPinned
       }
 
       // deadline isnt being tracked in local storage, reset to default
@@ -272,5 +280,8 @@ export default createReducer(initialState, builder =>
     .addCase(toggleHolidayMode, state => {
       const oldMode = state.holidayMode
       state.holidayMode = !oldMode
+    })
+    .addCase(pinSlippageControl, (state, { payload }) => {
+      state.isSlippageControlPinned = payload
     }),
 )


### PR DESCRIPTION
- `isSlippageControlPinned` should be saved to localStorage
Previously, `isSlippageControlPinned` was stored in `swap` reducer, but now I moved to `user` reducer. It should stay here instead.
- By default, `isSlippageControlPinned` = true