### PR TITLE
Redirect to / for wrong formatted urls

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -167,7 +167,7 @@ const RoutesWithNetworkPrefix = () => {
 
   const chainInfoFromParam = Object.values(NETWORKS_INFO_CONFIG).find(info => info.route === network)
   if (!chainInfoFromParam) {
-    return <Navigate to={location.pathname.replace(network, networkInfo.route)} replace />
+    return <Navigate to={'/'} replace />
   }
 
   return (


### PR DESCRIPTION
If user enters: `kyberswap.com/ swap/polygon` (notice there's a space before `swap`), this is what hapens:
- in browser, it shows: `kyberswap.com/%20swap/polygon`
- the param returned from `useParams` (from `react-router-dom`) is ` swap`
- location.pathname from `useLocation` is `/%20swap/polygon`