### PR TITLE
feat(swap): show Ronin maintenance notice on tx failure

### DIFF
--- a/apps/kyberswap-interface/src/components/TransactionConfirmationModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/TransactionConfirmationModal/index.tsx
@@ -1,7 +1,8 @@
 import { ChainId, Currency, Token } from '@kyberswap/ks-sdk-core'
 import { Trans, t } from '@lingui/macro'
+import { rgba } from 'polished'
 import React, { useState } from 'react'
-import { ArrowUpCircle, BarChart2 } from 'react-feather'
+import { AlertTriangle, ArrowUpCircle, BarChart2 } from 'react-feather'
 import { Flex, Text } from 'rebass'
 import styled from 'styled-components'
 import { useWatchAsset } from 'wagmi'
@@ -15,6 +16,7 @@ import Modal from 'components/Modal'
 import { RowBetween, RowFixed } from 'components/Row'
 import { CONNECTOR_ICON_OVERRIDE_MAP } from 'components/Web3Provider'
 import ListGridViewGroup from 'components/YieldPools/ListGridViewGroup'
+import { RONIN_MAINTENANCE_MESSAGE, isRoninMaintenanceActive } from 'constants/roninMaintenance'
 import { useActiveWeb3React, useWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import { VIEW_MODE } from 'state/user/reducer'
@@ -236,6 +238,21 @@ const StyledAlert = styled(Alert)`
   height: 108px;
   width: 108px;
 `
+
+const MaintenanceNotice = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: ${({ theme }) => rgba(theme.warning, 0.15)};
+  color: ${({ theme }) => theme.warning};
+  font-size: 13px;
+  line-height: 18px;
+  text-align: left;
+`
+
 export function TransactionErrorContent({
   message,
   onDismiss,
@@ -254,7 +271,9 @@ export function TransactionErrorContent({
   suggestionMessage?: React.ReactNode
 }) {
   const theme = useTheme()
+  const { chainId } = useActiveWeb3React()
   const [showDetail, setShowDetail] = useState<boolean>(false)
+  const showRoninMaintenance = isRoninMaintenanceActive(chainId)
 
   return (
     <Wrapper>
@@ -266,6 +285,12 @@ export function TransactionErrorContent({
           <CloseIcon onClick={onDismiss} />
         </RowBetween>
         <AutoColumn style={{ marginTop: 20 }} gap="8px" justify="center">
+          {showRoninMaintenance && (
+            <MaintenanceNotice>
+              <AlertTriangle size={16} style={{ flexShrink: 0, marginTop: 1 }} />
+              <span>{RONIN_MAINTENANCE_MESSAGE}</span>
+            </MaintenanceNotice>
+          )}
           <StyledAlert />
           <Text
             fontWeight={500}

--- a/apps/kyberswap-interface/src/constants/roninMaintenance.ts
+++ b/apps/kyberswap-interface/src/constants/roninMaintenance.ts
@@ -1,0 +1,15 @@
+import { ChainId } from '@kyberswap/ks-sdk-core'
+
+// Ronin network scheduled maintenance window.
+// 2026-05-12 22:00 (UTC+7, VN time) → 2026-05-13 08:00 (UTC+7) — ~10 hours.
+export const RONIN_MAINTENANCE_START_MS = Date.UTC(2026, 4, 12, 15, 0, 0)
+export const RONIN_MAINTENANCE_END_MS = Date.UTC(2026, 4, 13, 1, 0, 0)
+
+export const RONIN_MAINTENANCE_MESSAGE =
+  'Ronin Network is currently undergoing maintenance (est. 10 hours). Trades on Ronin are temporarily unavailable during this time.'
+
+export const isRoninMaintenanceActive = (chainId: number | undefined): boolean => {
+  if (chainId !== ChainId.RONIN) return false
+  const now = Date.now()
+  return now >= RONIN_MAINTENANCE_START_MS && now < RONIN_MAINTENANCE_END_MS
+}


### PR DESCRIPTION
Surface a scheduled-maintenance warning inside TransactionErrorContent when a transaction fails on Ronin during the 2026-05-12 22:00 → 2026-05-13 08:00 (UTC+7) downtime window. The notice auto-disables outside the window via a chainId + time-range check.