### PR TITLE
feat(compounding-widget): use chainId for RPC calls to enable rotation

### DIFF
--- a/packages/compounding-widget/src/Widget.tsx
+++ b/packages/compounding-widget/src/Widget.tsx
@@ -91,6 +91,7 @@ export default function Widget() {
     tokenId: +positionId,
     spender: zapInfo?.routerAddress || '',
     userAddress: connectedAccount?.address || '',
+    chainId,
     rpcUrl,
     nftManagerContract,
     onSubmitTx: onSubmitTx,
@@ -144,7 +145,7 @@ export default function Widget() {
           };
 
           try {
-            const gasEstimation = await estimateGas(rpcUrl, txData);
+            const gasEstimation = await estimateGas(chainId, txData);
             const txHash = await onSubmitTx(
               {
                 ...txData,
@@ -176,7 +177,7 @@ export default function Widget() {
         }
       });
     // .finally(() => setAttempTx(false));
-  }, [snapshotState, attempTx, txError, pool, chainId, account, rpcUrl, onSubmitTx, poolType, position]);
+  }, [snapshotState, attempTx, txError, pool, chainId, account, onSubmitTx, poolType, position]);
 
   useEffect(() => {
     handleClick();

--- a/packages/compounding-widget/src/hooks/useTxStatus.ts
+++ b/packages/compounding-widget/src/hooks/useTxStatus.ts
@@ -11,13 +11,11 @@ import { TxStatus } from '@/types/index';
 export default function useTxStatus({ txHash }: { txHash?: string }) {
   const {
     chainId,
-    rpcUrl,
     txStatus: txStatusFromApp,
     txHashMapping,
   } = useWidgetStore(
     useShallow(s => ({
       chainId: s.chainId,
-      rpcUrl: s.rpcUrl,
       txStatus: s.txStatus,
       txHashMapping: s.txHashMapping,
     })),
@@ -54,7 +52,7 @@ export default function useTxStatus({ txHash }: { txHash?: string }) {
 
     const checkTxStatus = () => {
       if (txStatus !== '') return;
-      isTransactionSuccessful(rpcUrl, currentTxHash).then(res => {
+      isTransactionSuccessful(chainId, currentTxHash).then(res => {
         if (!res) return;
 
         if (res.status) {
@@ -69,7 +67,7 @@ export default function useTxStatus({ txHash }: { txHash?: string }) {
     return () => {
       clearInterval(interval);
     };
-  }, [chainId, rpcUrl, currentTxHash, txStatus, txStatusFromApp]);
+  }, [chainId, currentTxHash, txStatus, txStatusFromApp]);
 
   return { txStatus, currentTxHash };
 }


### PR DESCRIPTION
Pass chainId to estimateGas, isTransactionSuccessful, and useNftApproval so RPC calls go through @kyber/rpc-client with automatic endpoint rotation, health probing, and fallback instead of a single rpcUrl.