### PR TITLE
fix: bungee get transaction status API also requires affiliate header

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BungeeAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BungeeAdapter.ts
@@ -165,7 +165,13 @@ export class BungeeAdapter extends BaseSwapAdapter {
     }
   }
   async getTransactionStatus(params: NormalizedTxResponse): Promise<SwapStatus> {
-    const response = await fetch(`${BUNGEE_API_BASE_URL}/api/v1/bungee/status?requestHash=${params.id}`)
+    const response = await fetch(`${BUNGEE_API_BASE_URL}/api/v1/bungee/status?requestHash=${params.id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        affiliate: BUNGEE_AFFILIATE_ID,
+      },
+    })
     const data = await response.json()
 
     if (!data.success) {
@@ -179,7 +185,7 @@ export class BungeeAdapter extends BaseSwapAdapter {
           ? 'Refunded'
           : [RequestStatusEnum.EXPIRED, RequestStatusEnum.CANCELLED].includes(res.bungeeStatusCode)
           ? 'Failed'
-          : res.bungeeStatusCode == RequestStatusEnum.FULFILLED
+          : [RequestStatusEnum.FULFILLED, RequestStatusEnum.SETTLED].includes(res.bungeeStatusCode)
           ? 'Success'
           : 'Processing',
     }


### PR DESCRIPTION
Root cause: Bungee API for kyberswap.com (they whitelisted our domain) requires sending the `affiliate` header

<img width="718" height="190" alt="image" src="https://github.com/user-attachments/assets/87c29358-a8af-4da3-8f22-7e6bf0068a49" />
