### PR TITLE
Separate slippage tolerance settings between Liquidity Actions & Swap

### DIFF
--- a/src/components/SwapForm/SlippageSetting.tsx
+++ b/src/components/SwapForm/SlippageSetting.tsx
@@ -23,13 +23,12 @@ type Props = {
   isStablePairSwap: boolean
   rightComponent?: ReactNode
   tooltip?: ReactNode
-  isCrossChain?: boolean
 }
-const SlippageSetting = ({ isStablePairSwap, rightComponent, tooltip, isCrossChain }: Props) => {
+const SlippageSetting = ({ isStablePairSwap, rightComponent, tooltip }: Props) => {
   const theme = useTheme()
   const [expanded, setExpanded] = useState(false)
 
-  const { setRawSlippage, rawSlippage, isSlippageControlPinned } = useSlippageSettingByPage(isCrossChain)
+  const { rawSlippage, setRawSlippage, isSlippageControlPinned } = useSlippageSettingByPage()
   const defaultRawSlippage = getDefaultSlippage(isStablePairSwap)
 
   const isWarningSlippage = checkWarningSlippage(rawSlippage, isStablePairSwap)

--- a/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/SlippageSetting.tsx
@@ -29,12 +29,10 @@ const Message = styled.div`
 
 type Props = {
   shouldShowPinButton?: boolean
-  isCrossChain?: boolean
 }
 
-const SlippageSetting: React.FC<Props> = ({ shouldShowPinButton = true, isCrossChain = false }) => {
-  const { rawSlippage, setRawSlippage, isSlippageControlPinned, togglePinSlippage } =
-    useSlippageSettingByPage(isCrossChain)
+const SlippageSetting: React.FC<Props> = ({ shouldShowPinButton = true }) => {
+  const { rawSlippage, setRawSlippage, isSlippageControlPinned, togglePinSlippage } = useSlippageSettingByPage()
 
   const isStablePairSwap = useCheckStablePairSwap()
   const slippageStatus = checkRangeSlippage(rawSlippage, isStablePairSwap)

--- a/src/components/swapv2/SwapSettingsPanel/index.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/index.tsx
@@ -112,7 +112,7 @@ const SettingsPanel: React.FC<Props> = ({
                 <Trans>Advanced Settings</Trans>
               </span>
 
-              <SlippageSetting isCrossChain={isCrossChainPage} />
+              <SlippageSetting />
               {isSwapPage && <TransactionTimeLimitSetting />}
               <DegenModeSetting showConfirmation={showConfirmation} setShowConfirmation={setShowConfirmation} />
               {isSwapPage && (

--- a/src/hooks/usePageLocation.ts
+++ b/src/hooks/usePageLocation.ts
@@ -1,0 +1,16 @@
+import { useLocation } from 'react-router-dom'
+
+import { APP_PATHS } from 'constants/index'
+
+const SWAP_PAGE_URLS = [APP_PATHS.SWAP, APP_PATHS.PARTNER_SWAP, APP_PATHS.LIMIT, APP_PATHS.CROSS_CHAIN]
+
+const usePageLocation = () => {
+  const location = useLocation()
+
+  return {
+    isSwapPage: SWAP_PAGE_URLS.some(url => location.pathname.startsWith(url)),
+    isCrossChain: location.pathname.startsWith(APP_PATHS.CROSS_CHAIN),
+  }
+}
+
+export default usePageLocation

--- a/src/pages/CrossChain/SwapForm/index.tsx
+++ b/src/pages/CrossChain/SwapForm/index.tsx
@@ -349,7 +349,6 @@ export default function SwapForm() {
         </div>
 
         <SlippageSetting
-          isCrossChain
           isStablePairSwap={isStablePairSwap}
           tooltip={
             <Text>

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -22,6 +22,9 @@ export interface SerializedPair {
 export const updateUserDegenMode = createAction<{ userDegenMode: boolean; isStablePairSwap: boolean }>(
   'user/updateUserDegenMode',
 )
+export const updatePoolDegenMode = createAction<{ poolDegenMode: boolean; isStablePairSwap: boolean }>(
+  'user/updatePoolDegenMode',
+)
 export const toggleUseAggregatorForZap = createAction('user/toggleUseAggregatorForZap')
 export const updateUserLocale = createAction<{ userLocale: SupportedLocale }>('user/updateUserLocale')
 export const updateUserSlippageTolerance = createAction<{ userSlippageTolerance: number }>(

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -27,6 +27,9 @@ export const updateUserLocale = createAction<{ userLocale: SupportedLocale }>('u
 export const updateUserSlippageTolerance = createAction<{ userSlippageTolerance: number }>(
   'user/updateUserSlippageTolerance',
 )
+export const updatePoolSlippageTolerance = createAction<{ poolSlippageTolerance: number }>(
+  'user/updatePoolSlippageTolerance',
+)
 
 export const updateUserDeadline = createAction<{ userDeadline: number }>('user/updateUserDeadline')
 export const addSerializedToken = createAction<{ serializedToken: SerializedToken }>('user/addSerializedToken')

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -124,23 +124,37 @@ export function useIsAcceptedTerm(): [boolean, (isAcceptedTerm: boolean) => void
 }
 
 export function useDegenModeManager(): [boolean, () => void] {
+  const [swapDegenMode, toggleSwapDegenMode] = useSwapDegenMode()
+  const [poolDegenMode, togglePoolDegenMode] = usePoolDegenMode()
+
+  const { isSwapPage } = usePageLocation()
+  if (isSwapPage) {
+    return [swapDegenMode, toggleSwapDegenMode]
+  }
+  return [poolDegenMode, togglePoolDegenMode]
+}
+
+export function useSwapDegenMode(): [boolean, () => void] {
   const dispatch = useDispatch<AppDispatch>()
   const isStablePairSwap = useCheckStablePairSwap()
 
-  const swapDegenMode = useSelector<AppState, AppState['user']['userDegenMode']>(state => state.user.userDegenMode)
-  const toggleSwapDegenMode = useCallback(() => {
-    dispatch(updateUserDegenMode({ userDegenMode: !swapDegenMode, isStablePairSwap }))
-  }, [swapDegenMode, dispatch, isStablePairSwap])
+  const userDegenMode = useSelector<AppState, AppState['user']['userDegenMode']>(state => state.user.userDegenMode)
+  const toggleUserDegenMode = useCallback(() => {
+    dispatch(updateUserDegenMode({ userDegenMode: !userDegenMode, isStablePairSwap }))
+  }, [userDegenMode, dispatch, isStablePairSwap])
+
+  return [userDegenMode, toggleUserDegenMode]
+}
+
+export function usePoolDegenMode(): [boolean, () => void] {
+  const dispatch = useDispatch<AppDispatch>()
+  const isStablePairSwap = useCheckStablePairSwap()
 
   const poolDegenMode = useSelector<AppState, AppState['user']['poolDegenMode']>(state => state.user.poolDegenMode)
   const togglePoolDegenMode = useCallback(() => {
     dispatch(updatePoolDegenMode({ poolDegenMode: !poolDegenMode, isStablePairSwap }))
   }, [poolDegenMode, dispatch, isStablePairSwap])
 
-  const { isSwapPage } = usePageLocation()
-  if (isSwapPage) {
-    return [swapDegenMode, toggleSwapDegenMode]
-  }
   return [poolDegenMode, togglePoolDegenMode]
 }
 
@@ -157,25 +171,28 @@ export function useAggregatorForZapSetting(): [boolean, () => void] {
   return [isUseAggregatorForZap === undefined ? true : isUseAggregatorForZap, toggle]
 }
 
-export function useUserSlippageTolerance(useLocation = true): [number, (slippage: number) => void] {
-  const dispatch = useDispatch<AppDispatch>()
+export function useUserSlippageTolerance(): [number, (slippage: number) => void] {
+  const [swapSlippageTolerance, setSwapSlippageTolerance] = useSwapSlippageTolerance()
   const [poolSlippageTolerance, setPoolSlippageTolerance] = usePoolSlippageTolerance()
 
+  const { isSwapPage } = usePageLocation()
+  if (isSwapPage) {
+    return [swapSlippageTolerance, setSwapSlippageTolerance]
+  }
+  return [poolSlippageTolerance, setPoolSlippageTolerance]
+}
+
+export function useSwapSlippageTolerance(): [number, (slippage: number) => void] {
+  const dispatch = useDispatch<AppDispatch>()
   const userSlippageTolerance = useSelector<AppState, AppState['user']['userSlippageTolerance']>(state => {
     return state.user.userSlippageTolerance
   })
-
   const setUserSlippageTolerance = useCallback(
     (userSlippageTolerance: number) => {
       dispatch(updateUserSlippageTolerance({ userSlippageTolerance }))
     },
     [dispatch],
   )
-
-  const { isSwapPage } = usePageLocation()
-  if (useLocation && !isSwapPage) {
-    return [poolSlippageTolerance, setPoolSlippageTolerance]
-  }
   return [userSlippageTolerance, setUserSlippageTolerance]
 }
 
@@ -184,14 +201,12 @@ export function usePoolSlippageTolerance(): [number, (slippage: number) => void]
   const poolSlippageTolerance = useSelector<AppState, AppState['user']['poolSlippageTolerance']>(state => {
     return state.user.poolSlippageTolerance
   })
-
   const setPoolSlippageTolerance = useCallback(
     (poolSlippageTolerance: number) => {
       dispatch(updatePoolSlippageTolerance({ poolSlippageTolerance }))
     },
     [dispatch],
   )
-
   return [poolSlippageTolerance, setPoolSlippageTolerance]
 }
 

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -35,6 +35,7 @@ import {
   toggleUseAggregatorForZap,
   updateAcceptedTermVersion,
   updateChainId,
+  updatePoolSlippageTolerance,
   updateTokenAnalysisSettings,
   updateUserDeadline,
   updateUserDegenMode,
@@ -66,8 +67,9 @@ export interface UserState {
   userDegenModeAutoDisableTimestamp: number
   useAggregatorForZap: boolean
 
-  // user defined slippage tolerance in bips, used in all txns
-  userSlippageTolerance: number
+  // user defined slippage tolerance in bips, used in SWAP page
+  userSlippageTolerance: number // For SWAP page
+  poolSlippageTolerance: number // For POOL and other pages
 
   // deadline set by user in minutes, used in all txns
   userDeadline: number
@@ -154,6 +156,7 @@ const initialState: UserState = {
   userDegenModeAutoDisableTimestamp: 0,
   userLocale: null,
   userSlippageTolerance: INITIAL_ALLOWED_SLIPPAGE,
+  poolSlippageTolerance: INITIAL_ALLOWED_SLIPPAGE,
   userDeadline: DEFAULT_DEADLINE_FROM_NOW,
   tokens: {},
   pairs: {},
@@ -236,6 +239,10 @@ export default createReducer(initialState, builder =>
     })
     .addCase(updateUserSlippageTolerance, (state, action) => {
       state.userSlippageTolerance = action.payload.userSlippageTolerance
+      state.timestamp = currentTimestamp()
+    })
+    .addCase(updatePoolSlippageTolerance, (state, action) => {
+      state.poolSlippageTolerance = action.payload.poolSlippageTolerance
       state.timestamp = currentTimestamp()
     })
     .addCase(updateUserDeadline, (state, action) => {

--- a/src/state/user/updater.tsx
+++ b/src/state/user/updater.tsx
@@ -5,31 +5,65 @@ import { useInterval } from 'react-use'
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP, MAX_NORMAL_SLIPPAGE_IN_BIPS } from 'constants/index'
 import { AppDispatch, AppState } from 'state/index'
 import { useCheckStablePairSwap } from 'state/swap/hooks'
-import { useUserSlippageTolerance } from 'state/user/hooks'
+import { usePoolSlippageTolerance, useUserSlippageTolerance } from 'state/user/hooks'
 
-import { updateUserDegenMode } from './actions'
+import { updatePoolDegenMode, updateUserDegenMode } from './actions'
 
 export default function Updater(): null {
   const dispatch = useDispatch<AppDispatch>()
-  const degenMode = useSelector<AppState, AppState['user']['userDegenMode']>(state => state.user.userDegenMode)
-  const userDegenModeAutoDisableTimestamp = useSelector<
+  const isStablePairSwap = useCheckStablePairSwap()
+
+  const swapDegenMode = useSelector<AppState, AppState['user']['userDegenMode']>(state => state.user.userDegenMode)
+  const swapDegenModeAutoDisableTimestamp = useSelector<
     AppState,
     AppState['user']['userDegenModeAutoDisableTimestamp']
   >(state => state.user.userDegenModeAutoDisableTimestamp)
-  const isStablePairSwap = useCheckStablePairSwap()
-  const [rawSlippage, setRawSlippage] = useUserSlippageTolerance()
 
-  const autoDisableDegenMode = useCallback(() => {
-    if (degenMode && userDegenModeAutoDisableTimestamp <= Date.now()) {
+  const poolDegenMode = useSelector<AppState, AppState['user']['poolDegenMode']>(state => state.user.poolDegenMode)
+  const poolDegenModeAutoDisableTimestamp = useSelector<
+    AppState,
+    AppState['user']['poolDegenModeAutoDisableTimestamp']
+  >(state => state.user.poolDegenModeAutoDisableTimestamp)
+
+  const [swapSlippageTolerance, setSwapSlippageTolerance] = useUserSlippageTolerance(false)
+  const [poolSlippageTolerance, setPoolSlippageTolerance] = usePoolSlippageTolerance()
+
+  const autoDisableSwapDegenMode = useCallback(() => {
+    if (swapDegenMode && swapDegenModeAutoDisableTimestamp <= Date.now()) {
       dispatch(updateUserDegenMode({ userDegenMode: false, isStablePairSwap }))
-      if (rawSlippage > MAX_NORMAL_SLIPPAGE_IN_BIPS) {
-        if (isStablePairSwap) setRawSlippage(DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP)
-        else setRawSlippage(DEFAULT_SLIPPAGE)
+      if (swapSlippageTolerance > MAX_NORMAL_SLIPPAGE_IN_BIPS) {
+        if (isStablePairSwap) setSwapSlippageTolerance(DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP)
+        else setSwapSlippageTolerance(DEFAULT_SLIPPAGE)
       }
     }
-  }, [degenMode, dispatch, isStablePairSwap, rawSlippage, setRawSlippage, userDegenModeAutoDisableTimestamp])
+  }, [
+    swapDegenMode,
+    dispatch,
+    isStablePairSwap,
+    swapSlippageTolerance,
+    setSwapSlippageTolerance,
+    swapDegenModeAutoDisableTimestamp,
+  ])
 
-  useInterval(autoDisableDegenMode, 1_000)
+  const autoDisablePoolDegenMode = useCallback(() => {
+    if (poolDegenMode && poolDegenModeAutoDisableTimestamp <= Date.now()) {
+      dispatch(updatePoolDegenMode({ poolDegenMode: false, isStablePairSwap }))
+      if (poolSlippageTolerance > MAX_NORMAL_SLIPPAGE_IN_BIPS) {
+        if (isStablePairSwap) setPoolSlippageTolerance(DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP)
+        else setPoolSlippageTolerance(DEFAULT_SLIPPAGE)
+      }
+    }
+  }, [
+    poolDegenMode,
+    dispatch,
+    isStablePairSwap,
+    poolSlippageTolerance,
+    setPoolSlippageTolerance,
+    poolDegenModeAutoDisableTimestamp,
+  ])
+
+  useInterval(autoDisableSwapDegenMode, 1_000)
+  useInterval(autoDisablePoolDegenMode, 1_000)
 
   return null
 }

--- a/src/state/user/updater.tsx
+++ b/src/state/user/updater.tsx
@@ -5,7 +5,7 @@ import { useInterval } from 'react-use'
 import { DEFAULT_SLIPPAGE, DEFAULT_SLIPPAGE_STABLE_PAIR_SWAP, MAX_NORMAL_SLIPPAGE_IN_BIPS } from 'constants/index'
 import { AppDispatch, AppState } from 'state/index'
 import { useCheckStablePairSwap } from 'state/swap/hooks'
-import { usePoolSlippageTolerance, useUserSlippageTolerance } from 'state/user/hooks'
+import { usePoolSlippageTolerance, useSwapSlippageTolerance } from 'state/user/hooks'
 
 import { updatePoolDegenMode, updateUserDegenMode } from './actions'
 
@@ -25,7 +25,7 @@ export default function Updater(): null {
     AppState['user']['poolDegenModeAutoDisableTimestamp']
   >(state => state.user.poolDegenModeAutoDisableTimestamp)
 
-  const [swapSlippageTolerance, setSwapSlippageTolerance] = useUserSlippageTolerance(false)
+  const [swapSlippageTolerance, setSwapSlippageTolerance] = useSwapSlippageTolerance()
   const [poolSlippageTolerance, setPoolSlippageTolerance] = usePoolSlippageTolerance()
 
   const autoDisableSwapDegenMode = useCallback(() => {


### PR DESCRIPTION
https://team-kyber.atlassian.net/browse/KEP-1837

Separate **slippage** tolerance settings between Liquidity Actions (Create, Add, Increase, Remove) & Swap Action.

-> Add `poolSlippageTolerance` state separately from `userSlippageTolerance`, in the **user** reducer

https://team-kyber.atlassian.net/browse/KEP-1931
Separate **degen mode** as well

-> Add `poolDegenMode` state separately from `userDegenMode`