### PR TITLE
refactor: improve optimex flow

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/OptimexAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/OptimexAdapter.ts
@@ -61,6 +61,60 @@ export class OptimexAdapter extends BaseSwapAdapter {
       // Handle error appropriately
     }
   }
+
+  private async initiateTrade(params: {
+    sessionId: string
+    fromUserAddress: string
+    amountIn: string
+    minAmountOut: string
+    toUserAddress: string
+    userRefundPubkey: string | undefined
+    userRefundAddress: string
+    creatorPublicKey: string | undefined
+    fromWalletAddress: string
+    feeBps: string
+  }): Promise<{ deposit_address: string; payload?: string; trade_id: string }> {
+    const tradeTimeout = new Date()
+    tradeTimeout.setHours(tradeTimeout.getHours() + 2)
+
+    const scriptTimeout = new Date()
+    scriptTimeout.setHours(scriptTimeout.getHours() + 24)
+
+    const res = await fetch(`${OPTIMEX_API}/trades/initiate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        session_id: params.sessionId,
+        from_user_address: params.fromUserAddress,
+        amount_in: params.amountIn,
+        min_amount_out: params.minAmountOut,
+        to_user_address: params.toUserAddress,
+        user_refund_pubkey: params.userRefundPubkey || params.fromUserAddress,
+        user_refund_address: params.userRefundAddress,
+        creator_public_key: params.creatorPublicKey,
+        from_wallet_address: params.fromWalletAddress,
+        trade_timeout: Math.floor(tradeTimeout.getTime() / 1000),
+        script_timeout: Math.floor(scriptTimeout.getTime() / 1000),
+        affiliate_info: [
+          {
+            provider: 'KyberSwap',
+            rate: params.feeBps,
+            receiver: CROSS_CHAIN_FEE_RECEIVER,
+            network: 'ethereum',
+          },
+        ],
+      }),
+    }).then(res => res.json())
+
+    if (!res.data?.deposit_address) {
+      throw new Error('Failed to initiate trade with Optimex')
+    }
+
+    return res.data
+  }
+
   getName(): string {
     return 'Optimex'
   }
@@ -143,46 +197,28 @@ export class OptimexAdapter extends BaseSwapAdapter {
 
     let txData: { deposit_address: string; payload?: string; trade_id: string } | null = null
 
-    if (params.sender && params.recipient && (isFromBtc ? params.publicKey : true)) {
-      const tradeTimeout = new Date()
-      tradeTimeout.setHours(tradeTimeout.getHours() + 2)
-
-      const scriptTimeout = new Date()
-      scriptTimeout.setHours(scriptTimeout.getHours() + 24)
-
-      const res = await fetch(`${OPTIMEX_API}/trades/initiate`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          session_id: quoteRes.data.session_id,
-          from_user_address: params.sender,
-          amount_in: params.amount,
-          min_amount_out: (
+    // For any flow going TO BTC (EVM->BTC, etc.), we need to call initiate in getQuote
+    // to get deposit address for frontend approval checks
+    if (params.sender && params.recipient && isToBtc) {
+      try {
+        txData = await this.initiateTrade({
+          sessionId: quoteRes.data.session_id,
+          fromUserAddress: params.sender,
+          amountIn: params.amount,
+          minAmountOut: (
             (BigInt(quoteRes.data.best_quote_after_fees) * (10_000n - BigInt(params.slippage))) /
             10_000n
           ).toString(),
-          to_user_address: params.recipient,
-          user_refund_pubkey: userRefundPubkey,
-          user_refund_address: params.sender,
-          creator_public_key: params.fromChain === NonEvmChain.Bitcoin ? params.publicKey : params.sender,
-          from_wallet_address: params.sender,
-          trade_timeout: Math.floor(tradeTimeout.getTime() / 1000),
-          script_timeout: Math.floor(scriptTimeout.getTime() / 1000),
-          affiliate_info: [
-            {
-              provider: 'KyberSwap',
-              rate: params.feeBps.toString(),
-              receiver: CROSS_CHAIN_FEE_RECEIVER,
-              network: 'ethereum',
-            },
-          ],
-        }),
-      }).then(res => res.json())
-
-      if (res.data.deposit_address) {
-        txData = res.data
+          toUserAddress: params.recipient,
+          userRefundPubkey: userRefundPubkey,
+          userRefundAddress: params.sender,
+          creatorPublicKey: params.fromChain === NonEvmChain.Bitcoin ? params.publicKey : params.sender,
+          fromWalletAddress: params.sender,
+          feeBps: params.feeBps.toString(),
+        })
+      } catch (error) {
+        console.log('Failed to initiate trade in getQuote:', error)
+        // Continue without txData for TO BTC flows - will try again in executeSwap
       }
     }
 
@@ -215,9 +251,81 @@ export class OptimexAdapter extends BaseSwapAdapter {
     _nearWallet: any,
     sendBtcFn?: (params: { recipient: string; amount: string | number }) => Promise<string>,
   ): Promise<NormalizedTxResponse> {
+    // For EVM -> BTC flow, txData should already exist from getQuote
+    // For BTC -> EVM flow, we need to initiate the trade here
+    let txData: { deposit_address: string; payload?: string; trade_id: string }
+
+    if (quote.rawQuote.txData) {
+      // EVM -> BTC flow: use existing txData from getQuote
+      txData = quote.rawQuote.txData
+    } else {
+      // BTC -> EVM flow: initiate trade now
+      const isFromBtc = quote.quoteParams.fromChain === NonEvmChain.Bitcoin
+      const isToBtc = quote.quoteParams.toChain === NonEvmChain.Bitcoin
+
+      // Get network and token info (only needed for BTC -> EVM flow)
+      const fromNetworkId = CHAIN_TO_OPTIMEX_NETWORK[quote.quoteParams.fromChain]
+      if (!fromNetworkId) {
+        throw new Error(`Optimex does not support source chain: ${quote.quoteParams.fromChain}`)
+      }
+
+      const toNetworkId = CHAIN_TO_OPTIMEX_NETWORK[quote.quoteParams.toChain]
+      if (!toNetworkId) {
+        throw new Error(`Optimex does not support destination chain: ${quote.quoteParams.toChain}`)
+      }
+
+      // Find tokens
+      const fromToken = isFromBtc
+        ? { token_id: 'BTC', token_symbol: 'BTC' }
+        : this.tokens.find(item => {
+            const address = (quote.quoteParams.fromToken as any).isNative
+              ? 'native'
+              : (quote.quoteParams.fromToken as any).wrapped.address
+            return item.network_id === fromNetworkId && address.toLowerCase() === item.token_address.toLowerCase()
+          })
+      const toToken = isToBtc
+        ? { token_id: 'BTC', token_symbol: 'BTC' }
+        : this.tokens.find(item => {
+            const address = (quote.quoteParams.toToken as any).isNative
+              ? 'native'
+              : (quote.quoteParams.toToken as any).wrapped.address
+            return item.network_id === toNetworkId && address.toLowerCase() === item.token_address.toLowerCase()
+          })
+      const fromTokenId = fromToken?.token_id
+      const toTokenId = toToken?.token_id
+
+      if (!fromTokenId || !toTokenId) {
+        throw new Error(
+          `Optimex does not support ${
+            !fromTokenId ? quote.quoteParams.fromToken.symbol : quote.quoteParams.toToken.symbol
+          }`,
+        )
+      }
+
+      const userRefundPubkey =
+        quote.quoteParams.fromChain === NonEvmChain.Bitcoin ? quote.quoteParams.publicKey : quote.quoteParams.sender
+
+      // Initiate trade using the reusable function
+      txData = await this.initiateTrade({
+        sessionId: quote.rawQuote.session_id,
+        fromUserAddress: quote.quoteParams.sender,
+        amountIn: quote.quoteParams.amount,
+        minAmountOut: (
+          (BigInt(quote.outputAmount) * (10_000n - BigInt(quote.quoteParams.slippage))) /
+          10_000n
+        ).toString(),
+        toUserAddress: quote.quoteParams.recipient,
+        userRefundPubkey: userRefundPubkey,
+        userRefundAddress: quote.quoteParams.sender,
+        creatorPublicKey: userRefundPubkey,
+        fromWalletAddress: quote.quoteParams.sender,
+        feeBps: quote.quoteParams.feeBps.toString(),
+      })
+    }
+
     const params = {
       sender: quote.quoteParams.sender,
-      id: quote.rawQuote.txData.trade_id,
+      id: txData.trade_id,
       adapter: this.getName(),
       sourceChain: quote.quoteParams.fromChain,
       targetChain: quote.quoteParams.toChain,
@@ -234,12 +342,12 @@ export class OptimexAdapter extends BaseSwapAdapter {
     if (quote.quoteParams.fromChain === NonEvmChain.Bitcoin) {
       if (!sendBtcFn) throw new Error('sendBtcFn is not defined')
       const res = await sendBtcFn({
-        recipient: quote.rawQuote.txData.deposit_address,
+        recipient: txData.deposit_address,
         amount: quote.quoteParams.amount,
       }).catch(e => {
         throw e
       })
-      await fetch(`${OPTIMEX_API}/trades/${quote.rawQuote.txData.trade_id}/submit-tx`, {
+      await fetch(`${OPTIMEX_API}/trades/${txData.trade_id}/submit-tx`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -260,14 +368,14 @@ export class OptimexAdapter extends BaseSwapAdapter {
 
     const account = walletClient.account?.address as `0x${string}`
     const hash = await walletClient.sendTransaction({
-      to: quote.rawQuote.txData.deposit_address,
+      to: txData.deposit_address as `0x${string}`,
       value: (quote.quoteParams.fromToken as any).isNative ? BigInt(quote.quoteParams.amount) : undefined,
-      data: quote.rawQuote.txData.payload,
+      data: txData.payload as `0x${string}` | undefined,
       chain: undefined,
       account,
     })
 
-    await fetch(`${OPTIMEX_API}/trades/${quote.rawQuote.txData.trade_id}/submit-tx`, {
+    await fetch(`${OPTIMEX_API}/trades/${txData.trade_id}/submit-tx`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Improve the API calling flow for Optimex, to avoid calling endpoint `/trades/initiate` when unnecessary:
- For EVM -> BTC: keep the same flow (because we need to check user approval for ERC20 token to the deposit address contract)
- For BTC -> EVM:
  - We only call the API `/indicative-quote` in the getQuote method
  - In the executeSwap method, we will call `/trades/initiate`