### PR TITLE
feat(earn): show newest past actions first and make list scrollable

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PositionDetail/AnalyticTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PositionDetail/AnalyticTab.tsx
@@ -10,7 +10,7 @@ import { NETWORKS_INFO } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import { usePositionDetailContext } from 'pages/Earns/PositionDetail/PositionDetailContext'
-import { HistoryCard, HistorySectionHeader } from 'pages/Earns/PositionDetail/styles'
+import { HistoryCard, HistorySectionHeader, PastActionsList } from 'pages/Earns/PositionDetail/styles'
 import PositionSkeleton from 'pages/Earns/components/PositionSkeleton'
 import useKemRewards from 'pages/Earns/hooks/useKemRewards'
 import useMerklRewards from 'pages/Earns/hooks/useMerklRewards'
@@ -80,8 +80,8 @@ const AnalyticTab = () => {
     [chronologicalHistory],
   )
 
-  // Past actions = all entries
-  const pastActions = chronologicalHistory
+  // Past actions = all entries, newest first
+  const pastActions = useMemo(() => [...chronologicalHistory].reverse(), [chronologicalHistory])
 
   const createdTime = useMemo(() => {
     if (!position?.createdTime) return '--'
@@ -307,7 +307,7 @@ const AnalyticTab = () => {
             <Text fontSize={14} color={theme.subText}>
               {t`Past Actions`}
             </Text>
-            <Flex flexDirection="column" alignItems="flex-end" sx={{ gap: '8px' }}>
+            <PastActionsList>
               {pastActions.map((entry, i) => {
                 const totalValue = getActionTotalValue(entry)
                 const label = getActionLabel(entry.type)
@@ -330,7 +330,7 @@ const AnalyticTab = () => {
                   </Flex>
                 )
               })}
-            </Flex>
+            </PastActionsList>
           </Flex>
         )}
       </Flex>

--- a/apps/kyberswap-interface/src/pages/Earns/PositionDetail/styles.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PositionDetail/styles.tsx
@@ -203,6 +203,27 @@ export const HistorySectionHeader = styled.div`
   width: 100%;
 `
 
+export const PastActionsList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 4px;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => rgba(theme.white, 0.16)};
+    border-radius: 2px;
+  }
+`
+
 export const HistoryCard = styled.div`
   background: ${({ theme }) => rgba(theme.white, 0.04)};
   border-radius: 12px;


### PR DESCRIPTION
Reverse position past actions so the most recent entry appears at the top, and cap the list with a scrollable container to handle long histories.