### PR TITLE
feat(earns): sync smart exit invert price across pool price condition

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Confirmation/Condition.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Confirmation/Condition.tsx
@@ -11,17 +11,19 @@ import {
   getPriceCondition,
   getTimeCondition,
 } from 'pages/Earns/components/SmartExit/utils/typeGuards'
-import { ConditionType, Metric, ParsedPosition, SelectedMetric } from 'pages/Earns/types'
+import { ConditionType, Metric, ParsedPosition, PriceCondition, SelectedMetric } from 'pages/Earns/types'
 import { formatDisplayNumber } from 'utils/numbers'
 
 export default function Condition({
   position,
   selectedMetrics,
   conditionType,
+  revertPrice = false,
 }: {
   position: ParsedPosition
   selectedMetrics: SelectedMetric[]
   conditionType: ConditionType
+  revertPrice?: boolean
 }) {
   const theme = useTheme()
 
@@ -33,6 +35,25 @@ export default function Condition({
   const feeYieldCondition2 = metric2 ? getFeeYieldCondition(metric2) : null
   const priceCondition2 = metric2 ? getPriceCondition(metric2) : null
   const timeCondition2 = metric2 ? getTimeCondition(metric2) : null
+
+  const baseSymbol = revertPrice ? position.token1.symbol : position.token0.symbol
+  const quoteSymbol = revertPrice ? position.token0.symbol : position.token1.symbol
+
+  // Stored `priceCondition` is always in forward (token0/token1) domain.
+  // In revert mode we flip the comparator and invert the price value for display only.
+  const renderPricePhrase = (priceCondition: PriceCondition) => {
+    const storedIsLte = !!priceCondition.lte
+    const storedValue = priceCondition.lte || priceCondition.gte || ''
+    const displayIsLte = revertPrice ? !storedIsLte : storedIsLte
+    const forwardNum = parseFloat(storedValue)
+    const displayValue = revertPrice && isFinite(forwardNum) && forwardNum > 0 ? 1 / forwardNum : forwardNum
+    return (
+      <>
+        <Trans>Pool price is</Trans> {displayIsLte ? '≤' : '≥'}{' '}
+        {formatDisplayNumber(displayValue, { significantDigits: 6 })} {baseSymbol}/{quoteSymbol}
+      </>
+    )
+  }
 
   return (
     <>
@@ -73,13 +94,7 @@ export default function Condition({
             <Text>{dayjs(timeCondition1.time).format('DD/MM/YYYY HH:mm:ss')}</Text>
           </>
         )}
-        {metric1.metric === Metric.PoolPrice && priceCondition1 && (
-          <Text>
-            <Trans>Pool price is</Trans> {priceCondition1.lte ? '≤' : '≥'}{' '}
-            {formatDisplayNumber(priceCondition1.lte || priceCondition1.gte, { significantDigits: 6 })}{' '}
-            {position.token0.symbol}/{position.token1.symbol}
-          </Text>
-        )}
+        {metric1.metric === Metric.PoolPrice && priceCondition1 && <Text>{renderPricePhrase(priceCondition1)}</Text>}
         {metric2 && (
           <>
             <Flex alignItems="center" sx={{ gap: '1rem' }} my="8px">
@@ -110,11 +125,7 @@ export default function Condition({
               </>
             )}
             {metric2.metric === Metric.PoolPrice && priceCondition2 && (
-              <Text mt="6px">
-                <Trans>Pool price is</Trans> {priceCondition2.lte ? '≤' : '≥'}{' '}
-                {formatDisplayNumber(priceCondition2.lte || priceCondition2.gte, { significantDigits: 6 })}{' '}
-                {position.token0.symbol}/{position.token1.symbol}
-              </Text>
+              <Text mt="6px">{renderPricePhrase(priceCondition2)}</Text>
             )}
           </>
         )}

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Confirmation/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Confirmation/index.tsx
@@ -25,6 +25,7 @@ export default function Confirmation({
   createSmartExitOrder,
   isCreating,
   isSuccess,
+  revertPrice = false,
 }: {
   selectedMetrics: SelectedMetric[]
   position: ParsedPosition
@@ -36,6 +37,7 @@ export default function Confirmation({
   createSmartExitOrder: (opts: { maxGas: number; permitData: string }) => Promise<boolean>
   isCreating: boolean
   isSuccess: boolean
+  revertPrice?: boolean
 }) {
   const theme = useTheme()
   const { chainId } = useActiveWeb3React()
@@ -62,7 +64,12 @@ export default function Confirmation({
         <X onClick={onDismiss} />
       </Flex>
 
-      <Condition position={position} selectedMetrics={selectedMetrics} conditionType={conditionType} />
+      <Condition
+        position={position}
+        selectedMetrics={selectedMetrics}
+        conditionType={conditionType}
+        revertPrice={revertPrice}
+      />
       <MoreInfo deadline={deadline} protocolFee={protocolFee} maxGas={maxGas} />
 
       <Text fontStyle="italic" fontSize={14} color={theme.subText} my="1rem">

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/MetricSelect.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/MetricSelect.tsx
@@ -19,6 +19,7 @@ export default function MetricSelect({
   position,
   onRemove,
   isFirstMetric = false,
+  revertPrice = false,
 }: {
   metric: SelectedMetric | null
   setMetric: (value: SelectedMetric) => void
@@ -26,6 +27,7 @@ export default function MetricSelect({
   position: ParsedPosition
   onRemove?: () => void
   isFirstMetric?: boolean
+  revertPrice?: boolean
 }) {
   const theme = useTheme()
   const { currentStep } = useGuidedHighlight()
@@ -94,7 +96,13 @@ export default function MetricSelect({
       )}
 
       {metric !== null && metric.metric === Metric.PoolPrice && (
-        <PriceInput metric={metric} setMetric={setMetric} position={position} isHighlighted={shouldHighlightInput} />
+        <PriceInput
+          metric={metric}
+          setMetric={setMetric}
+          position={position}
+          isHighlighted={shouldHighlightInput}
+          revertPrice={revertPrice}
+        />
       )}
 
       {metric !== null && metric.metric === Metric.Time && (

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/PriceInput.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/PriceInput.tsx
@@ -16,23 +16,68 @@ import { getPriceCondition } from 'pages/Earns/components/SmartExit/utils/typeGu
 import { Metric, PAIR_CATEGORY, ParsedPosition, SelectedMetric } from 'pages/Earns/types'
 import { formatDisplayNumber, toString } from 'utils/numbers'
 
+type Comparator = 'gte' | 'lte'
+
+const flipComparator = (c: Comparator): Comparator => (c === 'gte' ? 'lte' : 'gte')
+
 export default function PriceInput({
   metric,
   setMetric,
   position,
   isHighlighted = false,
+  revertPrice = false,
 }: {
   metric: SelectedMetric
   setMetric: (value: SelectedMetric) => void
   position: ParsedPosition
   isHighlighted?: boolean
+  revertPrice?: boolean
 }) {
   const theme = useTheme()
   const priceCondition = useMemo(() => getPriceCondition(metric) || defaultPriceCondition, [metric])
 
+  // Stored condition (priceCondition) is always in forward (token0/token1) domain
+  // so the backend payload and Confirmation view stay consistent regardless of display inversion.
+  // The local `inputPrice` and `comparator` state are in DISPLAY domain and mirror what the user sees.
+
+  const toDisplayPrice = useCallback(
+    (forward: string | number | undefined): string => {
+      if (forward === undefined || forward === null || forward === '') return ''
+      const n = typeof forward === 'number' ? forward : parseFloat(forward)
+      if (!isFinite(n) || n <= 0) return ''
+      if (!revertPrice) return typeof forward === 'string' ? forward : toString(forward)
+      return toString(formatNumberBySignificantDigits(1 / n, 6))
+    },
+    [revertPrice],
+  )
+
+  const toForwardPrice = useCallback(
+    (display: string): string => {
+      if (!display) return ''
+      const n = parseFloat(display)
+      if (!isFinite(n) || n <= 0) return ''
+      return revertPrice ? toString(formatNumberBySignificantDigits(1 / n, 6)) : display
+    },
+    [revertPrice],
+  )
+
+  const toDisplayComparator = useCallback(
+    (stored: Comparator): Comparator => (revertPrice ? flipComparator(stored) : stored),
+    [revertPrice],
+  )
+
+  const toStoredComparator = useCallback(
+    (display: Comparator): Comparator => (revertPrice ? flipComparator(display) : display),
+    [revertPrice],
+  )
+
   const [tick, setTick] = useState<number>()
-  const [inputPrice, setInputPrice] = useState(priceCondition?.lte ?? priceCondition?.gte ?? '')
-  const [comparator, setComparator] = useState<'lte' | 'gte'>(priceCondition?.lte ? 'lte' : 'gte')
+  const [inputPrice, setInputPrice] = useState<string>(() =>
+    toDisplayPrice(priceCondition?.lte || priceCondition?.gte || ''),
+  )
+  const [comparator, setComparator] = useState<Comparator>(() =>
+    toDisplayComparator(priceCondition?.lte ? 'lte' : 'gte'),
+  )
 
   // Track change source to prevent circular updates
   const changeSourceRef = useRef<'input' | 'slider' | null>(null)
@@ -49,51 +94,66 @@ export default function PriceInput({
     [position.pool.tickSpacing, position.priceRange, position.token0.decimals, position.token1.decimals],
   )
 
-  const priceToTick = useCallback(
-    (price: string) => {
-      if (!price) return undefined
-      const priceNum = parseFloat(price)
+  // Forward price string → nearest usable tick
+  const forwardPriceToTick = useCallback(
+    (forwardPrice: string) => {
+      if (!forwardPrice) return undefined
+      const priceNum = parseFloat(forwardPrice)
       if (!priceNum || priceNum <= 0 || !isFinite(priceNum)) return undefined
       return nearestUsableTick(
-        priceToClosestTick(price, position.token0.decimals, position.token1.decimals) || 0,
+        priceToClosestTick(forwardPrice, position.token0.decimals, position.token1.decimals) || 0,
         position.pool.tickSpacing,
       )
     },
     [position.pool.tickSpacing, position.token0.decimals, position.token1.decimals],
   )
 
-  // Sync comparator/input when condition changes externally (not via slider)
+  // Display price string → nearest usable tick (converts through forward domain)
+  const displayPriceToTick = useCallback(
+    (displayPrice: string) => forwardPriceToTick(toForwardPrice(displayPrice)),
+    [forwardPriceToTick, toForwardPrice],
+  )
+
+  // Sync display state when condition changes externally (not via slider)
+  // Also re-syncs when revertPrice toggles: toDisplayPrice/toDisplayComparator change,
+  // so this effect re-runs and reformats the shown value/comparator.
   useEffect(() => {
     if (changeSourceRef.current === 'slider') return
     if (priceCondition) {
-      const nextComparator = priceCondition.lte ? 'lte' : 'gte'
-      setComparator(nextComparator)
-      const nextPrice = priceCondition.lte || priceCondition.gte || ''
-      setInputPrice(nextPrice)
+      const storedComparator: Comparator = priceCondition.lte ? 'lte' : 'gte'
+      setComparator(toDisplayComparator(storedComparator))
+      const storedPrice = priceCondition.lte || priceCondition.gte || ''
+      setInputPrice(toDisplayPrice(storedPrice))
     }
-  }, [priceCondition])
+  }, [priceCondition, toDisplayComparator, toDisplayPrice])
 
+  // Detects a crossing of `currentTick` and flips the stored/display comparators accordingly.
+  // Returns the STORED (forward) comparator after any flip.
   const updateComparatorOnCross = useCallback(
-    (t: number | undefined, priceString: string): 'gte' | 'lte' => {
-      if (t === undefined) return comparator
+    (t: number | undefined, forwardPriceString: string): Comparator => {
+      const storedNow = toStoredComparator(comparator)
+      if (t === undefined) return storedNow
 
       const side: 'below' | 'above' = t >= currentTick ? 'above' : 'below'
       const hasCrossed = lastSideRef.current !== null && lastSideRef.current !== side
       lastSideRef.current = side
 
       if (hasCrossed) {
-        const next = side === 'above' ? 'gte' : 'lte'
-        setComparator(next)
+        const nextStored: Comparator = side === 'above' ? 'gte' : 'lte'
+        setComparator(toDisplayComparator(nextStored))
         setMetric({
           metric: Metric.PoolPrice,
-          condition: { gte: next === 'gte' ? priceString : '', lte: next === 'lte' ? priceString : '' },
+          condition: {
+            gte: nextStored === 'gte' ? forwardPriceString : '',
+            lte: nextStored === 'lte' ? forwardPriceString : '',
+          },
         })
-        return next
+        return nextStored
       }
 
-      return comparator
+      return storedNow
     },
-    [comparator, currentTick, setMetric],
+    [comparator, currentTick, setMetric, toDisplayComparator, toStoredComparator],
   )
 
   // Keep side reference in sync with latest tick (without forcing comparator change)
@@ -104,41 +164,49 @@ export default function PriceInput({
   }, [tick, currentTick])
 
   // Debounce input price updates
+  // Latest-effect ref pattern: the timer body reads from this ref so it always sees fresh
+  // closures (important when revertPrice toggles mid-debounce), while the effect deps stay
+  // narrow — unstable parent identities like setMetric can't reset the debounce timer.
+  const commitInputRef = useRef<() => void>(() => {})
+  commitInputRef.current = () => {
+    const forwardInput = toForwardPrice(inputPrice)
+    const typedTick = forwardPriceToTick(forwardInput)
+    let storedComparator: Comparator = toStoredComparator(comparator)
+    if (typedTick !== undefined) {
+      const side: 'below' | 'above' = typedTick >= currentTick ? 'above' : 'below'
+      const hasCrossed = lastSideRef.current !== null && lastSideRef.current !== side
+      if (hasCrossed) {
+        storedComparator = side === 'above' ? 'gte' : 'lte'
+      }
+      lastSideRef.current = side
+    }
+
+    const nextDisplayComparator = toDisplayComparator(storedComparator)
+    if (nextDisplayComparator !== comparator) {
+      setComparator(nextDisplayComparator)
+    }
+
+    if (
+      (storedComparator === 'gte' && forwardInput !== priceCondition?.gte) ||
+      (storedComparator === 'lte' && forwardInput !== priceCondition?.lte)
+    ) {
+      setMetric({
+        metric: Metric.PoolPrice,
+        condition: {
+          gte: storedComparator === 'gte' ? forwardInput : '',
+          lte: storedComparator === 'lte' ? forwardInput : '',
+        },
+      })
+    }
+  }
+
   useEffect(() => {
     if (changeSourceRef.current === 'slider' || metric.metric !== Metric.PoolPrice) return
     const timer = setTimeout(() => {
-      // Detect crossing on debounced input value
-      const typedTick = priceToTick(inputPrice)
-      let nextComparator = comparator
-      if (typedTick !== undefined) {
-        const side: 'below' | 'above' = typedTick >= currentTick ? 'above' : 'below'
-        const hasCrossed = lastSideRef.current !== null && lastSideRef.current !== side
-        if (hasCrossed) {
-          nextComparator = side === 'above' ? 'gte' : 'lte'
-        }
-        lastSideRef.current = side
-      }
-
-      if (nextComparator !== comparator) {
-        setComparator(nextComparator)
-      }
-
-      if (
-        (nextComparator === 'gte' && inputPrice !== priceCondition?.gte) ||
-        (nextComparator === 'lte' && inputPrice !== priceCondition?.lte)
-      ) {
-        setMetric({
-          metric: Metric.PoolPrice,
-          condition: {
-            gte: nextComparator === 'gte' ? inputPrice : '',
-            lte: nextComparator === 'lte' ? inputPrice : '',
-          },
-        })
-      }
+      commitInputRef.current()
     }, 300)
     return () => clearTimeout(timer)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inputPrice, comparator])
+  }, [inputPrice, comparator, metric.metric])
 
   // Debounce tick updates from input typing to avoid jitter on the slider
   useEffect(() => {
@@ -147,9 +215,8 @@ export default function PriceInput({
       clearTimeout(debounceTickFromInputRef.current)
     }
     debounceTickFromInputRef.current = setTimeout(() => {
-      const t = priceToTick(inputPrice)
+      const t = displayPriceToTick(inputPrice)
       if (t === undefined) {
-        // Reset tick when price is invalid (e.g., 0 or empty)
         setTick(undefined)
       } else if (t !== tick) {
         setTick(t)
@@ -164,114 +231,148 @@ export default function PriceInput({
         debounceTickFromInputRef.current = null
       }
     }
-  }, [currentTick, inputPrice, priceToTick, tick])
+  }, [currentTick, inputPrice, displayPriceToTick, tick])
 
   // Wrapper to set tick from slider (updates price)
   const setPriceTick = useCallback(
-    (tick: number | undefined) => {
+    (t: number | undefined) => {
       changeSourceRef.current = 'slider'
-      setTick(tick)
-      if (tick !== undefined) {
-        const price = toString(
-          formatNumberBySignificantDigits(
-            tickToPrice(tick, position.token0.decimals, position.token1.decimals, false),
-            6,
-          ),
+      setTick(t)
+      if (t !== undefined) {
+        const forwardPrice = toString(
+          formatNumberBySignificantDigits(tickToPrice(t, position.token0.decimals, position.token1.decimals, false), 6),
         )
-        const nextComparator = updateComparatorOnCross(tick, price)
+        const nextStored = updateComparatorOnCross(t, forwardPrice)
         setMetric({
           metric: Metric.PoolPrice,
           condition: {
-            gte: nextComparator === 'gte' ? price : '',
-            lte: nextComparator === 'lte' ? price : '',
+            gte: nextStored === 'gte' ? forwardPrice : '',
+            lte: nextStored === 'lte' ? forwardPrice : '',
           },
         })
-        setInputPrice(price)
+        setInputPrice(toDisplayPrice(forwardPrice))
       }
       // Reset source after React batch update
       setTimeout(() => {
         changeSourceRef.current = null
       }, 0)
     },
-    [position.token0.decimals, position.token1.decimals, setMetric, updateComparatorOnCross],
+    [position.token0.decimals, position.token1.decimals, setMetric, toDisplayPrice, updateComparatorOnCross],
   )
 
-  // Sync tick from price input (only when source is input, not slider)
+  // Sync tick from price condition (only when source is input, not slider)
   useEffect(() => {
     if (changeSourceRef.current === 'slider') return
     if (priceCondition) {
-      // Use || instead of ?? so empty strings fall through correctly
-      const priceTick = priceToTick(priceCondition.gte || priceCondition.lte || '')
+      const forwardPrice = priceCondition.gte || priceCondition.lte || ''
+      const priceTick = forwardPriceToTick(forwardPrice)
       if (priceTick === undefined) {
-        // Reset tick when price is invalid
         setTick(undefined)
       } else if (priceTick !== tick) {
         setTick(priceTick)
         // Update side reference but don't auto-switch comparator unless crossing
         lastSideRef.current = priceTick >= currentTick ? 'above' : 'below'
-        // Keep comparator from condition if provided; else keep current
-        const conditionComparator = priceCondition.lte ? 'lte' : priceCondition.gte ? 'gte' : comparator
-        if (conditionComparator !== comparator) {
-          setComparator(conditionComparator)
+        const storedComparator: Comparator = priceCondition.lte
+          ? 'lte'
+          : priceCondition.gte
+          ? 'gte'
+          : toStoredComparator(comparator)
+        const nextDisplayComparator = toDisplayComparator(storedComparator)
+        if (nextDisplayComparator !== comparator) {
+          setComparator(nextDisplayComparator)
         }
       }
     }
-  }, [comparator, currentTick, priceCondition, priceToTick, tick])
+  }, [comparator, currentTick, priceCondition, forwardPriceToTick, tick, toDisplayComparator, toStoredComparator])
 
-  const wrappedCorrectPrice = (value: string) => {
-    const tick = priceToClosestTick(value, position.token0.decimals, position.token1.decimals, false)
-    if (tick !== undefined) {
-      const correctedTick =
-        tick % position.pool.tickSpacing === 0 ? tick : nearestUsableTick(tick, position.pool.tickSpacing)
-      const correctedPrice = tickToPrice(correctedTick, position.token0.decimals, position.token1.decimals, false)
-      const formatted = toString(formatNumberBySignificantDigits(correctedPrice, 6))
-      const nextComparator = updateComparatorOnCross(correctedTick, formatted)
-      setInputPrice(formatted)
-      setMetric({
-        metric: Metric.PoolPrice,
-        condition: { gte: nextComparator === 'gte' ? formatted : '', lte: nextComparator === 'lte' ? formatted : '' },
-      })
-      setTick(correctedTick)
-    }
-  }
+  const wrappedCorrectPrice = useCallback(
+    (value: string) => {
+      const forwardValue = toForwardPrice(value)
+      const correctedTick = priceToClosestTick(forwardValue, position.token0.decimals, position.token1.decimals, false)
+      if (correctedTick !== undefined) {
+        const nearestTick =
+          correctedTick % position.pool.tickSpacing === 0
+            ? correctedTick
+            : nearestUsableTick(correctedTick, position.pool.tickSpacing)
+        const correctedForwardPrice = tickToPrice(
+          nearestTick,
+          position.token0.decimals,
+          position.token1.decimals,
+          false,
+        )
+        const formattedForward = toString(formatNumberBySignificantDigits(correctedForwardPrice, 6))
+        const nextStored = updateComparatorOnCross(nearestTick, formattedForward)
+        setInputPrice(toDisplayPrice(formattedForward))
+        setMetric({
+          metric: Metric.PoolPrice,
+          condition: {
+            gte: nextStored === 'gte' ? formattedForward : '',
+            lte: nextStored === 'lte' ? formattedForward : '',
+          },
+        })
+        setTick(nearestTick)
+      }
+    },
+    [
+      position.token0.decimals,
+      position.token1.decimals,
+      position.pool.tickSpacing,
+      setMetric,
+      toDisplayPrice,
+      toForwardPrice,
+      updateComparatorOnCross,
+    ],
+  )
 
   const handleComparatorChange = useCallback(
-    (next: 'gte' | 'lte') => {
-      setComparator(next)
+    (nextDisplay: Comparator) => {
+      setComparator(nextDisplay)
+      const nextStored = toStoredComparator(nextDisplay)
 
-      // Calculate default price with gap based on pair category
+      // Calculate default price with gap based on pair category (in forward domain)
       const pairCategory = position.pool.category
       const gap =
         pairCategory === PAIR_CATEGORY.STABLE ? 0.0001 : pairCategory === PAIR_CATEGORY.CORRELATED ? 0.001 : 0.1
-      const defaultPrice = position.priceRange.current * (1 + (next === 'gte' ? gap : -gap))
-      const newTick = priceToClosestTick(toString(defaultPrice), position.token0.decimals, position.token1.decimals)
+      const defaultForwardPrice = position.priceRange.current * (1 + (nextStored === 'gte' ? gap : -gap))
+      const newTick = priceToClosestTick(
+        toString(defaultForwardPrice),
+        position.token0.decimals,
+        position.token1.decimals,
+      )
 
       if (newTick !== undefined) {
         const nearestTick = nearestUsableTick(newTick, position.pool.tickSpacing)
-        const correctedPrice = toString(
+        const correctedForwardPrice = toString(
           formatNumberBySignificantDigits(
             tickToPrice(nearestTick, position.token0.decimals, position.token1.decimals, false),
             6,
           ),
         )
 
-        setInputPrice(correctedPrice)
+        setInputPrice(toDisplayPrice(correctedForwardPrice))
         setTick(nearestTick)
         lastSideRef.current = nearestTick >= currentTick ? 'above' : 'below'
 
         setMetric({
           metric: Metric.PoolPrice,
-          condition: { gte: next === 'gte' ? correctedPrice : '', lte: next === 'lte' ? correctedPrice : '' },
+          condition: {
+            gte: nextStored === 'gte' ? correctedForwardPrice : '',
+            lte: nextStored === 'lte' ? correctedForwardPrice : '',
+          },
         })
       } else {
         // Fallback to current input price if tick calculation fails
+        const fallbackForward = toForwardPrice(inputPrice)
         setMetric({
           metric: Metric.PoolPrice,
-          condition: { gte: next === 'gte' ? inputPrice : '', lte: next === 'lte' ? inputPrice : '' },
+          condition: {
+            gte: nextStored === 'gte' ? fallbackForward : '',
+            lte: nextStored === 'lte' ? fallbackForward : '',
+          },
         })
       }
     },
-    [currentTick, inputPrice, position, setMetric],
+    [currentTick, inputPrice, position, setMetric, toDisplayPrice, toForwardPrice, toStoredComparator],
   )
 
   const expectedAmounts = useMemo(
@@ -296,12 +397,15 @@ export default function PriceInput({
     ],
   )
 
+  const baseSymbol = revertPrice ? position.token1.symbol : position.token0.symbol
+  const quoteSymbol = revertPrice ? position.token0.symbol : position.token1.symbol
+
   return (
     <>
       <Flex alignItems="center" sx={{ gap: '4px' }}>
         <Text>
           <Trans>
-            Exit when {position.token0.symbol}/{position.token1.symbol}
+            Exit when {baseSymbol}/{quoteSymbol}
           </Trans>
         </Text>
         <HighlightWrapper isHighlighted={isHighlighted}>
@@ -322,16 +426,16 @@ export default function PriceInput({
               </PriceInputIcon>
             </Flex>
             <PriceCustomInput
-              placeholder={`${position.token0.symbol}/${position.token1.symbol}`}
+              placeholder={`${baseSymbol}/${quoteSymbol}`}
               value={inputPrice}
               onChange={e => {
                 const value = e.target.value
                 // Only allow numbers and decimal point
                 if (/^\d*\.?\d*$/.test(value)) {
                   setInputPrice(value)
-                  const typedTick = priceToTick(value)
+                  const typedTick = displayPriceToTick(value)
                   if (typedTick !== undefined) {
-                    updateComparatorOnCross(typedTick, value) // change comparator immediately on cross
+                    updateComparatorOnCross(typedTick, toForwardPrice(value)) // change comparator immediately on cross
                   }
                 }
               }}
@@ -351,9 +455,10 @@ export default function PriceInput({
           }}
           tick={tick}
           setTick={setPriceTick}
-          comparator={comparator}
+          comparator={toStoredComparator(comparator)}
           mode="range-to-infinite"
           showStepButtons
+          invertPrice={revertPrice}
         />
       </Box>
 

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/PriceInput.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/PriceInput.tsx
@@ -1,4 +1,3 @@
-import { formatNumberBySignificantDigits } from '@kyber/utils/dist/number'
 import { nearestUsableTick, priceToClosestTick, tickToPrice } from '@kyber/utils/dist/uniswapv3'
 import PriceSlider from '@kyberswap/price-slider'
 import '@kyberswap/price-slider/style.css'
@@ -19,6 +18,12 @@ import { formatDisplayNumber, toString } from 'utils/numbers'
 type Comparator = 'gte' | 'lte'
 
 const flipComparator = (c: Comparator): Comparator => (c === 'gte' ? 'lte' : 'gte')
+
+const toSignificantDigitString = (n: number | string, digits: number): string => {
+  const num = typeof n === 'number' ? n : parseFloat(n)
+  if (!isFinite(num) || num === 0) return '0'
+  return toString(Number(num.toPrecision(digits)))
+}
 
 export default function PriceInput({
   metric,
@@ -46,7 +51,7 @@ export default function PriceInput({
       const n = typeof forward === 'number' ? forward : parseFloat(forward)
       if (!isFinite(n) || n <= 0) return ''
       if (!revertPrice) return typeof forward === 'string' ? forward : toString(forward)
-      return toString(formatNumberBySignificantDigits(1 / n, 6))
+      return toSignificantDigitString(1 / n, 6)
     },
     [revertPrice],
   )
@@ -56,7 +61,7 @@ export default function PriceInput({
       if (!display) return ''
       const n = parseFloat(display)
       if (!isFinite(n) || n <= 0) return ''
-      return revertPrice ? toString(formatNumberBySignificantDigits(1 / n, 6)) : display
+      return revertPrice ? toSignificantDigitString(1 / n, 6) : display
     },
     [revertPrice],
   )
@@ -239,8 +244,9 @@ export default function PriceInput({
       changeSourceRef.current = 'slider'
       setTick(t)
       if (t !== undefined) {
-        const forwardPrice = toString(
-          formatNumberBySignificantDigits(tickToPrice(t, position.token0.decimals, position.token1.decimals, false), 6),
+        const forwardPrice = toSignificantDigitString(
+          tickToPrice(t, position.token0.decimals, position.token1.decimals, false),
+          6,
         )
         const nextStored = updateComparatorOnCross(t, forwardPrice)
         setMetric({
@@ -300,7 +306,7 @@ export default function PriceInput({
           position.token1.decimals,
           false,
         )
-        const formattedForward = toString(formatNumberBySignificantDigits(correctedForwardPrice, 6))
+        const formattedForward = toSignificantDigitString(correctedForwardPrice, 6)
         const nextStored = updateComparatorOnCross(nearestTick, formattedForward)
         setInputPrice(toDisplayPrice(formattedForward))
         setMetric({
@@ -342,11 +348,9 @@ export default function PriceInput({
 
       if (newTick !== undefined) {
         const nearestTick = nearestUsableTick(newTick, position.pool.tickSpacing)
-        const correctedForwardPrice = toString(
-          formatNumberBySignificantDigits(
-            tickToPrice(nearestTick, position.token0.decimals, position.token1.decimals, false),
-            6,
-          ),
+        const correctedForwardPrice = toSignificantDigitString(
+          tickToPrice(nearestTick, position.token0.decimals, position.token1.decimals, false),
+          6,
         )
 
         setInputPrice(toDisplayPrice(correctedForwardPrice))

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/Metrics/index.tsx
@@ -17,6 +17,7 @@ interface MetricsProps {
   conditionType: ConditionType
   setConditionType: (v: ConditionType) => void
   isLoading?: boolean
+  revertPrice?: boolean
 }
 
 export default function Metrics({
@@ -26,6 +27,7 @@ export default function Metrics({
   conditionType,
   setConditionType,
   isLoading = false,
+  revertPrice = false,
 }: MetricsProps) {
   const theme = useTheme()
   const [metric1, metric2] = selectedMetrics
@@ -92,6 +94,7 @@ export default function Metrics({
         position={position}
         isFirstMetric
         onRemove={metric2 !== undefined ? onRemoveMetric1 : undefined}
+        revertPrice={revertPrice}
       />
       {metric2 !== undefined ? (
         <>
@@ -116,6 +119,7 @@ export default function Metrics({
             selectedMetric={metric1}
             position={position}
             onRemove={onRemoveMetric2}
+            revertPrice={revertPrice}
           />
         </>
       ) : (

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/PoolPrice.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/PoolPrice.tsx
@@ -1,5 +1,4 @@
 import { Trans } from '@lingui/macro'
-import { useState } from 'react'
 import { Box, Flex, Text } from 'rebass'
 
 import { ReactComponent as RevertPriceIcon } from 'assets/svg/earn/ic_revert_price.svg'
@@ -17,11 +16,12 @@ import { formatDisplayNumber } from 'utils/numbers'
 interface PoolPriceProps {
   position: ParsedPosition | null
   isLoading?: boolean
+  revertPrice: boolean
+  setRevertPrice: (value: boolean) => void
 }
 
-export default function PoolPrice({ position, isLoading = false }: PoolPriceProps) {
+export default function PoolPrice({ position, isLoading = false, revertPrice, setRevertPrice }: PoolPriceProps) {
   const theme = useTheme()
-  const [revertPrice, setRevertPrice] = useState(false)
 
   if (isLoading || !position) {
     return (

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/index.tsx
@@ -94,6 +94,7 @@ export const SmartExit = ({ position, onDismiss, isLoading = false }: SmartExitP
             createSmartExitOrder={smartExit.createSmartExitOrder}
             isCreating={smartExit.isCreating}
             isSuccess={smartExit.isSuccess}
+            revertPrice={revertPrice}
           />
         ) : (
           <GuidedHighlightProvider selectedMetrics={selectedMetrics}>

--- a/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/SmartExit/index.tsx
@@ -38,6 +38,7 @@ export const SmartExit = ({ position, onDismiss, isLoading = false }: SmartExitP
   const [conditionType, setConditionType] = useState<ConditionType>(ConditionType.And)
   const [expireTime, setExpireTime] = useState(FOREVER_EXPIRE_TIME)
   const [showConfirm, setShowConfirm] = useState(false)
+  const [revertPrice, setRevertPrice] = useState(false)
 
   const [multiplier, setMultiplier] = useState<number>(2)
   const [customGasPercent, setCustomGasPercent] = useState<string>('')
@@ -118,7 +119,12 @@ export const SmartExit = ({ position, onDismiss, isLoading = false }: SmartExitP
             <ContentWrapper>
               <Flex flexDirection="column" sx={{ gap: '1rem' }} flex={1}>
                 <PositionLiquidity position={position} isLoading={positionLoading} />
-                <PoolPrice position={position} isLoading={positionLoading} />
+                <PoolPrice
+                  position={position}
+                  isLoading={positionLoading}
+                  revertPrice={revertPrice}
+                  setRevertPrice={setRevertPrice}
+                />
                 {orWithTimeAlreadyMet && conditionTime && <OrTimeAlreadyMetWarning conditionTime={conditionTime} />}
               </Flex>
 
@@ -130,6 +136,7 @@ export const SmartExit = ({ position, onDismiss, isLoading = false }: SmartExitP
                   conditionType={conditionType}
                   setConditionType={setConditionType}
                   isLoading={positionLoading}
+                  revertPrice={revertPrice}
                 />
                 <GasSetting
                   feeInfo={feeInfo}


### PR DESCRIPTION
Lift  state from PoolPrice up to the SmartExit modal and thread it through Metrics → MetricSelect → PriceInput so the right-pane pool price condition (label, typed input, slider, and comparator ≥/≤) now inverts alongside the left-pane display.

PriceInput keeps the stored  in the forward
(token0/token1) domain so the backend payload and Confirmation screen stay untouched, while  and  local state sit in
the display domain via / helpers.
 is unchanged since it consumes the forward
condition. The debounced input commit uses a latest-ref pattern to avoid stale closures when  toggles mid-debounce and to prevent parent re-renders from resetting the timer.