### PR TITLE
perf(earn): reduce Merkl API load and tighten post-claim refresh

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/components/ClaimAllModal/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/ClaimAllModal/index.tsx
@@ -64,6 +64,7 @@ type Props = {
   onPositionStatusChange?: (value: PositionStatus) => void
   merklChainRewards?: ChainRewardInfo[]
   merklTotalUsdValue?: number
+  merklSyncingChainIds?: number[]
   onClaimMerkl?: (chainId: number) => Promise<string | undefined>
   activeTab?: RewardTabType
   onTabChange?: (tab: RewardTabType) => void
@@ -81,6 +82,7 @@ export default function ClaimAllModal({
   onPositionStatusChange,
   merklChainRewards = [],
   merklTotalUsdValue = 0,
+  merklSyncingChainIds = [],
   onClaimMerkl,
   activeTab: controlledTab,
   onTabChange,
@@ -108,6 +110,8 @@ export default function ClaimAllModal({
 
   const selectedRewardChain = selectedChainId ? currentChains.find(c => c.chainId === selectedChainId) : null
   const isClaiming = !!(selectedChainId && claimingByChain[selectedChainId])
+  const isSyncingSelectedMerkl =
+    activeTab === 'bonus' && !!selectedChainId && merklSyncingChainIds.includes(selectedChainId)
 
   const handleClaim = useCallback(async () => {
     if (!library || !selectedChainId) return
@@ -313,15 +317,27 @@ export default function ClaimAllModal({
           )}
         </ClaimInfoWrapper>
 
+        {isSyncingSelectedMerkl && (
+          <Text fontSize={12} color={theme.warning} sx={{ marginTop: '-4px' }}>
+            {t`Syncing your last claim with Merkl — please wait a moment.`}
+          </Text>
+        )}
+
         <Row gap="16px" flexDirection={upToExtraSmall ? 'column-reverse' : 'row'}>
           <ButtonOutlined onClick={onClose}>{t`Cancel`}</ButtonOutlined>
           <ButtonPrimary
             gap="4px"
-            disabled={isClaiming || !selectedRewardChain?.claimableUsdValue}
+            disabled={isClaiming || isSyncingSelectedMerkl || !selectedRewardChain?.claimableUsdValue}
             onClick={handleClaim}
           >
-            {isClaiming && <Loader stroke={'#505050'} />}
-            {isClaiming ? t`Claiming` : activeTab === 'bonus' ? t`Claim Incentives` : t`Claim Rewards`}
+            {(isClaiming || isSyncingSelectedMerkl) && <Loader stroke={'#505050'} />}
+            {isClaiming
+              ? t`Claiming`
+              : isSyncingSelectedMerkl
+              ? t`Syncing`
+              : activeTab === 'bonus'
+              ? t`Claim Incentives`
+              : t`Claim Rewards`}
           </ButtonPrimary>
         </Row>
       </Wrapper>

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useClaimMerklRewards.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useClaimMerklRewards.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { ethers } from 'ethers'
 import { useCallback } from 'react'
-import { useLazyMerklRewardsQuery } from 'services/rewardMerkl'
+import { MerklRewardsResponse } from 'services/rewardMerkl'
 
 import { NotificationType } from 'components/Announcement/type'
 import MERKL_DISTRIBUTOR_ABI from 'constants/abis/merkl-distributor.json'
@@ -20,19 +20,11 @@ const useClaimMerklRewards = () => {
   const addTransactionWithType = useTransactionAdder()
   const { account } = useActiveWeb3React()
   const { library } = useWeb3React()
-  const [fetchMerklRewards] = useLazyMerklRewardsQuery()
 
   const claimMerklRewards = useCallback(
-    async (targetChainId: number) => {
+    async (targetChainId: number, chainRewards: MerklRewardsResponse | undefined) => {
       if (!library || !account) return
 
-      // Always fetch fresh data right before claiming to get the latest merkle root & proofs
-      const { data } = await fetchMerklRewards({
-        address: account,
-        chainId: String(targetChainId),
-      })
-
-      const chainRewards = data?.find(item => item.chain.id === targetChainId)
       if (!chainRewards?.rewards?.length) {
         notify({
           title: t`Error`,
@@ -111,7 +103,7 @@ const useClaimMerklRewards = () => {
 
       return txHash
     },
-    [account, addTransactionWithType, fetchMerklRewards, library, notify],
+    [account, addTransactionWithType, library, notify],
   )
 
   return { claimMerklRewards }

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
@@ -92,6 +92,9 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
   const [reloadMerklChain] = useReloadMerklChainMutation()
   const [rewardTab, setRewardTab] = useState<RewardTabType>('ks')
   const merklRetryInFlightRef = useRef<Set<number>>(new Set())
+  // Mirror of `merklRetryInFlightRef` exposed to the UI so callers can disable the claim
+  // button for chains whose post-claim sync hasn't finished yet.
+  const [merklSyncingChainIds, setMerklSyncingChainIds] = useState<number[]>([])
   // Keep `account` reachable from in-flight async retry loops so wallet disconnect aborts cleanly
   // (closure capture would hold the original account string indefinitely otherwise).
   const accountRef = useRef(account)
@@ -438,13 +441,13 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
   const reloadMerklUntilUpdated = useCallback(
     async (chainId: number, baselineClaimableUsd: number) => {
       if (!accountRef.current) return
-      // If a retry loop is already running for this chain, fall back to a single refetch so the
-      // second claim's data still gets a chance to sync via the next poll/refetch cycle.
-      if (merklRetryInFlightRef.current.has(chainId)) {
-        refetchMerklRewards()
-        return
-      }
+      // A retry loop is already running for this chain — return without firing another
+      // refetch. The in-flight loop will eventually call `refetchMerklRewards` itself (on
+      // catch-up or budget exhaust), so any extra refetch here would race against the
+      // loop's per-chain reload calls and double the request count to Merkl.
+      if (merklRetryInFlightRef.current.has(chainId)) return
       merklRetryInFlightRef.current.add(chainId)
+      setMerklSyncingChainIds(prev => (prev.includes(chainId) ? prev : [...prev, chainId]))
 
       const INITIAL_DELAY = 10_000
       const RETRY_INTERVAL = 8_000
@@ -486,6 +489,7 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
         refetchMerklRewards()
       } finally {
         merklRetryInFlightRef.current.delete(chainId)
+        setMerklSyncingChainIds(prev => prev.filter(id => id !== chainId))
       }
     },
     [reloadMerklChain, refetchMerklRewards],
@@ -613,6 +617,7 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
         onPositionStatusChange={setPositionStatus}
         merklChainRewards={merklChainRewards}
         merklTotalUsdValue={merklTotalUsdValue}
+        merklSyncingChainIds={merklSyncingChainIds}
         onClaimMerkl={handleClaimMerkl}
         activeTab={rewardTab}
         onTabChange={setRewardTab}

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
@@ -86,6 +86,7 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
     chainRewards: merklChainRewards,
     totalUsdValue: merklTotalUsdValue,
     refetch: refetchMerklRewards,
+    rawData: merklRawData,
   } = useMerklRewards()
   const { claimMerklRewards } = useClaimMerklRewards()
   const [reloadMerklChain] = useReloadMerklChainMutation()
@@ -581,7 +582,8 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
 
   const handleClaimMerkl = useCallback(
     async (targetChainId: number) => {
-      const txHash = await claimMerklRewards(targetChainId)
+      const chainRewards = merklRawData?.find(item => item.chain.id === targetChainId)
+      const txHash = await claimMerklRewards(targetChainId, chainRewards)
       if (txHash) {
         setPendingClaims(prev => {
           const claimKey = `merkl:${targetChainId}`
@@ -591,7 +593,7 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
       }
       return txHash
     },
-    [claimMerklRewards],
+    [claimMerklRewards, merklRawData],
   )
 
   const claimAllRewardsModal =

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
@@ -461,11 +461,12 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
           // Treating an errored response as "indexer caught up" would exit the loop prematurely.
           if ('data' in res) {
             const chainData = res.data?.find(c => c.chain.id === chainId)
-            // Require chainData to actually be present before deciding the indexer caught up.
-            // Merkl can return an empty array transiently while its cache is rebuilding after
-            // `reloadChainId` — that would otherwise read as claimable=0 and trigger a false-
-            // positive early exit, leaving the UI to wait for the next polling cycle.
-            if (chainData) {
+            // Require chainData to have actual reward entries before deciding the indexer
+            // caught up. Merkl can transiently return an empty array OR a chain entry with
+            // `rewards: []` while its cache is rebuilding after `reloadChainId` — both would
+            // read as claimable=0 and trigger a false-positive early exit, stopping the retry
+            // loop after a single attempt and leaving the UI to wait for the next poll cycle.
+            if (chainData?.rewards?.length) {
               const currentClaimableUsd = computeChainClaimableUsd(chainData)
               if (currentClaimableUsd < baselineClaimableUsd) {
                 // Indexer has caught up — sync the main query and stop

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useKemRewards.tsx
@@ -461,12 +461,17 @@ const useKemRewards = (props?: UseKemRewardsProps) => {
           // Treating an errored response as "indexer caught up" would exit the loop prematurely.
           if ('data' in res) {
             const chainData = res.data?.find(c => c.chain.id === chainId)
-            const currentClaimableUsd = computeChainClaimableUsd(chainData)
-
-            if (currentClaimableUsd < baselineClaimableUsd) {
-              // Indexer has caught up — sync the main query and stop
-              refetchMerklRewards()
-              return
+            // Require chainData to actually be present before deciding the indexer caught up.
+            // Merkl can return an empty array transiently while its cache is rebuilding after
+            // `reloadChainId` — that would otherwise read as claimable=0 and trigger a false-
+            // positive early exit, leaving the UI to wait for the next polling cycle.
+            if (chainData) {
+              const currentClaimableUsd = computeChainClaimableUsd(chainData)
+              if (currentClaimableUsd < baselineClaimableUsd) {
+                // Indexer has caught up — sync the main query and stop
+                refetchMerklRewards()
+                return
+              }
             }
           }
 

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useMerklRewards.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useMerklRewards.tsx
@@ -20,12 +20,37 @@ type UseMerklRewardsProps = {
   positions?: Array<ParsedPosition>
 }
 
+const POLLING_INTERVAL_MS = 120_000
+
+// Single visibility listener shared across all hook instances. Each instance subscribes
+// to receive (newInterval, didResume) updates so it can update RTK Query's polling and
+// trigger an immediate refetch when the tab becomes visible again (RTK Query otherwise
+// waits the full interval before the next fetch).
+type VisibilityCallback = (interval: number, didResume: boolean) => void
+const visibilitySubscribers = new Set<VisibilityCallback>()
+let currentVisibilityInterval =
+  typeof document !== 'undefined' && document.visibilityState === 'hidden' ? 0 : POLLING_INTERVAL_MS
+let visibilityListenerRegistered = false
+
+const ensureVisibilityListener = () => {
+  if (visibilityListenerRegistered || typeof document === 'undefined') return
+  visibilityListenerRegistered = true
+  document.addEventListener('visibilitychange', () => {
+    const next = document.visibilityState === 'hidden' ? 0 : POLLING_INTERVAL_MS
+    if (next === currentVisibilityInterval) return
+    const didResume = currentVisibilityInterval === 0 && next > 0
+    currentVisibilityInterval = next
+    visibilitySubscribers.forEach(cb => cb(next, didResume))
+  })
+}
+
 const useMerklRewards = (options?: UseMerklRewardsProps) => {
   const { account } = useActiveWeb3React()
   const { filters } = useFilter()
   const { supportedChains } = useChainsConfig()
   const [tokenLogos, setTokenLogos] = useState<Record<string, string>>({})
   const [searchTokensBySymbol] = useLazySearchTokensBySymbolQuery()
+  const [pollingInterval, setPollingInterval] = useState(currentVisibilityInterval)
 
   const positionsKey = useMemo(
     () => (options?.positions || []).map(position => `${position.positionId}-${position.pool.address}`).join('|'),
@@ -67,8 +92,23 @@ const useMerklRewards = (options?: UseMerklRewardsProps) => {
       address: account || '',
       chainId: filters.chainIds || supportedChains.map(chain => chain.chainId).join(','),
     },
-    { skip: !account, pollingInterval: 60_000 },
+    { skip: !account, pollingInterval },
   )
+
+  useEffect(() => {
+    ensureVisibilityListener()
+    const onChange: VisibilityCallback = (next, didResume) => {
+      setPollingInterval(next)
+      // Tab just became visible after being hidden — RTK Query restarts the poll timer
+      // from now, so without this the user would wait the full interval before fresh data.
+      // Concurrent refetch calls from sibling hook instances are deduped by RTK Query.
+      if (didResume && account) refetchMerklRewards()
+    }
+    visibilitySubscribers.add(onChange)
+    return () => {
+      visibilitySubscribers.delete(onChange)
+    }
+  }, [account, refetchMerklRewards])
 
   const {
     baseRewards,

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useMerklRewards.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useMerklRewards.tsx
@@ -421,8 +421,10 @@ const useMerklRewards = (options?: UseMerklRewardsProps) => {
       totalUsdValue,
       loading: isFetching,
       refetch: refetchMerklRewards,
+      // Raw Merkl response — needed by the claim flow to access merkle proofs.
+      rawData: data,
     }),
-    [parsedRewardsByPosition, parsedRewards, chainRewards, totalUsdValue, isFetching, refetchMerklRewards],
+    [parsedRewardsByPosition, parsedRewards, chainRewards, totalUsdValue, isFetching, refetchMerklRewards, data],
   )
 }
 

--- a/apps/kyberswap-interface/src/services/rewardMerkl.ts
+++ b/apps/kyberswap-interface/src/services/rewardMerkl.ts
@@ -58,12 +58,52 @@ interface MerklRewardsParams {
 
 const MERKL_API_BASE = 'https://api.merkl.xyz/v4'
 
+// Tracks whether Merkl's batched (multi-chain) endpoint is usable in this session.
+// Only flipped to 'unsupported' when Merkl returns a permanent error (4xx other than 429),
+// so a transient network blip or 5xx doesn't permanently downgrade the session to per-chain.
+let batchedSupportState: 'unknown' | 'supported' | 'unsupported' = 'unknown'
+
+type BatchedResult = { ok: true; data: MerklRewardsResponse[] } | { ok: false; permanent: boolean }
+
+const fetchRewardsPerChain = async (address: string, chainIds: string[]): Promise<MerklRewardsResponse[]> => {
+  const results = await Promise.all(
+    chainIds.map(async cId => {
+      try {
+        const res = await fetch(`${MERKL_API_BASE}/users/${address}/rewards?chainId=${cId}`)
+        if (!res.ok) return null
+        const data: MerklRewardsResponse[] = await res.json()
+        return data
+      } catch {
+        return null
+      }
+    }),
+  )
+  return results.filter(Boolean).flat() as MerklRewardsResponse[]
+}
+
+const fetchRewardsBatched = async (address: string, chainIds: string[]): Promise<BatchedResult> => {
+  try {
+    const params = chainIds.map(id => `chainId=${id}`).join('&')
+    const res = await fetch(`${MERKL_API_BASE}/users/${address}/rewards?${params}`)
+    if (res.ok) {
+      return { ok: true, data: (await res.json()) as MerklRewardsResponse[] }
+    }
+    // 4xx (except 429 rate-limit) signals the request format/chainIds are unsupported — permanent.
+    // 5xx and 429 are transient; don't lock the session out of batched mode for them.
+    const permanent = res.status >= 400 && res.status < 500 && res.status !== 429
+    return { ok: false, permanent }
+  } catch {
+    // Network errors / aborts — transient
+    return { ok: false, permanent: false }
+  }
+}
+
 const rewardMerklApi = createApi({
   reducerPath: 'rewardMerklApi',
   baseQuery: fetchBaseQuery({
     baseUrl: MERKL_API_BASE,
   }),
-  keepUnusedDataFor: 1,
+  keepUnusedDataFor: 60,
   endpoints: builder => ({
     merklRewards: builder.query<MerklRewardsResponse[], MerklRewardsParams>({
       async queryFn({ address, chainId }) {
@@ -76,22 +116,25 @@ const rewardMerklApi = createApi({
           return { data: [] }
         }
 
-        // Fetch each chain individually to avoid a single unsupported chain failing the entire request
-        const results = await Promise.all(
-          chainIds.map(async cId => {
-            try {
-              const res = await fetch(`${MERKL_API_BASE}/users/${address}/rewards?chainId=${cId}`)
-              if (!res.ok) return null
-              const data: MerklRewardsResponse[] = await res.json()
-              return data
-            } catch {
-              return null
-            }
-          }),
-        )
+        // Single chain: no batching benefit, just fetch directly
+        if (chainIds.length === 1 || batchedSupportState === 'unsupported') {
+          return { data: await fetchRewardsPerChain(address, chainIds) }
+        }
 
-        const merged = results.filter(Boolean).flat() as MerklRewardsResponse[]
-        return { data: merged }
+        // Try the batched (multi-chain) endpoint first to collapse N requests into 1.
+        const batched = await fetchRewardsBatched(address, chainIds)
+        if (batched.ok) {
+          batchedSupportState = 'supported'
+          return { data: batched.data }
+        }
+
+        // Only lock to per-chain when the failure is permanent (e.g., Merkl 4xx says the
+        // batched format is unsupported). Transient failures fall back this once but leave
+        // batchedSupportState alone so the next poll can try batched again.
+        if (batched.permanent) {
+          batchedSupportState = 'unsupported'
+        }
+        return { data: await fetchRewardsPerChain(address, chainIds) }
       },
     }),
     // Force Merkl's backend to refresh its cache for a specific chain (used after a successful

--- a/apps/kyberswap-interface/src/services/rewardMerkl.ts
+++ b/apps/kyberswap-interface/src/services/rewardMerkl.ts
@@ -239,6 +239,6 @@ const rewardMerklApi = createApi({
   }),
 })
 
-export const { useMerklRewardsQuery, useLazyMerklRewardsQuery, useReloadMerklChainMutation } = rewardMerklApi
+export const { useMerklRewardsQuery, useReloadMerklChainMutation } = rewardMerklApi
 
 export default rewardMerklApi

--- a/apps/kyberswap-interface/src/services/rewardMerkl.ts
+++ b/apps/kyberswap-interface/src/services/rewardMerkl.ts
@@ -134,19 +134,47 @@ const rewardMerklApi = createApi({
           return { data: [] }
         }
 
-        // If any chain was recently refreshed via `reloadMerklChain`, force per-chain so we
-        // hit the URL pattern that Merkl's backend just refreshed. Marks are read without
-        // consuming so every fetch in the freshness window (poll, tab-resume, explicit
-        // refetch) goes per-chain — avoids a race where one fetch consumes the mark and
-        // a later refetch ends up on a potentially-stale batched URL.
-        const forcePerChain = chainIds.length > 1 && chainIds.some(isChainRecentlyReloaded)
-
-        // Single chain: no batching benefit, just fetch directly
-        if (chainIds.length === 1 || batchedSupportState === 'unsupported' || forcePerChain) {
+        // Per-chain for everything: single chain, or batched known broken
+        if (chainIds.length === 1 || batchedSupportState === 'unsupported') {
           return { data: await fetchRewardsPerChain(address, chainIds) }
         }
 
-        // Try the batched (multi-chain) endpoint first to collapse N requests into 1.
+        const reloadedChains = chainIds.filter(isChainRecentlyReloaded)
+
+        // Hybrid path: batched for everyone + per-chain ONLY for chains whose backend cache
+        // was just refreshed by `reloadMerklChain` (e.g., post-claim flow). The per-chain
+        // results are guaranteed fresh — they hit the same URL pattern Merkl just refreshed —
+        // and replace the corresponding entries from the batched response. Cost: 2 requests
+        // instead of N. Only the just-claimed chain pays the targeted refresh; other chains
+        // reuse the batched response.
+        if (reloadedChains.length > 0) {
+          // Every requested chain is reloaded — batched would be fully discarded by the merge,
+          // so skip it and just per-chain everything.
+          if (reloadedChains.length === chainIds.length) {
+            return { data: await fetchRewardsPerChain(address, chainIds) }
+          }
+
+          const [batchedResult, freshPerChain] = await Promise.all([
+            fetchRewardsBatched(address, chainIds),
+            fetchRewardsPerChain(address, reloadedChains),
+          ])
+          if (batchedResult.ok) {
+            batchedSupportState = 'supported'
+            const refreshedIds = new Set(freshPerChain.map(item => item.chain.id))
+            const merged = batchedResult.data.filter(item => !refreshedIds.has(item.chain.id)).concat(freshPerChain)
+            return { data: merged }
+          }
+
+          if (batchedResult.permanent) batchedSupportState = 'unsupported'
+          // Batched failed — fetch the remaining (non-reloaded) chains per-chain and merge
+          // with the already-in-hand `freshPerChain` so we don't re-request reloaded chains.
+          const reloadedSet = new Set(reloadedChains)
+          const remainingChains = chainIds.filter(id => !reloadedSet.has(id))
+          const remainingPerChain = remainingChains.length ? await fetchRewardsPerChain(address, remainingChains) : []
+          return { data: remainingPerChain.concat(freshPerChain) }
+        }
+
+        // Normal poll: try the batched (multi-chain) endpoint to collapse N requests into 1.
         const batched = await fetchRewardsBatched(address, chainIds)
         if (batched.ok) {
           batchedSupportState = 'supported'

--- a/apps/kyberswap-interface/src/services/rewardMerkl.ts
+++ b/apps/kyberswap-interface/src/services/rewardMerkl.ts
@@ -83,11 +83,21 @@ const isChainRecentlyReloaded = (chainId: string): boolean => {
 
 type BatchedResult = { ok: true; data: MerklRewardsResponse[] } | { ok: false; permanent: boolean }
 
-const fetchRewardsPerChain = async (address: string, chainIds: string[]): Promise<MerklRewardsResponse[]> => {
+const fetchRewardsPerChain = async (
+  address: string,
+  chainIds: string[],
+  // Append `reloadChainId=X` to force Merkl's backend to refresh ITS cache for that chain
+  // before responding. Used in post-claim flows where we need to defeat any URL-keyed cache
+  // that wasn't invalidated by an earlier reload call.
+  withReload = false,
+): Promise<MerklRewardsResponse[]> => {
   const results = await Promise.all(
     chainIds.map(async cId => {
       try {
-        const res = await fetch(`${MERKL_API_BASE}/users/${address}/rewards?chainId=${cId}`)
+        const url = withReload
+          ? `${MERKL_API_BASE}/users/${address}/rewards?chainId=${cId}&reloadChainId=${cId}`
+          : `${MERKL_API_BASE}/users/${address}/rewards?chainId=${cId}`
+        const res = await fetch(url)
         if (!res.ok) return null
         const data: MerklRewardsResponse[] = await res.json()
         return data
@@ -124,7 +134,7 @@ const rewardMerklApi = createApi({
   keepUnusedDataFor: 60,
   endpoints: builder => ({
     merklRewards: builder.query<MerklRewardsResponse[], MerklRewardsParams>({
-      async queryFn({ address, chainId }) {
+      async queryFn({ address, chainId }, api) {
         const chainIds = chainId
           .split(',')
           .map(s => s.trim())
@@ -141,33 +151,45 @@ const rewardMerklApi = createApi({
 
         const reloadedChains = chainIds.filter(isChainRecentlyReloaded)
 
-        // Hybrid path: batched for everyone + per-chain ONLY for chains whose backend cache
-        // was just refreshed by `reloadMerklChain` (e.g., post-claim flow). The per-chain
-        // results are guaranteed fresh — they hit the same URL pattern Merkl just refreshed —
-        // and replace the corresponding entries from the batched response. Cost: 2 requests
-        // instead of N. Only the just-claimed chain pays the targeted refresh; other chains
-        // reuse the batched response.
+        // Post-claim path: only the reloaded chains have changed. Re-fetch JUST those with
+        // `reloadChainId` for guaranteed-fresh data, then merge with the already-cached
+        // entries for the unchanged chains. This avoids the wasteful batched call that
+        // re-fetches data we already have for chains that didn't claim.
         if (reloadedChains.length > 0) {
-          // Every requested chain is reloaded — batched would be fully discarded by the merge,
-          // so skip it and just per-chain everything.
+          // Every requested chain is reloaded — nothing to reuse from cache.
           if (reloadedChains.length === chainIds.length) {
-            return { data: await fetchRewardsPerChain(address, chainIds) }
+            return { data: await fetchRewardsPerChain(address, chainIds, true) }
           }
 
-          const [batchedResult, freshPerChain] = await Promise.all([
-            fetchRewardsBatched(address, chainIds),
-            fetchRewardsPerChain(address, reloadedChains),
-          ])
+          const freshPerChain = await fetchRewardsPerChain(address, reloadedChains, true)
+          // `as any` breaks the circular type inference — `rewardMerklApi` is being defined in
+          // the same statement and can't be type-named yet, but the runtime reference is fine
+          // because queryFn is only invoked after the api object has been constructed.
+          const existing =
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ((rewardMerklApi as any).endpoints.merklRewards.select({ address, chainId })(api.getState())?.data ??
+              []) as MerklRewardsResponse[]
+
+          // Use the cache-reuse optimization only when both halves have data. If `freshPerChain`
+          // is empty (per-chain fetch failed for every reloaded chain), returning unmodified
+          // cache would silently serve pre-claim data — fall through to the batched fallback
+          // so the user gets fresh data via a different URL path instead.
+          if (existing.length > 0 && freshPerChain.length > 0) {
+            const refreshedIds = new Set(freshPerChain.map(item => item.chain.id))
+            const merged = existing.filter(item => !refreshedIds.has(item.chain.id)).concat(freshPerChain)
+            return { data: merged }
+          }
+
+          // Cache empty OR `freshPerChain` empty — fall back to batched + reloaded-per-chain
+          // merge so the full picture is populated and stale cache isn't served silently.
+          const batchedResult = await fetchRewardsBatched(address, chainIds)
           if (batchedResult.ok) {
             batchedSupportState = 'supported'
             const refreshedIds = new Set(freshPerChain.map(item => item.chain.id))
             const merged = batchedResult.data.filter(item => !refreshedIds.has(item.chain.id)).concat(freshPerChain)
             return { data: merged }
           }
-
           if (batchedResult.permanent) batchedSupportState = 'unsupported'
-          // Batched failed — fetch the remaining (non-reloaded) chains per-chain and merge
-          // with the already-in-hand `freshPerChain` so we don't re-request reloaded chains.
           const reloadedSet = new Set(reloadedChains)
           const remainingChains = chainIds.filter(id => !reloadedSet.has(id))
           const remainingPerChain = remainingChains.length ? await fetchRewardsPerChain(address, remainingChains) : []

--- a/apps/kyberswap-interface/src/services/rewardMerkl.ts
+++ b/apps/kyberswap-interface/src/services/rewardMerkl.ts
@@ -63,6 +63,24 @@ const MERKL_API_BASE = 'https://api.merkl.xyz/v4'
 // so a transient network blip or 5xx doesn't permanently downgrade the session to per-chain.
 let batchedSupportState: 'unknown' | 'supported' | 'unsupported' = 'unknown'
 
+// Map of chainId → timestamp at which `reloadMerklChain` last refreshed Merkl's backend cache
+// for that chain. While a chain's mark is still within RELOAD_FRESHNESS_MS, every `merklRewards`
+// fetch covering that chain is forced down the per-chain path — the only URL pattern we know
+// was refreshed (Merkl may cache the batched URL separately). Mark is read without consuming so
+// concurrent fetches in the window (poll, tab-resume, explicit refetch) all see fresh data.
+const recentlyReloadedChainIds = new Map<string, number>()
+const RELOAD_FRESHNESS_MS = 60_000
+
+const isChainRecentlyReloaded = (chainId: string): boolean => {
+  const ts = recentlyReloadedChainIds.get(chainId)
+  if (ts === undefined) return false
+  if (Date.now() - ts > RELOAD_FRESHNESS_MS) {
+    recentlyReloadedChainIds.delete(chainId)
+    return false
+  }
+  return true
+}
+
 type BatchedResult = { ok: true; data: MerklRewardsResponse[] } | { ok: false; permanent: boolean }
 
 const fetchRewardsPerChain = async (address: string, chainIds: string[]): Promise<MerklRewardsResponse[]> => {
@@ -116,8 +134,15 @@ const rewardMerklApi = createApi({
           return { data: [] }
         }
 
+        // If any chain was recently refreshed via `reloadMerklChain`, force per-chain so we
+        // hit the URL pattern that Merkl's backend just refreshed. Marks are read without
+        // consuming so every fetch in the freshness window (poll, tab-resume, explicit
+        // refetch) goes per-chain — avoids a race where one fetch consumes the mark and
+        // a later refetch ends up on a potentially-stale batched URL.
+        const forcePerChain = chainIds.length > 1 && chainIds.some(isChainRecentlyReloaded)
+
         // Single chain: no batching benefit, just fetch directly
-        if (chainIds.length === 1 || batchedSupportState === 'unsupported') {
+        if (chainIds.length === 1 || batchedSupportState === 'unsupported' || forcePerChain) {
           return { data: await fetchRewardsPerChain(address, chainIds) }
         }
 
@@ -150,6 +175,9 @@ const rewardMerklApi = createApi({
           )
           if (!res.ok) return { error: { status: res.status, data: 'reload failed' } }
           const data: MerklRewardsResponse[] = await res.json()
+          // Mark this chain so any `merklRewards` fetch within RELOAD_FRESHNESS_MS uses
+          // the per-chain URL pattern that we just told Merkl to refresh.
+          recentlyReloadedChainIds.set(String(chainId), Date.now())
           return { data }
         } catch (err) {
           return { error: { status: 'CUSTOM_ERROR', error: (err as Error)?.message || 'reload failed' } }


### PR DESCRIPTION
## Summary

### Polling and request shape (`services/rewardMerkl.ts`, `useMerklRewards.tsx`)
- Switch the multi-chain `merklRewards` query to a batched
  `?chainId=A&chainId=B&...` request, falling back to per-chain only
  on a permanent 4xx (5xx, 429, and network errors are treated as
  transient and don't lock the session into per-chain mode).
- Raise `pollingInterval` from 60s to 120s and `keepUnusedDataFor`
  from 1s to 60s so remounting consumers reuse the cache instead of
  refetching.
- Pause polling while the tab is hidden via a single shared
  `visibilitychange` listener, and trigger an immediate refetch on
  resume so the user doesn't wait the full interval for fresh data.

### Post-claim refresh path (`services/rewardMerkl.ts`, `useKemRewards.tsx`)
- `reloadMerklChain` marks the chain it just refreshed. Within 60s of
  that mark, the next `merklRewards` fetch re-fetches only the marked
  chain with `reloadChainId` and merges with the cached entries for
  the other chains, avoiding a wasteful batched call covering chains
  that didn't change. Falls back to batched when the cache is empty
  or the per-chain fetch returns nothing.
- The retry loop's early-exit now requires `chainData.rewards.length`
  to be non-zero — an empty array (Merkl's cache rebuilding after
  `reloadChainId`) no longer reads as claimable=0 and short-circuits
  the loop after a single attempt.
- The retry loop's in-flight branch no longer fires a redundant
  `refetchMerklRewards`, which previously raced with the next reload
  attempt and doubled the per-chain request count.

### Claim flow (`useClaimMerklRewards.tsx`, `useKemRewards.tsx`, `ClaimAllModal/index.tsx`)
- Remove the pre-claim Merkl fetch. `claimMerklRewards` now takes the
  target chain's reward entry as a parameter sourced from the
  already-warm `useMerklRewards` data via the new `rawData` field.
- Expose `merklSyncingChainIds` from `useKemRewards` and disable the
  claim button (with a "Syncing" label, loader, and warning line) for
  the selected bonus chain while its post-claim retry loop is still
  running, so the user can't re-submit a claim with stale proofs.
