### PR TITLE
feat(analytics): add Token Searched formo event from token selector modals

### DIFF
--- a/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
@@ -207,6 +207,7 @@ interface CurrencyInputPanelProps {
   tight?: boolean
   styleSelect?: CSSProperties
   customChainId?: ChainId
+  trackingSource?: string
 }
 
 export default function CurrencyInputPanel({
@@ -247,6 +248,7 @@ export default function CurrencyInputPanel({
   loadingText,
   styleSelect = {},
   customChainId,
+  trackingSource,
 }: CurrencyInputPanelProps) {
   const tight = Boolean(tightProp && !currency)
   const [modalOpen, setModalOpen] = useState(false)
@@ -391,6 +393,7 @@ export default function CurrencyInputPanel({
             showCommonBases={showCommonBases}
             filterWrap={filterWrap}
             customChainId={customChainId}
+            trackingSource={trackingSource}
           />
         )}
       </InputPanel>

--- a/apps/kyberswap-interface/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/kyberswap-interface/src/components/SearchModal/CurrencySearch.tsx
@@ -14,6 +14,7 @@ import Column from 'components/Column'
 import InfoHelper from 'components/InfoHelper'
 import { RowBetween } from 'components/Row'
 import { KS_SETTING_API } from 'constants/env'
+import { NETWORKS_INFO } from 'constants/networks'
 import { Z_INDEXS } from 'constants/styles'
 import { NativeCurrencies } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
@@ -22,6 +23,7 @@ import useDebounce from 'hooks/useDebounce'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import useTheme from 'hooks/useTheme'
 import useToggle from 'hooks/useToggle'
+import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import store from 'state'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { useRemoveUserAddedToken, useUserAddedTokens, useUserFavoriteTokens } from 'state/user/hooks'
@@ -85,6 +87,7 @@ interface CurrencySearchProps {
   title?: string
   tooltip?: ReactNode
   setTokenToShowInfo: (token: Token) => void
+  trackingSource?: string
 }
 
 const PAGE_SIZE = 20
@@ -147,14 +150,17 @@ export function CurrencySearch({
   title,
   tooltip,
   setTokenToShowInfo,
+  trackingSource,
 }: CurrencySearchProps) {
   const { chainId: web3ChainId } = useActiveWeb3React()
   const chainId = customChainId || web3ChainId
   const theme = useTheme()
+  const { trackingHandler } = useTracking()
   const [activeTab, setActiveTab] = useState<Tab>(Tab.All)
 
   const [searchQuery, setSearchQuery] = useState<string>('')
   const debouncedQuery = useDebounce(searchQuery, 200)
+  const trackingDebouncedQuery = useDebounce(searchQuery, 1000)
   const isQueryValidEVMAddress = !!isAddress(chainId, debouncedQuery)
 
   const { favoriteTokens, toggleFavoriteToken } = useUserFavoriteTokens(chainId)
@@ -356,6 +362,16 @@ export function CurrencySearch({
     }
     // need call api when only debouncedQuery change
   }, [debouncedQuery, prevQuery, fetchListTokens])
+
+  useEffect(() => {
+    if (!trackingDebouncedQuery || !trackingSource) return
+    trackingHandler(TRACKING_EVENT_TYPE.TOKEN_SEARCHED, {
+      source: trackingSource,
+      search_query: trackingDebouncedQuery,
+      chain: NETWORKS_INFO[chainId].name,
+      is_address: !!isAddress(chainId, trackingDebouncedQuery),
+    })
+  }, [trackingDebouncedQuery, trackingSource, chainId, trackingHandler])
 
   const visibleCurrencies: Currency[] = useMemo(() => {
     return isImportedTab || (!isImportedTab && !filteredSortedTokens.length)

--- a/apps/kyberswap-interface/src/components/SearchModal/CurrencySearchModal.tsx
+++ b/apps/kyberswap-interface/src/components/SearchModal/CurrencySearchModal.tsx
@@ -23,6 +23,7 @@ interface CurrencySearchModalProps {
   tooltip?: ReactNode
   onCurrencyImport?: (token: Token) => void
   customChainId?: ChainId
+  trackingSource?: string
 }
 
 enum CurrencyModalView {
@@ -42,6 +43,7 @@ export default function CurrencySearchModal({
   tooltip,
   onCurrencyImport,
   customChainId,
+  trackingSource,
 }: CurrencySearchModalProps) {
   const [modalView, setModalView] = useState<CurrencyModalView>(CurrencyModalView.search)
   const lastOpen = useLast(isOpen)
@@ -115,6 +117,7 @@ export default function CurrencySearchModal({
           tooltip={tooltip}
           customChainId={customChainId}
           setTokenToShowInfo={setTokenToShowInfo}
+          trackingSource={trackingSource}
         />
       ) : modalView === CurrencyModalView.importToken && importToken ? (
         <ImportToken

--- a/apps/kyberswap-interface/src/components/SwapForm/InputCurrencyPanel.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/InputCurrencyPanel.tsx
@@ -66,6 +66,7 @@ const InputCurrencyPanel: React.FC<Props> = ({
       showCommonBases={true}
       estimatedUsd={trade?.amountInUsd ? `${formattedNum(trade.amountInUsd.toString(), true)}` : undefined}
       customChainId={customChainId}
+      trackingSource="swap"
     />
   )
 }

--- a/apps/kyberswap-interface/src/components/SwapForm/OutputCurrencyPanel.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/OutputCurrencyPanel.tsx
@@ -118,6 +118,7 @@ const OutputCurrencyPanel: React.FC<Props> = ({
         }
         positionLabel="in"
         customChainId={customChainId}
+        trackingSource="swap"
       />
     </Box>
   )

--- a/apps/kyberswap-interface/src/components/ZapCreatePool/CreatePoolModal.tsx
+++ b/apps/kyberswap-interface/src/components/ZapCreatePool/CreatePoolModal.tsx
@@ -4,7 +4,7 @@ import { TokenLogo } from '@kyber/ui'
 import { Trans, t } from '@lingui/macro'
 import Portal from '@reach/portal'
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Text } from 'rebass'
 import { useCheckPairQuery } from 'services/marketOverview'
 import { useLazyPoolDetailQuery, useSupportedProtocolsQuery } from 'services/zapEarn'
@@ -16,9 +16,11 @@ import FeeTierControl from 'components/FeeTierControl'
 import Loader from 'components/Loader'
 import Modal from 'components/Modal'
 import Row from 'components/Row'
+import { NETWORKS_INFO } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
 import useChainsConfig from 'hooks/useChainsConfig'
 import useTheme from 'hooks/useTheme'
+import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import DropdownMenu from 'pages/Earns/components/DropdownMenu'
 import { Exchange } from 'pages/Earns/constants'
 import { fetchExistingPoolAddress } from 'pages/Earns/utils/zap'
@@ -107,6 +109,20 @@ const CreatePoolModal = ({ isOpen, filterChainId, onDismiss, onSubmit }: Props) 
   const theme = useTheme()
   const { account, chainId: activeChainId } = useActiveWeb3React()
   const toggleWalletModal = useWalletModalToggle()
+  const { trackingHandler } = useTracking()
+
+  const handleTokenSelectorTrackEvent = useCallback(
+    (eventName: string, data?: Record<string, unknown>) => {
+      if (eventName !== 'TOKEN_SEARCHED') return
+      const { chain_id, ...rest } = (data ?? {}) as { chain_id?: number } & Record<string, unknown>
+      trackingHandler(TRACKING_EVENT_TYPE.TOKEN_SEARCHED, {
+        source: 'earn_create_pool',
+        ...rest,
+        chain: typeof chain_id === 'number' ? NETWORKS_INFO[chain_id as keyof typeof NETWORKS_INFO]?.name : undefined,
+      })
+    },
+    [trackingHandler],
+  )
 
   const { supportedChains } = useChainsConfig()
   const { data: supportedProtocols } = useSupportedProtocolsQuery()
@@ -386,6 +402,7 @@ const CreatePoolModal = ({ isOpen, filterChainId, onDismiss, onSubmit }: Props) 
             positionOptions={{
               poolAddress: '',
             }}
+            onTrackEvent={handleTokenSelectorTrackEvent}
           />
         </Portal>
       )}

--- a/apps/kyberswap-interface/src/components/swapv2/LimitOrder/LimitOrderForm.tsx
+++ b/apps/kyberswap-interface/src/components/swapv2/LimitOrder/LimitOrderForm.tsx
@@ -930,6 +930,7 @@ const LimitOrderForm = forwardRef<LimitOrderFormHandle, Props>(function LimitOrd
             }
             positionLabel="in"
             customChainId={chainId}
+            trackingSource="limit_order"
           />
         </Tooltip>
 
@@ -1022,6 +1023,7 @@ const LimitOrderForm = forwardRef<LimitOrderFormHandle, Props>(function LimitOrd
             }
             positionLabel="in"
             customChainId={chainId}
+            trackingSource="limit_order"
           />
         </Tooltip>
 

--- a/apps/kyberswap-interface/src/hooks/useTracking.ts
+++ b/apps/kyberswap-interface/src/hooks/useTracking.ts
@@ -230,6 +230,7 @@ export enum TRACKING_EVENT_TYPE {
 
   // Swap form interactions
   TOKEN_SELECTED,
+  TOKEN_SEARCHED,
   AMOUNT_ENTERED,
   TOKEN_PAIR_REVERSED,
   MAX_BALANCE_CLICKED,
@@ -1448,6 +1449,10 @@ export default function useTracking(currencies?: { [field in Field]?: Currency }
         // Swap form interaction events
         case TRACKING_EVENT_TYPE.TOKEN_SELECTED: {
           formoTrack('Token Selected', payload)
+          break
+        }
+        case TRACKING_EVENT_TYPE.TOKEN_SEARCHED: {
+          formoTrack('Token Searched', payload)
           break
         }
         case TRACKING_EVENT_TYPE.AMOUNT_ENTERED: {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TokenPanel.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TokenPanel.tsx
@@ -416,6 +416,7 @@ export const TokenPanel = ({
           selectedCurrency={selectedCurrency as EvmCurrency}
           showCommonBases
           customChainId={selectedChain as ChainId}
+          trackingSource="cross_chain"
         />
       ) : (
         <Modal

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityTokenInput.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityTokenInput.tsx
@@ -270,6 +270,7 @@ const AddLiquidityTokenInput = ({
               initialSlippage: currentSlippage,
               onSelectLiquiditySource: onOpenZapMigration ? handleOpenZapMigration : undefined,
             }}
+            onTrackEvent={onTrackEvent}
           />,
           document.body,
         )}

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/index.tsx
@@ -94,6 +94,7 @@ const AddLiquidityColumn = styled(Stack)`
 
 const TRACKING_EVENT_MAP: Record<string, TRACKING_EVENT_TYPE> = {
   LIQ_TOKEN_SELECTED: TRACKING_EVENT_TYPE.LIQ_TOKEN_SELECTED,
+  TOKEN_SEARCHED: TRACKING_EVENT_TYPE.TOKEN_SEARCHED,
   LIQ_EXISTING_POSITION_SELECTED: TRACKING_EVENT_TYPE.LIQ_EXISTING_POSITION_SELECTED,
   LIQ_MAX_CLICKED: TRACKING_EVENT_TYPE.LIQ_MAX_CLICKED,
   LIQ_HALF_CLICKED: TRACKING_EVENT_TYPE.LIQ_HALF_CLICKED,
@@ -313,7 +314,17 @@ const AddLiquidity = ({ children }: AddLiquidityProps) => {
   const handleTrackEvent = useCallback(
     (eventName: string, data?: Record<string, unknown>) => {
       const trackingType = TRACKING_EVENT_MAP[eventName]
-      if (trackingType !== undefined) trackingHandler(trackingType, data)
+      if (trackingType === undefined) return
+      if (eventName === 'TOKEN_SEARCHED') {
+        const { chain_id, ...rest } = (data ?? {}) as { chain_id?: number } & Record<string, unknown>
+        trackingHandler(trackingType, {
+          source: 'earn_add_liquidity',
+          ...rest,
+          chain: typeof chain_id === 'number' ? NETWORKS_INFO[chain_id as keyof typeof NETWORKS_INFO]?.name : undefined,
+        })
+        return
+      }
+      trackingHandler(trackingType, data)
     },
     [trackingHandler],
   )

--- a/packages/token-selector/src/TokenModal.tsx
+++ b/packages/token-selector/src/TokenModal.tsx
@@ -53,6 +53,7 @@ const TokenModal = ({
   wallet,
   tokenOptions,
   positionOptions,
+  onTrackEvent,
 }: TokenSelectorModalProps) => {
   const { importToken } = useTokenState();
 
@@ -216,6 +217,7 @@ const TokenModal = ({
             setTokenToImport={handleSetTokenToImport}
             onClose={onClose}
             initialSlippage={initialSlippage}
+            onTrackEvent={onTrackEvent}
           />
         )}
       </DialogContent>

--- a/packages/token-selector/src/TokenSelector.tsx
+++ b/packages/token-selector/src/TokenSelector.tsx
@@ -47,6 +47,7 @@ enum MODAL_TAB {
 
 const MESSAGE_TIMEOUT = 4_000;
 const DEBOUNCE_DELAY = 150;
+const TRACKING_DEBOUNCE_DELAY = 1_000;
 
 /** Internal props for TokenSelector component (used by TokenModal) */
 interface TokenSelectorProps {
@@ -87,6 +88,9 @@ interface TokenSelectorProps {
   setSelectedTokens: (tokens: Token[]) => void;
   setTokenToShow: (token: Token) => void;
   setTokenToImport: (token: Token) => void;
+
+  // Analytics
+  onTrackEvent?: (eventName: string, data?: Record<string, unknown>) => void;
 }
 
 const normalizeSpecialCharacters = (value: string) => value.replace(/₮/g, "T");
@@ -211,6 +215,7 @@ export default function TokenSelector({
   setTokenToImport,
   onClose,
   initialSlippage,
+  onTrackEvent,
 }: TokenSelectorProps) {
   const { i18n } = useLingui();
   const {
@@ -239,6 +244,9 @@ export default function TokenSelector({
   const [modalAmountsIn, setModalAmountsIn] = useState(amountsIn);
   const messageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const trackingDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const initialTokensInAddress = useRef(
     new Set(tokensIn.map((token) => token.address.toLowerCase())),
   );
@@ -568,6 +576,26 @@ export default function TokenSelector({
       }
     };
   }, [searchTerm]);
+
+  useEffect(() => {
+    if (trackingDebounceRef.current) {
+      clearTimeout(trackingDebounceRef.current);
+    }
+    if (!searchTerm || !onTrackEvent) return;
+    trackingDebounceRef.current = setTimeout(() => {
+      onTrackEvent("TOKEN_SEARCHED", {
+        search_query: searchTerm,
+        chain_id: chainId,
+        is_address: isAddress(searchTerm.toLowerCase().trim()),
+      });
+    }, TRACKING_DEBOUNCE_DELAY);
+
+    return () => {
+      if (trackingDebounceRef.current) {
+        clearTimeout(trackingDebounceRef.current);
+      }
+    };
+  }, [searchTerm, chainId, onTrackEvent]);
 
   useEffect(() => {
     if (unImportedTokens?.length) {

--- a/packages/token-selector/src/types.ts
+++ b/packages/token-selector/src/types.ts
@@ -227,6 +227,8 @@ export interface TokenSelectorModalProps {
   tokenOptions?: TokenOptions;
   /** Position/liquidity source options */
   positionOptions?: PositionOptions;
+  /** Optional analytics callback (e.g. for TOKEN_SEARCHED events) */
+  onTrackEvent?: (eventName: string, data?: Record<string, unknown>) => void;
 }
 
 // Internal token with additional UI state


### PR DESCRIPTION
Emit  when a user types in the token search modal across swap, limit order, cross-chain, earn add liquidity, and earn create pool. A 1s debounce on the search input gates the event so it does not fire on every keystroke, and a  field on the payload identifies which feature opened the modal.

For the in-app  (swap / LO / cross-chain) a prop is threaded through  and; the event only fires when this prop is set, so unrelated callers stay silent. For the shared  package (earn flows) a new callback prop is forwarded into , and the earn consumers bridge the raw  from the package into a name plus inject  before forwarding to the tracking handler.