### PR TITLE
Fix number formatter of minimum received

### DIFF
--- a/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
+++ b/src/components/SwapForm/SwapModal/SwapDetails/index.tsx
@@ -14,44 +14,16 @@ import { RowBetween, RowFixed } from 'components/Row'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import SlippageValue from 'components/SwapForm/SwapModal/SwapDetails/SlippageValue'
 import ValueWithLoadingSkeleton from 'components/SwapForm/SwapModal/SwapDetails/ValueWithLoadingSkeleton'
+import { formatMinimumReceived } from 'components/SwapForm/utils'
 import { StyledBalanceMaxMini } from 'components/swapv2/styleds'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import { TYPE } from 'theme'
 import { DetailedRouteSummary } from 'types/route'
-import { formattedNum, toK } from 'utils'
+import { formattedNum } from 'utils'
 import { minimumAmountAfterSlippage } from 'utils/currencyAmount'
 import { getFormattedFeeAmountUsdV2 } from 'utils/fee'
 import { checkPriceImpact, formatPriceImpact } from 'utils/prices'
-
-function formattedMinimumReceived(number: string) {
-  if (!number) {
-    return 0
-  }
-
-  const num = parseFloat(number)
-
-  if (num > 500000000) {
-    return toK(num.toFixed(0))
-  }
-
-  if (num === 0) {
-    return 0
-  }
-
-  if (num < 0.0001 && num > 0) {
-    return '< 0.0001'
-  }
-
-  if (num >= 1000) {
-    return Number(num.toFixed(0)).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 6 })
-  }
-
-  return Number(num.toFixed(6)).toLocaleString(undefined, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 6,
-  })
-}
 
 function formatExecutionPrice(executionPrice?: Price<Currency, Currency>, inverted?: boolean): string {
   if (!executionPrice) {
@@ -110,7 +82,7 @@ const SwapDetails: React.FC<Props> = ({
           whiteSpace: 'nowrap',
         }}
       >
-        {formattedMinimumReceived(minimumAmountOut.toSignificant(6))} {currencyOut.symbol}
+        {formatMinimumReceived(minimumAmountOut.toSignificant(6))} {currencyOut.symbol}
       </Text>
     ) : (
       ''

--- a/src/components/SwapForm/TradeSummary.tsx
+++ b/src/components/SwapForm/TradeSummary.tsx
@@ -8,6 +8,7 @@ import { AutoColumn } from 'components/Column'
 import Divider from 'components/Divider'
 import InfoHelper from 'components/InfoHelper'
 import { RowBetween, RowFixed } from 'components/Row'
+import { formatMinimumReceived } from 'components/SwapForm/utils'
 import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
 import useTheme from 'hooks/useTheme'
 import { TYPE } from 'theme'
@@ -75,6 +76,23 @@ const TradeSummary: React.FC<Props> = ({ feeConfig, routeSummary, slippage }) =>
 
   const formattedFeeAmountUsd = amountInUsd ? getFormattedFeeAmountUsdV2(Number(amountInUsd), feeConfig?.feeAmount) : 0
   const minimumAmountOut = parsedAmountOut ? minimumAmountAfterSlippage(parsedAmountOut, slippage) : undefined
+  const currencyOut = parsedAmountOut?.currency
+  const minimumAmountOutStr =
+    minimumAmountOut && currencyOut ? (
+      <Text
+        as="span"
+        sx={{
+          color: theme.text,
+          fontWeight: 'bold',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {formatMinimumReceived(minimumAmountOut.toSignificant(6))} {currencyOut.symbol}
+      </Text>
+    ) : (
+      ''
+    )
+
   const { mixpanelHandler } = useMixpanel()
   const handleClickExpand = () => {
     setExpanded(prev => !prev)
@@ -109,9 +127,7 @@ const TradeSummary: React.FC<Props> = ({ feeConfig, routeSummary, slippage }) =>
             </RowFixed>
             <RowFixed>
               <TYPE.black color={theme.text} fontSize={12}>
-                {minimumAmountOut
-                  ? `${formattedNum(minimumAmountOut.toSignificant(10) || '0')} ${minimumAmountOut.currency.symbol}`
-                  : '--'}
+                {minimumAmountOutStr || '--'}
               </TYPE.black>
             </RowFixed>
           </RowBetween>

--- a/src/components/SwapForm/utils.ts
+++ b/src/components/SwapForm/utils.ts
@@ -1,0 +1,41 @@
+import { toK } from 'utils'
+
+// Take only 6 fraction digits
+// This returns a different result compared to toFixed
+// 0.000297796.toFixed(6) = 0.000298
+// truncateFloatNumber(0.000297796) = 0.000297
+const truncateFloatNumber = (num: number, maximumFractionDigits = 6) => {
+  const [wholePart, fractionalPart] = String(num).split('.')
+
+  if (!fractionalPart) {
+    return wholePart
+  }
+
+  return `${wholePart}.${fractionalPart.slice(0, maximumFractionDigits)}`
+}
+
+export function formatMinimumReceived(strNum: string) {
+  if (!strNum) {
+    return 0
+  }
+
+  const num = parseFloat(strNum)
+
+  if (num > 500000000) {
+    return toK(num.toFixed(0))
+  }
+
+  if (num >= 1000) {
+    return Number(num.toFixed(0)).toLocaleString(undefined)
+  }
+
+  if (0 < num && num < 0.0001) {
+    return '< 0.0001'
+  }
+
+  if (num === 0) {
+    return 0
+  }
+
+  return truncateFloatNumber(num)
+}


### PR DESCRIPTION
There are some issues (take a closer look at the minimum received number in More Information and in the Confirm popup, in the Before image)
- It shows 0 for minimum received in More Information, but it shows 0.000298 in Confirm popup
- Expects 0.000297..., but minimum received is 0.000298

Pair: XDO -> AAVE on Polygon

| Before | After |
| --- | --- |
| ![kyberswap com_swap_polygon_xdo-to-aave](https://user-images.githubusercontent.com/19758667/225495746-88b74cd6-7c5d-4d94-9326-71b3ca97c084.png) | ![localhost_3000_swap_polygon_xdo-to-aave](https://user-images.githubusercontent.com/19758667/225495758-3c9176ed-feae-4dd9-a2e2-3015765f5b99.png) |