### PR TITLE
Abort GET request when processing swap

### DIFF
--- a/src/components/SwapForm/RefreshButton/index.tsx
+++ b/src/components/SwapForm/RefreshButton/index.tsx
@@ -30,8 +30,9 @@ const IconButton = styled.button`
 type Props = {
   shouldDisable: boolean
   callback: () => void
+  abort: () => void
 }
-const RefreshButton: React.FC<Props> = ({ shouldDisable, callback }) => {
+const RefreshButton: React.FC<Props> = ({ shouldDisable, callback, abort }) => {
   const svgRef = useRef<SVGSVGElement>(null)
 
   useEffect(() => {
@@ -42,6 +43,8 @@ const RefreshButton: React.FC<Props> = ({ shouldDisable, callback }) => {
     }
 
     if (shouldDisable) {
+      abort()
+
       // reset svg animate duration to 0 and PAUSE animations
       element.setCurrentTime(0)
       element.pauseAnimations()
@@ -59,7 +62,7 @@ const RefreshButton: React.FC<Props> = ({ shouldDisable, callback }) => {
     return () => {
       clearInterval(interval)
     }
-  }, [callback, shouldDisable])
+  }, [callback, abort, shouldDisable])
 
   return (
     <IconButton


### PR DESCRIPTION
The problem is it still triggers a Get route request right before a Build route request. This is the root cause.

The best solution is not to trigger the Get request, but it's way too hard. So this PR aims to abort/cancel the Get request (after it's fired)

To do this:
1. Put abort() in the RefreshButton. This function is called when it's not allowed to get route
2. Debouce the fetcher function, instead of the trigger function
3. Set leading=true for the debounce option, so that the first request is invoked immidiately without delay 
4. When using abort(), AbortError is emitted. Need to skip this error