### PR TITLE
docs: ✏️ Update README.md, add build dependencies command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ To access the KyberSwap Interface, visit [kyberswap.com](https://kyberswap.com/)
 pnpm i
 ```
 
+### Build Dependencies
+
+```bash
+pnpm build-package
+```
+
 ### Run
 
 ```bash


### PR DESCRIPTION
When initiating the project, I identified an issue: if we only install the dependencies without executing the build operation for the dependent base components, the project will throw an error stating that some essential dependencies cannot be found. 

Therefore, I have added an additional step in the documentation to clarify this build requirement, ensuring the project can start successfully without dependency-related errors.