### PR TITLE
Encode URI component before replacing in URL

### DIFF
--- a/src/hooks/web3/useSyncNetworkParamWithStore.ts
+++ b/src/hooks/web3/useSyncNetworkParamWithStore.ts
@@ -63,7 +63,10 @@ export function useSyncNetworkParamWithStore() {
       triedSync.current &&
       triedEager
     ) {
-      navigate({ ...location, pathname: location.pathname.replace(networkParam, networkInfo.route) }, { replace: true })
+      navigate(
+        { ...location, pathname: location.pathname.replace(encodeURIComponent(networkParam), networkInfo.route) },
+        { replace: true },
+      )
     }
   }, [location, networkInfo.route, navigate, triedEager, networkParam, requestingNetwork])
 }


### PR DESCRIPTION
The current chain is Ethereum. Cases covered:
- `https://kyberswap.com/ swap/ethereum` -> `https://kyberswap.com/`
- `https://kyberswap.com/%20swap/ethereum` -> `https://kyberswap.com/`
- `https://kyberswap.com/%20swap/polygon` -> `https://kyberswap.com/`
- `https://kyberswap.com/%20swap/aaaaaaaa` -> `https://kyberswap.com/`
- `https://kyberswap.com/swap/aaaaaaaa` -> `https://kyberswap.com/`