### PR TITLE
chore(swap): add diagnostic logs for empty amountInUsd on build route

### DIFF
--- a/apps/kyberswap-interface/src/components/SwapForm/hooks/useBuildRoute.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/hooks/useBuildRoute.tsx
@@ -71,6 +71,22 @@ const useBuildRoute = (args: Args) => {
     delete rawRouteSummary.rawAmountInUsd
     delete rawRouteSummary.rawAmountOutUsd
 
+    if (!rawRouteSummary.amountInUsd || !rawRouteSummary.amountOutUsd) {
+      console.error('[buildRoute] amountInUsd/amountOutUsd missing or empty before send', {
+        finalAmountInUsd: rawRouteSummary.amountInUsd,
+        finalAmountOutUsd: rawRouteSummary.amountOutUsd,
+        rawAmountInUsd: routeSummary.rawAmountInUsd,
+        rawAmountOutUsd: routeSummary.rawAmountOutUsd,
+        transformedAmountInUsd: routeSummary.amountInUsd,
+        transformedAmountOutUsd: routeSummary.amountOutUsd,
+        tokenIn: routeSummary.tokenIn,
+        tokenOut: routeSummary.tokenOut,
+        chainId,
+        tokenInDecimals: currencyIn?.decimals,
+        tokenOutDecimals: currencyOut?.decimals,
+      })
+    }
+
     const payload: BuildRoutePayload = {
       routeSummary: rawRouteSummary,
       deadline: Math.floor(Date.now() / 1000) + transactionTimeout,

--- a/apps/kyberswap-interface/src/services/route/index.ts
+++ b/apps/kyberswap-interface/src/services/route/index.ts
@@ -45,6 +45,16 @@ const routeApi = createApi({
         if (baseResponse?.data?.routeSummary && routeSummary && chainId && tokenInDecimals && tokenOutDecimals) {
           const { amountIn, amountOut } = routeSummary
 
+          if (!routeSummary.amountInUsd || !routeSummary.amountOutUsd) {
+            console.warn('[getRoute] aggregator returned empty amountInUsd/amountOutUsd', {
+              amountInUsd: routeSummary.amountInUsd,
+              amountOutUsd: routeSummary.amountOutUsd,
+              tokenIn,
+              tokenOut,
+              chainId,
+            })
+          }
+
           try {
             const wrappedTokenIn = getWrappedToken(tokenIn, chainId)
             const wrappedTokenOut = getWrappedToken(tokenOut, chainId)
@@ -87,8 +97,26 @@ const routeApi = createApi({
               },
             }
           } catch (error) {
-            console.error('Failed to fetch on-chain price:', error)
+            console.error('[getRoute] on-chain price fetch failed; rawAmount*Usd will not be set', {
+              error,
+              tokenIn,
+              tokenOut,
+              chainId,
+              apiAmountInUsd: routeSummary.amountInUsd,
+              apiAmountOutUsd: routeSummary.amountOutUsd,
+            })
           }
+        } else {
+          console.warn('[getRoute] transform skipped; rawAmount*Usd will not be set', {
+            hasRouteSummary: !!routeSummary,
+            chainId,
+            tokenInDecimals,
+            tokenOutDecimals,
+            tokenIn,
+            tokenOut,
+            apiAmountInUsd: routeSummary?.amountInUsd,
+            apiAmountOutUsd: routeSummary?.amountOutUsd,
+          })
         }
 
         // Return original response if conditions are not met or request fails


### PR DESCRIPTION
Log at three points to pinpoint the cause when build route receives missing/empty amountInUsd or amountOutUsd: aggregator returning empty values, price-fetch transform throwing, and transform skipped due to missing chainId/decimals. Adds a final detection log in useBuildRoute with full context so production reports can be classified directly.