### PR TITLE
keep old route noti center + don't allow change email when sign in email

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -176,6 +176,8 @@ export const APP_PATHS = {
   IAM_LOGIN: '/login',
   IAM_LOGOUT: '/logout',
   IAM_CONSENT: '/consent',
+
+  DEPRECATED_NOTI_CENTER: '/notification-center/overview',
 } as const
 
 export const TERM_FILES_PATH = {

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -26,6 +26,7 @@ import { useAutoLogin } from 'hooks/useLogin'
 import { useGlobalMixpanelEvents } from 'hooks/useMixpanel'
 import useSessionExpiredGlobal from 'hooks/useSessionExpire'
 import { useSyncNetworkParamWithStore } from 'hooks/web3/useSyncNetworkParamWithStore'
+import { PROFILE_MANAGE_ROUTES } from 'pages/NotificationCenter/const'
 import { RedirectPathToSwapV3Network } from 'pages/SwapV3/redirects'
 import KyberAIExplore from 'pages/TrueSightV2'
 import TruesightFooter from 'pages/TrueSightV2/components/TruesightFooter'
@@ -365,6 +366,14 @@ export default function App() {
                   element={
                     <ProtectedRoute>
                       <NotificationCenter />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={APP_PATHS.DEPRECATED_NOTI_CENTER}
+                  element={
+                    <ProtectedRoute>
+                      <NotificationCenter redirectRoute={PROFILE_MANAGE_ROUTES.PREFERENCE} />
                     </ProtectedRoute>
                   }
                 />

--- a/src/pages/NotificationCenter/NotificationPreference/index.tsx
+++ b/src/pages/NotificationCenter/NotificationPreference/index.tsx
@@ -22,6 +22,7 @@ import InputEmailWithVerification from 'pages/NotificationCenter/NotificationPre
 import { PROFILE_MANAGE_ROUTES } from 'pages/NotificationCenter/const'
 import { useNotify } from 'state/application/hooks'
 import { useSessionInfo } from 'state/authen/hooks'
+import { useSignedAccountInfo } from 'state/profile/hooks'
 import { useIsWhiteListKyberAI } from 'state/user/hooks'
 import { pushUnique } from 'utils'
 import { isEmailValid } from 'utils/string'
@@ -141,6 +142,7 @@ function NotificationPreference({ toggleModal = noop }: { toggleModal?: () => vo
   const { account } = useActiveWeb3React()
   const { userInfo, isLogin } = useSessionInfo()
   const { isWhiteList } = useIsWhiteListKyberAI()
+  const { isSignInEmail } = useSignedAccountInfo()
 
   const { inputEmail, errorInput, onChangeEmail, reset } = useValidateEmail(userInfo?.email)
   const [isShowVerify, setIsShowVerify] = useState(false)
@@ -377,6 +379,7 @@ function NotificationPreference({ toggleModal = noop }: { toggleModal?: () => vo
           isVerifiedEmail={!!isVerifiedEmail}
           isShowVerify={isShowVerify}
           onDismissVerifyModal={onDismissVerifyModal}
+          disabled={isSignInEmail}
         />
         {errorInput && (
           <Label style={{ color: errorInput ? theme.red : theme.border, margin: '7px 0px 0px 0px' }}>

--- a/src/pages/NotificationCenter/Profile/index.tsx
+++ b/src/pages/NotificationCenter/Profile/index.tsx
@@ -131,7 +131,7 @@ export default function Profile() {
   const [nickname, setNickName] = useState('')
   const { signOut } = useLogin()
   const navigate = useNavigate()
-  const { isSignInEth, signedAccount, isSigInGuest } = useSignedAccountInfo()
+  const { isSignInEth, signedAccount, isSigInGuest, isSignInEmail } = useSignedAccountInfo()
   const { totalGuest } = useProfileInfo()
   const canSignOut = !isSigInGuest || (isSigInGuest && totalGuest > 1)
 
@@ -297,6 +297,7 @@ export default function Profile() {
                 isVerifiedEmail={!!isVerifiedEmail}
                 isShowVerify={isShowVerify}
                 onDismissVerifyModal={onDismissVerifyModal}
+                disabled={isSignInEmail}
               />
             </FormGroup>
           </LeftColum>

--- a/src/pages/NotificationCenter/index.tsx
+++ b/src/pages/NotificationCenter/index.tsx
@@ -96,8 +96,9 @@ const RightColumn = styled.div`
   `}
 `
 
-function NotificationCenter() {
+function NotificationCenter({ redirectRoute }: { redirectRoute?: PROFILE_MANAGE_ROUTES }) {
   const isMobile = useMedia(`(max-width: ${MEDIA_WIDTHS.upToMedium}px)`)
+
   return (
     <PageWrapper>
       <HeaderWrapper>
@@ -149,7 +150,11 @@ function NotificationCenter() {
 
             <Route
               path="*"
-              element={<Navigate to={`${APP_PATHS.PROFILE_MANAGE}${PROFILE_MANAGE_ROUTES.ALL_NOTIFICATION}`} />}
+              element={
+                <Navigate
+                  to={`${APP_PATHS.PROFILE_MANAGE}${redirectRoute || PROFILE_MANAGE_ROUTES.ALL_NOTIFICATION}`}
+                />
+              }
             />
           </Routes>
         </RightColumn>

--- a/src/state/profile/hooks.ts
+++ b/src/state/profile/hooks.ts
@@ -197,6 +197,7 @@ export const useSignedAccountInfo = () => {
     isSigInGuest,
     isSignInGuestDefault,
     isSignInEth,
+    isSignInEmail,
   }
 }
 


### PR DESCRIPTION
- keep old route noti center:
-- because many email template use old link, this pr will support to keep old route:
 `https://kyberswap.com/notification-center/overview` 
 => redirect to `https://kyberswap.com/manage/notification/preferences`

- don't allow change email when sign in email