### PR TITLE
fix(rpc-client): retry HTTP 500, add Monad endpoints, tag errors

### DIFF
--- a/packages/liquidity-widgets/src/components/Action/useActionButton.ts
+++ b/packages/liquidity-widgets/src/components/Action/useActionButton.ts
@@ -13,7 +13,7 @@ import {
   univ3PoolNormalize,
   univ4Types,
 } from '@kyber/schema';
-import { PI_LEVEL, friendlyError } from '@kyber/utils';
+import { PI_LEVEL } from '@kyber/utils';
 
 import { ERROR_MESSAGE, translateErrorMessage } from '@/constants';
 import { ApprovalState } from '@/hooks/useApproval';
@@ -175,39 +175,63 @@ export default function useActionButton({ approval, deadline }: { approval: Appr
         [positionId]: approval.permit.data.permitData,
       };
     }
+
+    let data: BuildDataWithGas | undefined;
     try {
       const response = await fetch(`${API_URLS.ZAP_API}/${CHAIN_ID_TO_CHAIN[chainId]}/api/v1/in/route/build`, {
         method: 'POST',
         body: JSON.stringify(buildBody),
       });
 
-      let body: { data: BuildDataWithGas } | null = null;
-      body = await response.json();
-
-      const { data } = body || {};
-      if (data && data.callData && account) {
-        const txData = {
-          from: account,
-          to: data.routerAddress,
-          data: data.callData,
-          value: `0x${BigInt(data.value).toString(16)}`,
-        };
-
-        const { gasUsd, error } = await estimateGasForTx({ txData, chainId });
-
-        if (error || !gasUsd) {
-          setWidgetError(error);
-          return;
-        }
-        return { ...data, gasUsd };
+      let body: { data?: BuildDataWithGas; message?: string; error?: string } | null = null;
+      try {
+        body = await response.json();
+      } catch {
+        // Handled below based on HTTP status.
       }
 
-      if (data && 'message' in data && typeof data.message === 'string') {
-        throw new Error(data.message);
+      if (!response.ok) {
+        const apiMsg = body?.message || body?.error;
+        throw new Error(
+          `Build route step: build API returned HTTP ${response.status} ${response.statusText}${apiMsg ? ` — ${apiMsg}` : ''}`,
+        );
       }
-      throw new Error('Failed to build route');
+
+      data = body?.data;
+      if (!data?.callData) {
+        const apiMsg = body?.message || body?.error;
+        throw new Error(`Build route step: build API returned no data${apiMsg ? ` — ${apiMsg}` : ''}`);
+      }
     } catch (err) {
-      setWidgetError(friendlyError(err as Error));
+      const msg = (err as Error)?.message || 'unknown error';
+      setWidgetError(msg.startsWith('Build route step:') ? msg : `Build route step: ${msg}`);
+      console.error(err);
+      setGasLoading(false);
+      return;
+    }
+
+    if (!account) {
+      setGasLoading(false);
+      return;
+    }
+
+    try {
+      const txData = {
+        from: account,
+        to: data.routerAddress,
+        data: data.callData,
+        value: `0x${BigInt(data.value).toString(16)}`,
+      };
+
+      const { gasUsd, error } = await estimateGasForTx({ txData, chainId });
+
+      if (error || !gasUsd) {
+        setWidgetError(error || 'Estimate gas step: estimate gas failed');
+        return;
+      }
+      return { ...data, gasUsd };
+    } catch (err) {
+      setWidgetError(`Estimate gas step: ${(err as Error)?.message || 'unknown error'}`);
       console.error(err);
     } finally {
       setGasLoading(false);

--- a/packages/liquidity-widgets/src/utils/index.ts
+++ b/packages/liquidity-widgets/src/utils/index.ts
@@ -217,7 +217,7 @@ export const estimateGasForTx = async ({
 
     return {
       gasUsd: undefined,
-      error: friendlyError(message),
+      error: `Estimate gas step: ${friendlyError(message)}`,
     };
   }
 };

--- a/packages/rpc-client/src/client.ts
+++ b/packages/rpc-client/src/client.ts
@@ -19,6 +19,19 @@ const DEFAULT_MAX_BLOCK_LAG = 50;
 const DEFAULT_PROBE_INTERVAL_MS = 60000; // 1 minute
 
 /**
+ * Build a standardized RPC error message prefixed with "Rpc issue:" and tagged
+ * with the originating endpoint host and method, so failures are easy to spot
+ * in UI / logs.
+ */
+export function buildRpcErrorMessage(endpoint: string, method: string, detail: string): string {
+  // Extract host without relying on URL (DOM lib not available in this package).
+  // Strip protocol, then take substring up to first `/`, `?`, or `#`.
+  const noProto = endpoint.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
+  const host = noProto.split(/[/?#]/, 1)[0] || endpoint;
+  return `Rpc issue: [${method} @ ${host}] ${detail}`;
+}
+
+/**
  * RPC Client with automatic endpoint rotation, health probing, and fallback.
  *
  * Features:
@@ -503,22 +516,36 @@ export class RpcClient {
 
       if (!response.ok) {
         if (response.status === 429 || response.status === 402) {
-          throw new RpcError(429, 'Rate limit exceeded');
+          throw new RpcError(429, buildRpcErrorMessage(endpoint, method, 'Rate limit exceeded'));
         }
-        if (response.status === 502 || response.status === 503 || response.status === 504) {
-          throw new RpcError(response.status, `Provider unavailable: ${response.status} ${response.statusText}`);
+        if (response.status === 500 || response.status === 502 || response.status === 503 || response.status === 504) {
+          throw new RpcError(
+            response.status,
+            buildRpcErrorMessage(
+              endpoint,
+              method,
+              `Provider unavailable (HTTP ${response.status} ${response.statusText})`,
+            ),
+          );
         }
-        throw new RpcError(response.status, `HTTP error: ${response.status} ${response.statusText}`);
+        throw new RpcError(
+          response.status,
+          buildRpcErrorMessage(endpoint, method, `HTTP error ${response.status} ${response.statusText}`),
+        );
       }
 
       const data = (await response.json()) as JsonRpcResponse<T>;
 
       if (data.error) {
-        throw new RpcError(data.error.code, data.error.message, data.error.data);
+        throw new RpcError(
+          data.error.code,
+          buildRpcErrorMessage(endpoint, method, `JSON-RPC error ${data.error.code}: ${data.error.message}`),
+          data.error.data,
+        );
       }
 
       if (data.result === undefined) {
-        throw new RpcError(-1, 'No result in response');
+        throw new RpcError(-1, buildRpcErrorMessage(endpoint, method, 'No result in response'));
       }
 
       return {
@@ -534,10 +561,10 @@ export class RpcClient {
       }
 
       if ((error as Error).name === 'AbortError') {
-        throw new RpcError(-1, `Request timeout after ${effectiveTimeout}ms`);
+        throw new RpcError(-1, buildRpcErrorMessage(endpoint, method, `Request timeout after ${effectiveTimeout}ms`));
       }
 
-      throw new RpcError(-1, (error as Error).message);
+      throw new RpcError(-1, buildRpcErrorMessage(endpoint, method, (error as Error).message || 'Network error'));
     }
   }
 
@@ -570,12 +597,22 @@ export class RpcClient {
 
       if (!response.ok) {
         if (response.status === 429 || response.status === 402) {
-          throw new RpcError(429, 'Rate limit exceeded');
+          throw new RpcError(429, buildRpcErrorMessage(endpoint, 'batch', 'Rate limit exceeded'));
         }
-        if (response.status === 502 || response.status === 503 || response.status === 504) {
-          throw new RpcError(response.status, `Provider unavailable: ${response.status} ${response.statusText}`);
+        if (response.status === 500 || response.status === 502 || response.status === 503 || response.status === 504) {
+          throw new RpcError(
+            response.status,
+            buildRpcErrorMessage(
+              endpoint,
+              'batch',
+              `Provider unavailable (HTTP ${response.status} ${response.statusText})`,
+            ),
+          );
         }
-        throw new RpcError(response.status, `HTTP error: ${response.status} ${response.statusText}`);
+        throw new RpcError(
+          response.status,
+          buildRpcErrorMessage(endpoint, 'batch', `HTTP error ${response.status} ${response.statusText}`),
+        );
       }
 
       const data = (await response.json()) as JsonRpcResponse[];
@@ -586,7 +623,18 @@ export class RpcClient {
       const results: unknown[] = [];
       for (const item of sortedData) {
         if (item.error) {
-          throw new RpcError(item.error.code, item.error.message, item.error.data);
+          // Requests are sent with 1-indexed numeric ids (see `requests` above), but
+          // a non-compliant provider could echo back a string or null id — guard
+          // against NaN/out-of-range lookups so we always surface the error even
+          // if the method tag falls back to "batch".
+          const rawId = Number(item.id);
+          const idx = Number.isFinite(rawId) ? rawId - 1 : -1;
+          const failedMethod = calls[idx]?.method ?? 'batch';
+          throw new RpcError(
+            item.error.code,
+            buildRpcErrorMessage(endpoint, failedMethod, `JSON-RPC error ${item.error.code}: ${item.error.message}`),
+            item.error.data,
+          );
         }
         results.push(item.result);
       }
@@ -600,10 +648,10 @@ export class RpcClient {
       }
 
       if ((error as Error).name === 'AbortError') {
-        throw new RpcError(-1, `Request timeout after ${this.timeout}ms`);
+        throw new RpcError(-1, buildRpcErrorMessage(endpoint, 'batch', `Request timeout after ${this.timeout}ms`));
       }
 
-      throw new RpcError(-1, (error as Error).message);
+      throw new RpcError(-1, buildRpcErrorMessage(endpoint, 'batch', (error as Error).message || 'Network error'));
     }
   }
 
@@ -732,6 +780,7 @@ export class RpcClient {
         -32000, // Server error
         -32603, // Internal error
         -1, // Timeout
+        500, // Internal server error
         502, // Bad gateway
         503, // Service unavailable
         504, // Gateway timeout

--- a/packages/rpc-client/src/endpoints.ts
+++ b/packages/rpc-client/src/endpoints.ts
@@ -131,7 +131,15 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
     'https://ronin.gateway.tenderly.co',
     'https://ronin.lgns.net/rpc',
   ],
-  [MONAD]: ['https://rpc1.monad.xyz', 'https://rpc-mainnet.monadinfra.com', 'https://rpc.monad.xyz'],
+  [MONAD]: [
+    'https://rpc1.monad.xyz',
+    'https://rpc2.monad.xyz',
+    'https://rpc3.monad.xyz',
+    'https://rpc4.monad.xyz',
+    'https://rpc.monad.xyz',
+    'https://rpc-mainnet.monadinfra.com',
+    'https://monad.gateway.tenderly.co',
+  ],
 };
 
 export const KYBER_RPC_ENDPOINTS: Record<number, string> = {

--- a/packages/rpc-client/src/fetch.ts
+++ b/packages/rpc-client/src/fetch.ts
@@ -1,4 +1,4 @@
-import { getRpcClient } from './client';
+import { buildRpcErrorMessage, getRpcClient } from './client';
 import { JsonRpcResponse, RpcClientConfig, RpcError } from './types';
 
 /**
@@ -126,17 +126,24 @@ async function fetchDirectRpc<T>(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw new RpcError(response.status, `HTTP error: ${response.status} ${response.statusText}`);
+      throw new RpcError(
+        response.status,
+        buildRpcErrorMessage(rpcUrl, method, `HTTP error ${response.status} ${response.statusText}`),
+      );
     }
 
     const data = (await response.json()) as JsonRpcResponse<T>;
 
     if (data.error) {
-      throw new RpcError(data.error.code, data.error.message, data.error.data);
+      throw new RpcError(
+        data.error.code,
+        buildRpcErrorMessage(rpcUrl, method, `JSON-RPC error ${data.error.code}: ${data.error.message}`),
+        data.error.data,
+      );
     }
 
     if (data.result === undefined) {
-      throw new RpcError(-1, 'No result in response');
+      throw new RpcError(-1, buildRpcErrorMessage(rpcUrl, method, 'No result in response'));
     }
 
     return data.result;
@@ -148,10 +155,10 @@ async function fetchDirectRpc<T>(
     }
 
     if ((error as Error).name === 'AbortError') {
-      throw new RpcError(-1, `Request timeout after ${timeout}ms`);
+      throw new RpcError(-1, buildRpcErrorMessage(rpcUrl, method, `Request timeout after ${timeout}ms`));
     }
 
-    throw new RpcError(-1, (error as Error).message);
+    throw new RpcError(-1, buildRpcErrorMessage(rpcUrl, method, (error as Error).message || 'Network error'));
   }
 }
 

--- a/packages/rpc-client/src/types.ts
+++ b/packages/rpc-client/src/types.ts
@@ -130,7 +130,14 @@ export class AllEndpointsFailedError extends Error {
     public readonly chainId: number,
     public readonly errors: Array<{ endpoint: string; error: Error }>,
   ) {
-    super(`All RPC endpoints failed for chain ${chainId}`);
+    // Inner error.message already carries the `Rpc issue: [method @ host] ...`
+    // prefix from the client's throw sites. Strip it so the composed message
+    // keeps a single leading "Rpc issue:" instead of nesting it per-endpoint.
+    const reasons = errors.map(({ error }) => error.message.replace(/^Rpc issue:\s*/, '')).join(' | ');
+    super(
+      `Rpc issue: all ${errors.length} RPC endpoint${errors.length === 1 ? '' : 's'} failed for chain ${chainId}` +
+        (reasons ? ` — ${reasons}` : ''),
+    );
     this.name = 'AllEndpointsFailedError';
   }
 }

--- a/packages/utils/src/crypto/transaction.ts
+++ b/packages/utils/src/crypto/transaction.ts
@@ -41,7 +41,7 @@ export const estimateGasForTx = async ({
 
     return {
       gasUsd: undefined,
-      error: friendlyError(message),
+      error: `Estimate gas step: ${friendlyError(message)}`,
     };
   }
 };

--- a/packages/zap-create-widgets/src/components/Action/useActionButton.ts
+++ b/packages/zap-create-widgets/src/components/Action/useActionButton.ts
@@ -5,7 +5,7 @@ import { t } from '@lingui/macro';
 import { APPROVAL_STATE, useErc20Approvals } from '@kyber/hooks';
 import { API_URLS, CHAIN_ID_TO_CHAIN } from '@kyber/schema';
 import { translateZapImpact } from '@kyber/ui';
-import { PI_LEVEL, friendlyError } from '@kyber/utils';
+import { PI_LEVEL } from '@kyber/utils';
 import { parseUnits } from '@kyber/utils/crypto';
 
 import { ERROR_MESSAGE, translateErrorMessage } from '@/constants';
@@ -130,45 +130,77 @@ export default function useActionButton({
   const getGasEstimation = async ({ deadline }: { deadline: number }) => {
     if (!zapInfo) return;
     setGasLoading(true);
-    const res = await fetch(`${API_URLS.ZAP_API}/${CHAIN_ID_TO_CHAIN[chainId]}/api/v1/create/route/build`, {
-      method: 'POST',
-      body: JSON.stringify({
-        sender: account,
-        recipient: account,
-        route: zapInfo.route,
-        deadline,
-        source,
-      }),
-    })
-      .then(res => res.json())
-      .then(async res => {
-        const { data } = res || {};
-        if (data?.callData && account) {
-          const txData = {
-            from: account,
-            to: data.routerAddress,
-            data: data.callData,
-            value: `0x${BigInt(data.value).toString(16)}`,
-          };
 
-          const { gasUsd, error } = await estimateGasForTx({ rpcUrl, txData, chainId });
-
-          if (error) {
-            setWidgetError(error);
-            return;
-          }
-          return gasUsd;
-        }
-      })
-      .catch(err => {
-        setWidgetError(friendlyError(err as Error));
-        console.error(err);
-      })
-      .finally(() => {
-        setGasLoading(false);
+    let data: { callData: string; routerAddress: string; value: string } | undefined;
+    try {
+      const response = await fetch(`${API_URLS.ZAP_API}/${CHAIN_ID_TO_CHAIN[chainId]}/api/v1/create/route/build`, {
+        method: 'POST',
+        body: JSON.stringify({
+          sender: account,
+          recipient: account,
+          route: zapInfo.route,
+          deadline,
+          source,
+        }),
       });
 
-    return res;
+      let body: {
+        data?: { callData: string; routerAddress: string; value: string };
+        message?: string;
+        error?: string;
+      } | null = null;
+      try {
+        body = await response.json();
+      } catch {
+        // Handled below based on HTTP status.
+      }
+
+      if (!response.ok) {
+        const apiMsg = body?.message || body?.error;
+        throw new Error(
+          `Build route step: build API returned HTTP ${response.status} ${response.statusText}${apiMsg ? ` — ${apiMsg}` : ''}`,
+        );
+      }
+
+      data = body?.data;
+      if (!data?.callData) {
+        const apiMsg = body?.message || body?.error;
+        throw new Error(`Build route step: build API returned no data${apiMsg ? ` — ${apiMsg}` : ''}`);
+      }
+    } catch (err) {
+      const msg = (err as Error)?.message || 'unknown error';
+      setWidgetError(msg.startsWith('Build route step:') ? msg : `Build route step: ${msg}`);
+      console.error(err);
+      setGasLoading(false);
+      return;
+    }
+
+    if (!account) {
+      setGasLoading(false);
+      return;
+    }
+
+    try {
+      const txData = {
+        from: account,
+        to: data.routerAddress,
+        data: data.callData,
+        value: `0x${BigInt(data.value).toString(16)}`,
+      };
+
+      const { gasUsd, error } = await estimateGasForTx({ rpcUrl, txData, chainId });
+
+      if (error) {
+        setWidgetError(error);
+        return;
+      }
+      return gasUsd;
+    } catch (err) {
+      setWidgetError(`Estimate gas step: ${(err as Error)?.message || 'unknown error'}`);
+      console.error(err);
+    } finally {
+      setGasLoading(false);
+    }
   };
 
   const hanldeClick = async () => {

--- a/packages/zap-create-widgets/src/utils/index.ts
+++ b/packages/zap-create-widgets/src/utils/index.ts
@@ -182,7 +182,7 @@ export const estimateGasForTx = async ({
 
     return {
       gasUsd: undefined,
-      error: friendlyError(message),
+      error: `Estimate gas step: ${friendlyError(message)}`,
     };
   }
 };

--- a/packages/zap-migration-widgets/src/components/Action/useActionButton.ts
+++ b/packages/zap-migration-widgets/src/components/Action/useActionButton.ts
@@ -5,7 +5,7 @@ import { msg, t } from '@lingui/macro';
 
 import { PermitNftState } from '@kyber/hooks';
 import { getDexName, univ2Types, univ4Types } from '@kyber/schema';
-import { PI_LEVEL, friendlyError } from '@kyber/utils';
+import { PI_LEVEL } from '@kyber/utils';
 import { estimateGasForTx } from '@kyber/utils/crypto/transaction';
 
 import { useOwner } from '@/components/Action/useOwner';
@@ -316,8 +316,9 @@ export function useActionButton({ onConnectWallet, onSwitchChain }: UseActionBut
     if (!route || !connectedAccount.address) return;
     setGasLoading(true);
 
+    let buildData;
     try {
-      const buildData = await buildRouteData({
+      buildData = await buildRouteData({
         sender: connectedAccount.address,
         route: route.route,
         source: client,
@@ -336,12 +337,15 @@ export function useActionButton({ onConnectWallet, onSwitchChain }: UseActionBut
           },
         }),
       });
-      if (!buildData) {
-        setGasLoading(false);
-        setWidgetError(t`Build route data failed`);
-        return;
-      }
+    } catch (error) {
+      const msg = (error as Error)?.message || 'unknown error';
+      setWidgetError(msg.startsWith('Build route step:') ? msg : `Build route step: ${msg}`);
+      console.log('build route error', error);
+      setGasLoading(false);
+      return;
+    }
 
+    try {
       const txData = {
         from: connectedAccount.address,
         to: buildData.routerAddress,
@@ -349,16 +353,15 @@ export function useActionButton({ onConnectWallet, onSwitchChain }: UseActionBut
         value: `0x${BigInt(buildData.value).toString(16)}`,
       };
       const { gasUsd, error } = await estimateGasForTx({ txData, chainId });
-      setGasLoading(false);
 
       if (error || !gasUsd) {
-        setWidgetError(error || t`Estimate gas failed`);
+        setWidgetError(error || 'Estimate gas step: estimate gas failed');
         return;
       }
 
       return { ...buildData, gasUsd };
     } catch (error) {
-      setWidgetError(friendlyError(error as Error));
+      setWidgetError(`Estimate gas step: ${(error as Error)?.message || 'unknown error'}`);
       console.log('estimate gas error', error);
     } finally {
       setGasLoading(false);

--- a/packages/zap-migration-widgets/src/utils/index.ts
+++ b/packages/zap-migration-widgets/src/utils/index.ts
@@ -24,24 +24,44 @@ export const buildRouteData = async ({
   permits?: {
     [key: string]: string;
   };
-}): Promise<BuildRouteData | null> => {
-  const buildData = await fetch(`${API_URLS.ZAP_API}/${CHAIN_ID_TO_CHAIN[chainId]}/api/v1/migrate/route/build`, {
-    method: 'POST',
-    body: JSON.stringify({
-      sender,
-      route,
-      burnNft: false,
-      source,
-      referral,
-      deadline,
-      permits,
-    }),
-  })
-    .then(res => res.json())
-    .then(async res => {
-      const { data } = res || {};
-      return data;
+}): Promise<BuildRouteData> => {
+  const url = `${API_URLS.ZAP_API}/${CHAIN_ID_TO_CHAIN[chainId]}/api/v1/migrate/route/build`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      body: JSON.stringify({
+        sender,
+        route,
+        burnNft: false,
+        source,
+        referral,
+        deadline,
+        permits,
+      }),
     });
+  } catch (e) {
+    throw new Error(`Build route step: network error calling build API — ${(e as Error).message || 'unknown error'}`);
+  }
 
-  return buildData;
+  let body: { data?: BuildRouteData; message?: string; error?: string } | null = null;
+  try {
+    body = await res.json();
+  } catch {
+    // Swallow — handled below based on HTTP status.
+  }
+
+  if (!res.ok) {
+    const apiMsg = body?.message || body?.error;
+    throw new Error(
+      `Build route step: build API returned HTTP ${res.status} ${res.statusText}${apiMsg ? ` — ${apiMsg}` : ''}`,
+    );
+  }
+
+  if (!body?.data) {
+    const apiMsg = body?.message || body?.error;
+    throw new Error(`Build route step: build API returned no data${apiMsg ? ` — ${apiMsg}` : ''}`);
+  }
+
+  return body.data;
 };

--- a/packages/zap-out-widgets/src/components/Action/useActionButton.ts
+++ b/packages/zap-out-widgets/src/components/Action/useActionButton.ts
@@ -4,7 +4,7 @@ import { t } from '@lingui/macro';
 
 import { PermitNftState, usePositionOwner } from '@kyber/hooks';
 import { FARMING_CONTRACTS, univ2Types } from '@kyber/schema';
-import { PI_LEVEL, friendlyError } from '@kyber/utils';
+import { PI_LEVEL } from '@kyber/utils';
 import { estimateGasForTx } from '@kyber/utils/crypto/transaction';
 
 import { useApproval } from '@/hooks/useApproval';
@@ -92,8 +92,9 @@ export default function useActionButton() {
     if (!route || !connectedAccount.address) return;
     setGasLoading(true);
 
+    let buildData;
     try {
-      const buildData = await buildRouteData({
+      buildData = await buildRouteData({
         sender: connectedAccount.address,
         route: route.route,
         source,
@@ -107,11 +108,15 @@ export default function useActionButton() {
             },
           }),
       });
-      if (!buildData) {
-        setGasLoading(false);
-        return;
-      }
+    } catch (error) {
+      const msg = (error as Error)?.message || 'unknown error';
+      setWidgetError(msg.startsWith('Build route step:') ? msg : `Build route step: ${msg}`);
+      console.log('build route error', error);
+      setGasLoading(false);
+      return;
+    }
 
+    try {
       const txData = {
         from: connectedAccount.address,
         to: buildData.routerAddress,
@@ -119,16 +124,15 @@ export default function useActionButton() {
         value: `0x${BigInt(buildData.value).toString(16)}`,
       };
       const { gasUsd, error } = await estimateGasForTx({ txData, chainId });
-      setGasLoading(false);
 
       if (error || !gasUsd) {
-        setWidgetError(error || t`Estimate Gas Failed`);
+        setWidgetError(error || 'Estimate gas step: estimate gas failed');
         return;
       }
 
       return { ...buildData, gasUsd };
     } catch (error) {
-      setWidgetError(friendlyError(error as Error));
+      setWidgetError(`Estimate gas step: ${(error as Error)?.message || 'unknown error'}`);
       console.log('estimate gas error', error);
     } finally {
       setGasLoading(false);

--- a/packages/zap-out-widgets/src/utils/index.ts
+++ b/packages/zap-out-widgets/src/utils/index.ts
@@ -42,24 +42,44 @@ export const buildRouteData = async ({
   chainId: ChainId;
   deadline: number;
   permits?: { [x: string]: string };
-}): Promise<BuildRouteData | null> => {
-  const buildData = await fetch(`${API_URLS.ZAP_API}/${CHAIN_ID_TO_CHAIN[chainId]}/api/v1/out/route/build`, {
-    method: 'POST',
-    body: JSON.stringify({
-      sender,
-      route,
-      burnNft: false,
-      source,
-      referral,
-      deadline,
-      ...(permits ? { permits } : {}),
-    }),
-  })
-    .then(res => res.json())
-    .then(async res => {
-      const { data } = res || {};
-      return data;
+}): Promise<BuildRouteData> => {
+  const url = `${API_URLS.ZAP_API}/${CHAIN_ID_TO_CHAIN[chainId]}/api/v1/out/route/build`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      body: JSON.stringify({
+        sender,
+        route,
+        burnNft: false,
+        source,
+        referral,
+        deadline,
+        ...(permits ? { permits } : {}),
+      }),
     });
+  } catch (e) {
+    throw new Error(`Build route step: network error calling build API — ${(e as Error).message || 'unknown error'}`);
+  }
 
-  return buildData;
+  let body: { data?: BuildRouteData; message?: string; error?: string } | null = null;
+  try {
+    body = await res.json();
+  } catch {
+    // Swallow — handled below based on HTTP status.
+  }
+
+  if (!res.ok) {
+    const apiMsg = body?.message || body?.error;
+    throw new Error(
+      `Build route step: build API returned HTTP ${res.status} ${res.statusText}${apiMsg ? ` — ${apiMsg}` : ''}`,
+    );
+  }
+
+  if (!body?.data) {
+    const apiMsg = body?.message || body?.error;
+    throw new Error(`Build route step: build API returned no data${apiMsg ? ` — ${apiMsg}` : ''}`);
+  }
+
+  return body.data;
 };


### PR DESCRIPTION
- Treat HTTP 500 as a retryable 'provider unavailable' status in fetchRpc/fetchBatchRpc and add 500 to isRetryableError codes so a flaky RPC rotates to the next endpoint instead of surfacing to the UI (fixes 'Failed to load position — HTTP error: 500' in the zap migration widget).
- Expand Monad (chainId 143) endpoints from 3 → 7 by adding rpc2/rpc3/rpc4.monad.xyz and monad.gateway.tenderly.co, all verified against chainId, blockNumber, eth_call, getCode, getBalance, batch, and getBlockByNumber.
- Prefix every thrown RpcError with 'Rpc issue: [method @ host] …' via a new buildRpcErrorMessage helper, and enrich AllEndpointsFailedError with per-endpoint reasons so failures are easy to identify in the UI and logs.