### PR TITLE
fix(earn): fix out-of-range detection for liquidity positions

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PositionDetail/InformationTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PositionDetail/InformationTab.tsx
@@ -592,7 +592,7 @@ const InformationTab = () => {
                 }
               }}
             >
-              {!isOutRange ? t`Add Liquidity` : t`Reposition to new range`}
+              {!isOutRange ? t`Increase Liquidity` : t`Reposition to new range`}
             </PositionAction>
           )}
         </PositionActionWrapper>

--- a/packages/liquidity-widgets/src/components/Header/index.tsx
+++ b/packages/liquidity-widgets/src/components/Header/index.tsx
@@ -62,7 +62,10 @@ const Header = () => {
 
   const isOutOfRange = useMemo(() => {
     if (!positionId || !isUniV3 || !poolPrice || minPrice === null || maxPrice === null) return false;
-    return poolPrice < +minPrice || poolPrice > +maxPrice;
+
+    const min = parseFloat(minPrice.replace(/,/g, ''));
+    const max = parseFloat(maxPrice.replace(/,/g, ''));
+    return poolPrice < min || poolPrice > max;
   }, [isUniV3, maxPrice, minPrice, poolPrice, positionId]);
 
   const isClosed = position !== null && position.liquidity.toString() === '0';


### PR DESCRIPTION
## Summary
- Fix `isOutOfRange` calculation in liquidity-widgets by correctly parsing formatted price strings that contain comma separators
- Update position action label from "Add Liquidity" to "Increase Liquidity" when repositioning an existing position within range
