### PR TITLE
fix(token-search): skip search input auto-focus on mobile

### DIFF
--- a/apps/kyberswap-interface/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/kyberswap-interface/src/components/SearchModal/CurrencySearch.tsx
@@ -3,6 +3,7 @@ import { Trans, t } from '@lingui/macro'
 import axios from 'axios'
 import { rgba } from 'polished'
 import { ChangeEvent, KeyboardEvent, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { isMobile } from 'react-device-detect'
 import { Trash } from 'react-feather'
 import { usePrevious } from 'react-use'
 import { Flex, Text } from 'rebass'
@@ -216,7 +217,7 @@ export function CurrencySearch({
   useEffect(() => {
     if (isOpen) {
       setSearchQuery('')
-      inputRef.current?.focus()
+      if (!isMobile) inputRef.current?.focus()
     }
   }, [isOpen])
 


### PR DESCRIPTION
Prevents the on-screen keyboard from opening on modal open and covering the token list.