### PR TITLE
fix: menu flyout

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -70,14 +70,6 @@ const MenuItem = styled.li`
   color: ${({ theme }) => theme.subText};
   font-size: 15px;
 
-  :hover {
-    color: ${({ theme }) => theme.text};
-    cursor: pointer;
-    a {
-      color: ${({ theme }) => theme.text};
-    }
-  }
-
   svg {
     margin-right: 8px;
     height: 16px;

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -299,7 +299,7 @@ export default function Menu() {
       }
     }
     return
-  })
+  }, [])
 
   return (
     <StyledMenu>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -292,13 +292,16 @@ export default function Menu() {
   useEffect(() => {
     const wrapper = wrapperNode.current
     if (wrapper) {
+      const abortController = new AbortController()
       const onScroll = () => {
+        if (abortController.signal.aborted) return
         setShowScroll(Math.abs(wrapper.offsetHeight + wrapper.scrollTop - wrapper.scrollHeight) > 10) //no need to show scroll down when scrolled to last 10px
       }
       onScroll()
       wrapper.addEventListener('scroll', onScroll)
       window.addEventListener('resize', onScroll)
       return () => {
+        abortController.abort()
         wrapper.removeEventListener('scroll', onScroll)
         window.removeEventListener('resize', onScroll)
       }

--- a/src/components/MenuFlyout/index.tsx
+++ b/src/components/MenuFlyout/index.tsx
@@ -17,28 +17,25 @@ import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import useTheme from 'hooks/useTheme'
 
 const Arrow = css`
-  & > div {
-    position: relative;
-    :after {
-      bottom: 100%;
-      right: 0;
-      top: -40px;
-      border: solid transparent;
-      content: '';
-      height: 0;
-      width: 0;
-      position: absolute;
-      pointer-events: none;
-      border-bottom-color: ${({ theme }) => theme.tableHeader};
-      border-width: 10px;
-      margin-left: -10px;
-    }
+  :after {
+    bottom: 100%;
+    right: 20px;
+    top: -20px;
+    border: solid transparent;
+    content: '';
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    border-bottom-color: ${({ theme }) => theme.tableHeader};
+    border-width: 10px;
+    margin-left: -10px;
   }
   ${({ theme }) => theme.mediaWidth.upToLarge`
-    & > div:after {
-      top: calc(100% + 20px);
+    :after {
+      top: 100%;
       border-top-color: ${({ theme }) => theme.tableHeader};
-      border-bottom-color: transparent
+      border-bottom-color: transparent;
       border-width: 10px;
       margin-left: -10px;
     }


### PR DESCRIPTION
# Why dis PR
Dis PR fix 3 issue:
  1. When Menu is too long, it overflow the screen -> set menu `overflow-y: scroll`

| Prod | Fix |
| --- | --- |
| <img width="258" alt="image" src="https://github.com/KyberNetwork/kyberswap-interface/assets/23650671/7c668d05-ccaf-45ee-8ff9-fdee1a7c9beb"> | <img width="244" alt="image" src="https://github.com/KyberNetwork/kyberswap-interface/assets/23650671/4988546d-fe5e-479a-be61-c551ddd0d278"> |

  3. The arrow of menu point to it's parent stay at wrong position.

| Prod | Fix |
| --- | --- |
| <img width="247" alt="image" src="https://github.com/KyberNetwork/kyberswap-interface/assets/23650671/ee729fb6-dc7c-478d-9a1a-1ff2fcf0f69e"> | <img width="704" alt="image" src="https://github.com/KyberNetwork/kyberswap-interface/assets/23650671/9ed536f4-b919-423a-92ad-f6099924162d"> |

  4. Highlight hover menu item correctly

| Prod | Fix |
| --- | --- |
| <img width="244" alt="image" src="https://github.com/KyberNetwork/kyberswap-interface/assets/23650671/52456d88-63a4-4bc4-83a6-62d42ee07a7d"> | <img width="247" alt="image" src="https://github.com/KyberNetwork/kyberswap-interface/assets/23650671/1effd859-2c81-4eb1-a2e4-425154770599"> |

