### PR TITLE
Grant campaign UI improvement

### DIFF
--- a/src/hooks/campaigns/useGetLeaderboardGrantProgram.ts
+++ b/src/hooks/campaigns/useGetLeaderboardGrantProgram.ts
@@ -47,7 +47,9 @@ const useGetLeaderboardGrantProgram = (args: Args) => {
   )
 
   const refresh = () => {
-    mutate(url)
+    mutate(url, undefined, {
+      revalidate: true,
+    })
   }
 
   return {

--- a/src/pages/GrantProgram/CountdownTimer.tsx
+++ b/src/pages/GrantProgram/CountdownTimer.tsx
@@ -1,12 +1,17 @@
 import { t } from '@lingui/macro'
 import dayjs from 'dayjs'
 import { rgba } from 'polished'
+import { useEffect, useState } from 'react'
 import { Text } from 'rebass'
 import styled, { css } from 'styled-components'
 
 import { MouseoverTooltip } from 'components/Tooltip'
 import useTheme from 'hooks/useTheme'
 import { getFormattedTimeFromSecond } from 'utils/formatTime'
+
+const getNow = () => {
+  return Math.floor(Date.now() / 1000)
+}
 
 const TimeWrapper = styled.div<{ $background: string }>`
   width: fit-content;
@@ -107,10 +112,19 @@ type Props = {
   startTime: number
   endTime: number
 }
-
 const CountdownTimer: React.FC<Props> = ({ startTime, endTime }) => {
   const theme = useTheme()
-  const now = Math.floor(Date.now() / 1000)
+  const [now, setNow] = useState(getNow())
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNow(getNow())
+    }, 1_000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
 
   if (now < startTime) {
     return (

--- a/src/pages/GrantProgram/SingleProgram/LeaderBoardSection/index.tsx
+++ b/src/pages/GrantProgram/SingleProgram/LeaderBoardSection/index.tsx
@@ -7,7 +7,6 @@ import Loader from 'components/Loader'
 import useGetLeaderboardGrantProgram, { RankByParam } from 'hooks/campaigns/useGetLeaderboardGrantProgram'
 import useTheme from 'hooks/useTheme'
 import { ProjectRanking } from 'types/grantProgram'
-import { formattedNumLong } from 'utils'
 
 import { HeaderText } from '../../styleds'
 import LeaderBoard from './LeaderBoard'
@@ -26,6 +25,18 @@ const EmptyRankings: any[] = []
 
 export const ITEMS_PER_PAGE = 5
 
+const formatTradingVolume = (num: number) => {
+  const notation = num > 100_000_000 ? 'compact' : 'standard'
+  const formatter = new Intl.NumberFormat('en-US', {
+    notation,
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+  return formatter.format(num)
+}
+
 export type RankByConfig = {
   extracter: (p: ProjectRanking) => string // used to extract the value
   param: RankByParam // used as param in GET request
@@ -42,7 +53,7 @@ const rankByConfigs: RankByConfig[] = [
   },
   {
     extracter: (p: ProjectRanking) => {
-      return formattedNumLong(Number(p.totalVolume), true)
+      return formatTradingVolume(Number(p.totalVolume))
     },
     param: 'total_volume',
     title: t`Trading Volume`,


### PR DESCRIPTION
1. Use compact notation for trading volume that >= $100_000_000, in leaderboard
2. If user's not focusing on the page, even when time's out, it will not revalidate the leaderboard data. Need to use force here
3. Update countdown timer every second