### PR TITLE
Abort GET requests when processing swap/debouncing

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-REACT_APP_AGGREGATOR_API=https://meta-aggregator.stg.kyberengineering.io
+REACT_APP_AGGREGATOR_API=https://meta-aggregator-api.kyberswap.com
 REACT_APP_AGGREGATOR_STATS_API=https://aggregator-stats.kyberswap.com
 REACT_APP_SENTRY_DNS=https://d94ee2d3c22043bdaec966758680b5a8@sentry.ops.kyberengineering.io/4
 
@@ -12,7 +12,7 @@ REACT_APP_REWARD_SERVICE_API=https://rewards.kyberswap.com/api/v1
 REACT_APP_PRICE_CHART_API=https://price-chart.kyberswap.com/api
 REACT_APP_PRICE_API=https://price.kyberswap.com
 
-REACT_APP_NOTIFICATION_API=https://notification.dev.kyberengineering.io/api
+REACT_APP_NOTIFICATION_API=https://notification.kyberswap.com/api
 
 REACT_APP_CAMPAIGN_BASE_URL=https://campaigns.kyberswap.com
 REACT_APP_TYPE_AND_SWAP_URL=https://type-swap.kyberswap.com/api
@@ -20,7 +20,7 @@ REACT_APP_TYPE_AND_SWAP_URL=https://type-swap.kyberswap.com/api
 REACT_APP_TRANSAK_URL=https://global.transak.com
 REACT_APP_TRANSAK_API_KEY=48949c0b-2d20-4e3a-a311-51ca91ae8c0d
 
-REACT_APP_KS_SETTING_API=https://ks-setting.dev.kyberengineering.io/api
+REACT_APP_KS_SETTING_API=https://ks-setting.kyberswap.com/api
 
 REACT_APP_GTM_ID=GTM-TRQCJ8F
 
@@ -32,4 +32,4 @@ REACT_APP_LIMIT_ORDER_API_READ=https://limit-order.kyberswap.com/read-ks/api
 
 # Kyber DAO Apis
 REACT_APP_KYBER_DAO_STATS_API=https://kyberswap-dao-stats.kyberengineering.io
-REACT_APP_NOTIFICATION_IGNORE_TEMPLATE_IDS=2,29
+REACT_APP_NOTIFICATION_IGNORE_TEMPLATE_IDS=2,16

--- a/src/components/CurrencyInputPanel/CurrencyInputPanelBridge.tsx
+++ b/src/components/CurrencyInputPanel/CurrencyInputPanelBridge.tsx
@@ -1,6 +1,6 @@
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Flex, Text } from 'rebass'
 
 import { ReactComponent as DropdownSVG } from 'assets/svg/down.svg'
@@ -60,10 +60,15 @@ export default function CurrencyInputPanelBridge({
 
   const currencyAddress: string = !currency ? '' : currency.isNative ? ETHER_ADDRESS : currency.wrapped.address
 
-  const { data: tokenPriceData, refetch } = useTokenPricesWithLoading(
-    currencyAddress ? [currencyAddress] : EMPTY_ARRAY,
-    currency?.chainId,
-  )
+  const tokenAddresses = useMemo(() => {
+    if (currencyAddress) {
+      return [currencyAddress]
+    }
+
+    return EMPTY_ARRAY
+  }, [currencyAddress])
+
+  const { data: tokenPriceData, refetch } = useTokenPricesWithLoading(tokenAddresses, currency?.chainId)
 
   const currencyValueInUSD = tokenPriceData?.[currencyAddress] * Number(value)
   const currencyValueString =

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -98,14 +98,15 @@ export const Container = styled.div<{ selected: boolean; hideInput: boolean; err
   border-radius: 16px;
   background-color: ${({ theme, hideInput }) => (hideInput ? 'transparent' : theme.buttonBlack)};
   padding: ${({ hideInput }) => (hideInput ? 0 : '0.75rem')};
+  border: 1px solid transparent;
   ${({ error, theme, $outline }) =>
     error
       ? css`
-          border: 1px solid ${theme.red};
+          border-color: ${theme.red};
         `
       : $outline
       ? css`
-          border: 1px solid ${theme.border};
+          border-color: ${theme.border};
         `
       : ''}
 `

--- a/src/components/SwapForm/RefreshButton/index.tsx
+++ b/src/components/SwapForm/RefreshButton/index.tsx
@@ -30,8 +30,9 @@ const IconButton = styled.button`
 type Props = {
   shouldDisable: boolean
   callback: () => void
+  abort: () => void
 }
-const RefreshButton: React.FC<Props> = ({ shouldDisable, callback }) => {
+const RefreshButton: React.FC<Props> = ({ shouldDisable, callback, abort }) => {
   const svgRef = useRef<SVGSVGElement>(null)
 
   useEffect(() => {
@@ -42,6 +43,8 @@ const RefreshButton: React.FC<Props> = ({ shouldDisable, callback }) => {
     }
 
     if (shouldDisable) {
+      abort()
+
       // reset svg animate duration to 0 and PAUSE animations
       element.setCurrentTime(0)
       element.pauseAnimations()
@@ -59,7 +62,7 @@ const RefreshButton: React.FC<Props> = ({ shouldDisable, callback }) => {
     return () => {
       clearInterval(interval)
     }
-  }, [callback, shouldDisable])
+  }, [callback, abort, shouldDisable])
 
   return (
     <IconButton

--- a/src/components/SwapForm/hooks/useGetRoute.ts
+++ b/src/components/SwapForm/hooks/useGetRoute.ts
@@ -1,6 +1,6 @@
 import { Currency, CurrencyAmount, WETH } from '@kyberswap/ks-sdk-core'
 import { debounce } from 'lodash'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import routeApi from 'services/route'
 import { GetRouteParams } from 'services/route/types/getRoute'
 
@@ -37,13 +37,42 @@ const useGetRoute = (args: Args) => {
   const { chargeFeeBy = '', feeReceiver = '', feeAmount = '' } = feeConfig || {}
   const isInBps = feeConfig?.isInBps !== undefined ? (feeConfig.isInBps ? '1' : '0') : ''
 
-  const triggerDebounced = useMemo(() => debounce(trigger, INPUT_DEBOUNCE_TIME), [trigger])
+  const currentRequestRef = useRef<any>()
+  const debouncedFuncRef = useRef<any>()
+
+  const getRoute = useCallback(
+    (params: GetRouteParams) => {
+      ;(Object.keys(params) as (keyof typeof params)[]).forEach(key => {
+        if (!params[key]) {
+          delete params[key]
+        }
+      })
+
+      const url = `${aggregatorDomain}/${NETWORKS_INFO[chainId].aggregatorRoute}/api/v1/routes`
+
+      currentRequestRef.current = trigger({
+        url,
+        params,
+      })
+    },
+    [aggregatorDomain, chainId, trigger],
+  )
+
+  const getRouteWithDebounce = useMemo(() => {
+    const debouncedFunc = debounce(getRoute, INPUT_DEBOUNCE_TIME, {
+      leading: true,
+      trailing: true,
+    })
+    debouncedFuncRef.current = debouncedFunc
+
+    return debouncedFunc
+  }, [getRoute])
 
   const fetcher = useCallback(async () => {
     const amountIn = parsedAmount?.quotient?.toString() || ''
 
     if (!currencyIn || !currencyOut || !amountIn || !parsedAmount?.currency?.equals(currencyIn)) {
-      return undefined
+      return
     }
 
     const tokenInAddress = getRouteTokenAddressParam(currencyIn)
@@ -64,37 +93,27 @@ const useGetRoute = (args: Args) => {
       feeReceiver,
     }
 
-    ;(Object.keys(params) as (keyof typeof params)[]).forEach(key => {
-      if (!params[key]) {
-        delete params[key]
-      }
-    })
-
-    const url = `${aggregatorDomain}/${NETWORKS_INFO[chainId].aggregatorRoute}/api/v1/routes`
-
-    triggerDebounced({
-      url,
-      params,
-    })
-
-    return undefined
+    getRouteWithDebounce(params)
   }, [
-    aggregatorDomain,
-    chainId,
     chargeFeeBy,
     currencyIn,
     currencyOut,
     dexes,
     feeAmount,
     feeReceiver,
+    getRouteWithDebounce,
     isInBps,
     isSaveGas,
     parsedAmount?.currency,
     parsedAmount?.quotient,
-    triggerDebounced,
   ])
 
-  return { fetcher, result }
+  const abort = useCallback(() => {
+    currentRequestRef.current?.abort()
+    debouncedFuncRef.current?.cancel()
+  }, [])
+
+  return { fetcher, abort, result }
 }
 
 export default useGetRoute

--- a/src/components/SwapForm/index.tsx
+++ b/src/components/SwapForm/index.tsx
@@ -1,4 +1,5 @@
 import { Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
+import { SerializedError } from '@reduxjs/toolkit'
 import { useEffect, useMemo, useState } from 'react'
 import { Box, Flex } from 'rebass'
 import { parseGetRouteResponse } from 'services/route/utils'
@@ -81,7 +82,11 @@ const SwapForm: React.FC<SwapFormProps> = props => {
 
   const isStablePairSwap = useCheckStablePairSwap(currencyIn, currencyOut)
 
-  const { fetcher: getRoute, result } = useGetRoute({
+  const {
+    fetcher: getRoute,
+    abort,
+    result,
+  } = useGetRoute({
     currencyIn,
     currencyOut,
     feeConfig,
@@ -91,7 +96,11 @@ const SwapForm: React.FC<SwapFormProps> = props => {
 
   const { data: getRouteRawResponse, isFetching: isGettingRoute, error: getRouteError } = result
   const getRouteResponse = useMemo(() => {
-    if (!getRouteRawResponse?.data || getRouteError || !currencyIn || !currencyOut) {
+    const serializedError = getRouteError as SerializedError | undefined
+    const isAbortError = serializedError?.name === 'AbortError'
+
+    // skip this check if it's AbortError
+    if (!getRouteRawResponse?.data || (serializedError && !isAbortError) || !currencyIn || !currencyOut) {
       return undefined
     }
 
@@ -169,6 +178,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
                     <RefreshButton
                       shouldDisable={!parsedAmount || parsedAmount.equalTo(0) || isProcessingSwap}
                       callback={getRoute}
+                      abort={abort}
                     />
                     <TradePrice price={routeSummary?.executionPrice} />
                   </>

--- a/src/pages/Bridge/ComfirmBridgeModal.tsx
+++ b/src/pages/Bridge/ComfirmBridgeModal.tsx
@@ -1,5 +1,6 @@
 import { Trans, t } from '@lingui/macro'
-import { memo, useCallback, useMemo } from 'react'
+import { rgba } from 'polished'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { X } from 'react-feather'
 import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
@@ -13,36 +14,94 @@ import { NETWORKS_INFO } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import { OutputBridgeInfo, useBridgeState } from 'state/bridge/hooks'
+import { ExternalLink } from 'theme'
 import { TransactionFlowState } from 'types'
 import { formatNumberWithPrecisionRange, shortenAddress } from 'utils'
 
+const Disclaimer = styled.div`
+  padding: 8px;
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  font-size: 10px;
+  line-height: 14px;
+  font-weight: 400;
+
+  border-radius: 16px;
+  background-color: ${({ theme }) => rgba(theme.buttonBlack, 0.35)};
+  color: ${({ theme }) => theme.text};
+  accent-color: ${({ theme }) => theme.primary};
+
+  cursor: pointer;
+  transition: background-color 100ms linear;
+
+  :hover {
+    background-color: ${({ theme }) => rgba(theme.buttonBlack, 0.5)};
+  }
+`
+
+const Multichain = () => {
+  return (
+    <ExternalLink href="https://multichain.org/" onClick={e => e.stopPropagation()}>
+      Multichain
+    </ExternalLink>
+  )
+}
+
 const Container = styled.div`
-  padding: 25px 30px;
+  padding: 20px;
   width: 100%;
 `
 const Row = styled.div`
-  line-height: 20px;
+  line-height: 16px;
   display: flex;
   justify-content: space-between;
   width: 100%;
 `
 
 const Value = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  font-size: 14px;
+  line-height: 20px;
   color: ${({ theme }) => theme.text};
   font-weight: 500;
-  display: flex;
-  gap: 5px;
-  align-items: center;
 `
+
 const Label = styled.div`
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
   color: ${({ theme }) => theme.subText};
-  font-weight: 500;
 `
+
+const SubLabel = styled.div`
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  color: ${({ theme }) => theme.subText};
+`
+
+const SubValue = styled.div`
+  display: flex;
+  align-items: center;
+
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
+  color: ${({ theme }) => theme.text};
+`
+
 const formatValue = (amount: string) =>
   !amount ? '' : formatNumberWithPrecisionRange(parseFloat(amount.toString()), 0, 10)
 
-const styleLogo = { width: 20, height: 20 }
-export default memo(function Disclaimer({
+const styleLogo = { width: 16, height: 16 }
+
+export default memo(function ConfirmBridgeModal({
   onSwap,
   onDismiss,
   outputInfo,
@@ -54,6 +113,7 @@ export default memo(function Disclaimer({
   swapState: TransactionFlowState
 }) {
   const theme = useTheme()
+  const [accepted, setAccepted] = useState(false)
   const { account, chainId } = useActiveWeb3React()
   const [{ chainIdOut, currencyIn, currencyOut }] = useBridgeState()
 
@@ -75,7 +135,7 @@ export default memo(function Disclaimer({
         content: (
           <Value>
             <NetworkLogo chainId={chainId} style={styleLogo} />
-            <Text>{chainId && NETWORKS_INFO?.[chainId]?.name}</Text>
+            <span>{chainId && NETWORKS_INFO?.[chainId]?.name}</span>
           </Value>
         ),
       },
@@ -84,7 +144,7 @@ export default memo(function Disclaimer({
         content: (
           <Value>
             {chainIdOut && <NetworkLogo chainId={chainIdOut} style={styleLogo} />}
-            {chainIdOut && <Text>{NETWORKS_INFO[chainIdOut].name}</Text>}
+            {chainIdOut && <span>{NETWORKS_INFO[chainIdOut].name}</span>}
           </Value>
         ),
       },
@@ -93,9 +153,9 @@ export default memo(function Disclaimer({
         content: (
           <Value>
             <CurrencyLogo currency={currencyOut} style={styleLogo} />
-            <Text>
+            <span>
               {formatValue(outputInfo?.outputAmount?.toString())} {currencyOut?.symbol}
-            </Text>
+            </span>
           </Value>
         ),
       },
@@ -103,7 +163,7 @@ export default memo(function Disclaimer({
         label: t`at this address`,
         content: account && (
           <Value>
-            <Text>{shortenAddress(chainId, account, 5)}</Text>
+            <span>{shortenAddress(chainId, account, 5)}</span>
             <CopyHelper toCopy={account} style={{ color: theme.subText }} />
           </Value>
         ),
@@ -117,15 +177,13 @@ export default memo(function Disclaimer({
         <TransactionErrorContent onDismiss={onDismiss} message={swapState.errorMessage} />
       ) : (
         <Container>
-          <Flex flexDirection={'column'} style={{ gap: 25 }}>
-            <Flex justifyContent={'space-between'}>
-              <Flex color={theme.text} alignItems="center" style={{ gap: 8 }}>
-                <Text fontSize={20}>{t`Review your transfer`}</Text>
-              </Flex>
+          <Flex flexDirection={'column'} style={{ gap: '16px' }}>
+            <Flex justifyContent={'space-between'} alignItems="center">
+              <Text color={theme.text} fontSize={20}>{t`Review your transfer`}</Text>
               <X onClick={onDismiss} style={{ cursor: 'pointer' }} color={theme.text} />
             </Flex>
 
-            <Flex style={{ gap: 20 }} flexDirection="column">
+            <Flex sx={{ gap: '12px' }} flexDirection="column">
               {listData.map(item => (
                 <Row key={item.label}>
                   <Label>{item.label}</Label>
@@ -138,36 +196,66 @@ export default memo(function Disclaimer({
               flexDirection={'column'}
               style={{
                 borderRadius: 16,
-                padding: '14px 18px',
+                padding: '12px',
                 border: `1px solid ${theme.border}`,
-                gap: 8,
-                fontSize: 13,
+                gap: '12px',
+                fontSize: '12px',
               }}
             >
               <Row>
-                <Label>
+                <SubLabel>
                   <Trans>Estimated Processing Time</Trans>
-                </Label>
-                <Value>{outputInfo.time}</Value>
+                </SubLabel>
+                <SubValue>{outputInfo.time}</SubValue>
               </Row>
               <Row>
-                <Label>
+                <SubLabel>
                   <Trans>Transaction Fee</Trans>
-                </Label>
-                <Value>{outputInfo.fee ? `~${outputInfo.fee} ${currencyIn?.symbol}` : '--'}</Value>
+                </SubLabel>
+                <SubValue>{outputInfo.fee ? `~${outputInfo.fee} ${currencyIn?.symbol}` : '--'}</SubValue>
               </Row>
             </Flex>
 
             <Text fontSize={12} fontStyle="italic" color={theme.subText}>
-              <Trans>Note: It may take upto 30 minutes for your transaction to show up under Transfer History.</Trans>
+              <Trans>Note: It may take upto 30 minutes for your transaction to show up under Transfer History</Trans>
             </Text>
-            <ButtonPrimary onClick={onSwap}>
+
+            <Disclaimer role="button" onClick={() => setAccepted(e => !e)}>
+              <input
+                onChange={() => {
+                  // empty
+                }}
+                type="checkbox"
+                checked={accepted}
+                style={{ height: '16px', width: '16px', cursor: 'pointer' }}
+              />
+              <span>
+                <Trans>
+                  You agree that KyberSwap is using <Multichain /> to facilitate transfer of tokens between chains, and
+                  in case of a security breach on Multichain, KyberSwap won&apos;t assume any liability for any losses
+                </Trans>
+              </span>
+            </Disclaimer>
+
+            <ButtonPrimary onClick={onSwap} disabled={!accepted}>
               <Trans>Transfer</Trans>
             </ButtonPrimary>
           </Flex>
         </Container>
       ),
-    [onDismiss, swapState.errorMessage, listData, onSwap, outputInfo, theme, currencyIn?.symbol],
+    [
+      accepted,
+      currencyIn?.symbol,
+      listData,
+      onDismiss,
+      onSwap,
+      outputInfo.fee,
+      outputInfo.time,
+      swapState.errorMessage,
+      theme.border,
+      theme.subText,
+      theme.text,
+    ],
   )
 
   return (

--- a/src/services/route/index.ts
+++ b/src/services/route/index.ts
@@ -7,6 +7,7 @@ import { GetRouteParams, GetRouteResponse } from './types/getRoute'
 const routeApi = createApi({
   reducerPath: 'routeApi',
   baseQuery: fetchBaseQuery({ baseUrl: '' }),
+  tagTypes: ['GetRoute'],
   endpoints: builder => ({
     getRoute: builder.query<
       GetRouteResponse,
@@ -19,6 +20,7 @@ const routeApi = createApi({
         url,
         params,
       }),
+      keepUnusedDataFor: 5,
     }),
   }),
 })


### PR DESCRIPTION
The problem is it still triggers a Get route request right before a Build route request. This is the root cause.

The best solution is not to trigger the Get request, but it's way too hard. So this PR aims to abort/cancel the Get request (after it's fired)

To do this:
1. Put abort() in the RefreshButton. This function is called when it's not allowed to get route
2. Separate getRoute. It takes a GetRouteParams object and trigger the request.
3. Debouce the getRoute function, instead of the trigger function. @nguyenhoaidanh suggested debouncing `amountIn`, but I think we need to debounce the getRoute function. Several requests will be fired when user checks/unchecks a dex => needs to debounce this also.
4. Set leading=true for the debounce option, so that the first request is invoked immidiately without delay 
5. When using abort(), AbortError is emitted. Need to skip this error

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19758667/227840408-4308fa0e-1ee7-47e6-9352-9df327fff63a.png) | ![image](https://user-images.githubusercontent.com/19758667/227842208-337f8791-0f1e-4ef5-b49c-4c8a31e04d4d.png) |



