### PR TITLE
refactor: disable weth as token in for Bungee adapter

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BaseSwapAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BaseSwapAdapter.ts
@@ -142,7 +142,7 @@ export interface SwapProvider {
     connection?: Connection,
   ): Promise<NormalizedTxResponse>
   getTransactionStatus(p: NormalizedTxResponse): Promise<SwapStatus>
-  canSupport(category: string): boolean
+  canSupport(category: string, tokenIn?: Currency, tokenOut?: Currency): boolean
 }
 export abstract class BaseSwapAdapter implements SwapProvider {
   abstract getName(): string
@@ -157,8 +157,8 @@ export abstract class BaseSwapAdapter implements SwapProvider {
   ): Promise<NormalizedTxResponse>
   abstract getTransactionStatus(p: NormalizedTxResponse): Promise<SwapStatus>
 
-  canSupport(_category: string): boolean {
-    // Default implementation - support all categories
+  canSupport(_category: string, _tokenIn?: Currency, _tokenOut?: Currency): boolean {
+    // Default implementation - support all cases
     return true
   }
 

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BungeeAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BungeeAdapter.ts
@@ -1,13 +1,14 @@
-import { Currency } from '@kyberswap/ks-sdk-core'
 import { WalletClient, formatUnits } from 'viem'
 
 import { BUNGEE_AFFILIATE_ID, CROSS_CHAIN_FEE_RECEIVER, ETHER_ADDRESS, KYBERSWAP_DOMAIN } from 'constants/index'
 import { MAINNET_NETWORKS } from 'constants/networks'
 
 import { Quote } from '../registry'
+import { isWrappedToken } from '../utils'
 import {
   BaseSwapAdapter,
   Chain,
+  Currency,
   EvmQuoteParams,
   NOT_SUPPORTED_CHAINS_PRICE_SERVICE,
   NormalizedQuote,
@@ -42,6 +43,21 @@ export class BungeeAdapter extends BaseSwapAdapter {
   getIcon(): string {
     return 'https://www.bungee.exchange/favicon.ico'
   }
+
+  canSupport(_category: string, tokenIn?: Currency, _tokenOut?: Currency): boolean {
+    // Bungee only supports EVM tokens, so check if it has chainId
+    if (!tokenIn || !('chainId' in tokenIn) || !tokenIn.chainId) return false
+
+    const isWrappedTokenIn = isWrappedToken(tokenIn)
+
+    if (isWrappedTokenIn) {
+      console.warn(`Bungee does not support swap from wrapped token: ${tokenIn.symbol || 'unknown'}`)
+      return false
+    }
+
+    return true
+  }
+
   getSupportedChains(): Chain[] {
     return [...MAINNET_NETWORKS]
   }

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
@@ -5,6 +5,7 @@ import { CROSS_CHAIN_FEE_RECEIVER, ZERO_ADDRESS } from 'constants/index'
 
 import { Quote } from '../registry'
 import {
+  Currency as AdapterCurrency,
   BaseSwapAdapter,
   Chain,
   EvmQuoteParams,
@@ -28,9 +29,14 @@ export class SymbiosisAdapter extends BaseSwapAdapter {
     return 'https://app.symbiosis.finance/images/favicon-32x32.png'
   }
 
-  canSupport(category: string): boolean {
+  canSupport(category: string, _tokenIn?: AdapterCurrency, _tokenOut?: AdapterCurrency): boolean {
     // Symbiosis should only be used for stablePair category
-    return category === 'stablePair'
+    if (category !== 'stablePair') {
+      console.warn(`Symbiosis does not support category: ${category}`)
+      return false
+    }
+
+    return true
   }
 
   getSupportedChains(): Chain[] {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
@@ -572,8 +572,8 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
           if (signal.aborted) throw new Error('Cancelled')
 
           // Skip adapter if it does not support the category
-          if (!adapter.canSupport(category)) {
-            console.log(`Skipping ${adapter.getName()} because it does not support category ${category}`)
+          if (!adapter.canSupport(category, currencyIn, currencyOut)) {
+            // reason will be logged in adapter.canSupport for specific adapter
             return
           }
 

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/utils/index.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/utils/index.ts
@@ -1,9 +1,9 @@
-import { ChainId } from '@kyberswap/ks-sdk-core'
+import { ChainId, WETH } from '@kyberswap/ks-sdk-core'
 
 import { NETWORKS_INFO } from 'constants/networks'
 import { isEvmChain } from 'utils'
 
-import { Chain, NonEvmChain, NonEvmChainInfo } from '../adapters'
+import { Chain, Currency, NonEvmChain, NonEvmChainInfo } from '../adapters'
 
 export const getNetworkInfo = (chain: Chain) => {
   if (isEvmChain(chain))
@@ -50,6 +50,17 @@ export const NEAR_STABLE_COINS = [
   'nep141:17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1',
   'nep141:usdt.tether-token.near',
 ]
+
+export const isWrappedToken = (token: Currency) => {
+  // Check if it's an EVM token (has chainId property)
+  if (!('chainId' in token) || !token.chainId) return false
+
+  // Check if it's native
+  if ('isNative' in token && token.isNative) return false
+
+  // Check if it's the wrapped native token
+  return 'address' in token && WETH[token.chainId]?.address?.toLowerCase() === token.address?.toLowerCase()
+}
 
 export function isCanonicalPair(chainId0: number, address0: string, chainId1: number, address1: string) {
   for (const [, chainMapping] of Object.entries(CANONICAL_TOKENS)) {


### PR DESCRIPTION
- Move the reason log into each adapter to catch the specific reason
- Skip wrapped native token as token in for Bungee adapter (they have a smart contract issue that will revert tx with error `InvalidMsgValue`)