### PR TITLE
Prevent users from dismissing token warning modal

### DIFF
--- a/src/components/TokenWarningModal/index.tsx
+++ b/src/components/TokenWarningModal/index.tsx
@@ -3,19 +3,21 @@ import { Currency, Token } from '@kyberswap/ks-sdk-core'
 import Modal from 'components/Modal'
 import { ImportToken } from 'components/SearchModal/ImportToken'
 
+const noop = () => {
+  // empty
+}
+
 export default function TokenWarningModal({
   isOpen,
   tokens,
   onConfirm,
-  onDismiss,
 }: {
   isOpen: boolean
   tokens: Token[]
   onConfirm: (token: Currency[]) => void
-  onDismiss: () => void
 }) {
   return (
-    <Modal isOpen={isOpen} onDismiss={onDismiss} maxHeight={100}>
+    <Modal isOpen={isOpen} onDismiss={noop} maxHeight={100}>
       <ImportToken tokens={tokens} handleCurrencySelect={onConfirm} enterToImport={isOpen} />
     </Modal>
   )

--- a/src/pages/SwapV2/index.tsx
+++ b/src/pages/SwapV2/index.tsx
@@ -650,7 +650,6 @@ export default function Swap() {
         isOpen={isShowModalImportToken}
         tokens={importTokensNotInDefault}
         onConfirm={handleConfirmTokenWarning}
-        onDismiss={handleDismissTokenWarning}
       />
       <PageWrapper>
         <Banner />

--- a/src/pages/SwapV3/index.tsx
+++ b/src/pages/SwapV3/index.tsx
@@ -268,7 +268,6 @@ export default function Swap() {
         isOpen={isShowModalImportToken}
         tokens={importTokensNotInDefault}
         onConfirm={handleConfirmTokenWarning}
-        onDismiss={handleDismissTokenWarning}
       />
       <PageWrapper>
         <Banner />

--- a/src/pages/SwapV3/index.tsx
+++ b/src/pages/SwapV3/index.tsx
@@ -156,7 +156,6 @@ export default function Swap() {
   }, [isLimitPage])
 
   useDefaultsFromURLSearch()
-  const [dismissTokenWarning, setDismissTokenWarning] = useState<boolean>(false)
 
   const theme = useTheme()
 
@@ -201,8 +200,6 @@ export default function Swap() {
   const handleDismissTokenWarning = useCallback(() => {
     if (showingPairSuggestionImport) {
       setShowingPairSuggestionImport(false)
-    } else {
-      setDismissTokenWarning(true)
     }
   }, [showingPairSuggestionImport])
 
@@ -248,7 +245,7 @@ export default function Swap() {
   const shouldRenderTokenInfo = isShowTokenInfoSetting && currencyIn && currencyOut && isPairInWhiteList && isSwapPage
 
   const isShowModalImportToken =
-    isLoadedTokenDefault && importTokensNotInDefault.length > 0 && (!dismissTokenWarning || showingPairSuggestionImport)
+    isLoadedTokenDefault && (importTokensNotInDefault.length > 0 || showingPairSuggestionImport)
 
   const tradeRouteComposition = useMemo(() => {
     return getTradeComposition(chainId, routeSummary?.parsedAmountIn, undefined, routeSummary?.route, defaultTokens)


### PR DESCRIPTION
1. There's a bug when user doesn't click I understand in the Token Warning modal. Look at the bug for more info
2. Another one is that: after user clicks "I understand" to import the first token, the token warning modal won't show anymore when user selects a not-yet-imported token