### PR TITLE
feat(pancake-widget): route RPC calls through rpc-client rotation

### DIFF
--- a/packages/pancake-liquidity-widgets/package.json
+++ b/packages/pancake-liquidity-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyberswap/pancake-liquidity-widgets",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/pancake-liquidity-widgets/package.json
+++ b/packages/pancake-liquidity-widgets/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@kyber/hooks": "workspace:*",
+    "@kyber/rpc-client": "workspace:*",
     "@kyber/svgr-esbuild-plugin": "workspace:^",
     "@kyber/ui": "workspace:*",
     "@kyber/utils": "workspace:^",

--- a/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
@@ -31,7 +31,6 @@ import X from "@/assets/x.svg";
 import ErrorIcon from "@/assets/error.svg";
 import {
   MAX_ZAP_IN_TOKENS,
-  NetworkInfo,
   POSITION_MANAGER_CONTRACT,
   CoreProtocol,
 } from "@/constants";
@@ -89,7 +88,7 @@ export default function Content({
     pendingTx: pendingTxNft,
     checkApproval: checkNftApproval,
   } = useNftApproval({
-    rpcUrl: NetworkInfo[chainId].defaultRpc,
+    chainId,
     nftManagerContract,
     nftId: positionId ? +positionId : undefined,
     spender: zapInfo?.routerAddress,

--- a/packages/pancake-liquidity-widgets/src/components/Widget/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Widget/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
-import { WalletClient, Address, http, createPublicClient } from "viem";
+import { WalletClient, Address, custom, createPublicClient } from "viem";
 import * as chains from "viem/chains";
+import { getRpcClient } from "@kyber/rpc-client";
 import { Theme, defaultTheme, lightTheme } from "@/theme";
 import Setting from "@/components/Setting";
 import WidgetContent from "@/components/Content";
@@ -77,9 +78,16 @@ export default function Widget({
       throw new Error(`chainId: ${chainId} is not supported`);
     }
 
+    const rpcClient = getRpcClient(chainId, {
+      configRpcEndpoint: NetworkInfo[chainId].defaultRpc,
+    });
+
     return createPublicClient({
       chain,
-      transport: http(NetworkInfo[chainId].defaultRpc),
+      transport: custom({
+        request: ({ method, params }) =>
+          rpcClient.call(method, params as unknown[]),
+      }),
     });
   }, [chainId]);
 

--- a/packages/pancake-liquidity-widgets/src/hooks/useNftApproval.ts
+++ b/packages/pancake-liquidity-widgets/src/hooks/useNftApproval.ts
@@ -1,4 +1,5 @@
 import { useWeb3Provider } from "@/hooks/useProvider";
+import { rpcFetch } from "@kyber/rpc-client/fetch";
 import {
   calculateGasMargin,
   decodeAddress,
@@ -11,12 +12,12 @@ import { useCallback, useEffect, useState } from "react";
 let intervalCheckApproval: ReturnType<typeof setTimeout> | null;
 
 export function useNftApproval({
-  rpcUrl,
+  chainId,
   nftManagerContract,
   nftId,
   spender,
 }: {
-  rpcUrl: string;
+  chainId: number;
   nftManagerContract: string;
   nftId?: number;
   spender?: string;
@@ -41,7 +42,7 @@ export function useNftApproval({
       value: "0x0",
     };
 
-    const gasEstimation = await estimateGas(rpcUrl, txData);
+    const gasEstimation = await estimateGas(chainId, txData);
     const txHash = await walletClient.sendTransaction({
       account,
       to: nftManagerContract as `0x${string}`,
@@ -51,24 +52,28 @@ export function useNftApproval({
       chain: undefined,
     });
     setPendingTx(txHash);
-  }, [account, nftId, nftManagerContract, rpcUrl, spender, walletClient]);
+  }, [account, chainId, nftId, nftManagerContract, spender, walletClient]);
 
   useEffect(() => {
     if (pendingTx) {
       const i = setInterval(() => {
-        isTransactionSuccessful(rpcUrl, pendingTx).then((res) => {
-          if (res) {
-            setPendingTx("");
-            setIsApproved(res.status);
-          }
-        });
+        isTransactionSuccessful(chainId, pendingTx)
+          .then((res) => {
+            if (res) {
+              setPendingTx("");
+              setIsApproved(res.status);
+            }
+          })
+          .catch(() => {
+            /* ignore — will retry on next tick */
+          });
       }, 8_000);
 
       return () => {
         clearInterval(i);
       };
     }
-  }, [pendingTx, rpcUrl]);
+  }, [chainId, pendingTx]);
 
   const checkApproval = useCallback(async () => {
     if (!spender || !account || !nftId || pendingTx) return;
@@ -78,29 +83,16 @@ export function useNftApproval({
     const encodedTokenId = nftId.toString(16).padStart(64, "0");
     const data = "0x" + methodSignature + encodedTokenId;
 
-    fetch(rpcUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+    rpcFetch<string>(chainId, "eth_call", [
+      {
+        to: nftManagerContract,
+        data,
       },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "eth_call",
-        params: [
-          {
-            to: nftManagerContract,
-            data,
-          },
-          "latest",
-        ],
-      }),
-    })
-      .then((res) => res.json())
-      .then((res) => {
-        setIsChecking(false);
+      "latest",
+    ])
+      .then((result) => {
         if (
-          decodeAddress((res?.result || "").slice(2))?.toLowerCase() ===
+          decodeAddress((result || "").slice(2))?.toLowerCase() ===
           spender.toLowerCase()
         )
           setIsApproved(true);
@@ -109,7 +101,7 @@ export function useNftApproval({
       .finally(() => {
         setIsChecking(false);
       });
-  }, [account, nftId, nftManagerContract, pendingTx, rpcUrl, spender]);
+  }, [account, chainId, nftId, nftManagerContract, pendingTx, spender]);
 
   useEffect(() => {
     checkApproval();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1347,6 +1347,9 @@ importers:
       '@kyber/hooks':
         specifier: workspace:*
         version: link:../hooks
+      '@kyber/rpc-client':
+        specifier: workspace:*
+        version: link:../rpc-client
       '@kyber/svgr-esbuild-plugin':
         specifier: workspace:^
         version: link:../svgr-esbuild-plugin


### PR DESCRIPTION
Replace the single hardcoded defaultRpc endpoint with @kyber/rpc-client's automatic public-endpoint rotation and Kyber/default RPC fallback chain.

- Widget: createPublicClient now uses a viem custom transport backed by getRpcClient(chainId, { configRpcEndpoint: defaultRpc })
- useNftApproval: swap rpcUrl prop for chainId; replace raw fetch with rpcFetch; add .catch on isTransactionSuccessful polling
- Content: pass chainId instead of rpcUrl to useNftApproval