### PR TITLE
refactor(token-prices): dedupe price fetches with react query

### DIFF
--- a/apps/kyberswap-interface/src/state/tokenPrices/hooks.ts
+++ b/apps/kyberswap-interface/src/state/tokenPrices/hooks.ts
@@ -1,5 +1,6 @@
 import { NATIVE_TOKEN_ADDRESS, NETWORKS_INFO as SCHEMA_NETWORKS_INFO, ChainId as SchemaChainId } from '@kyber/schema'
 import { ChainId } from '@kyberswap/ks-sdk-core'
+import { useQueryClient } from '@tanstack/react-query'
 import debounce from 'lodash.debounce'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
@@ -39,8 +40,9 @@ export const useTokenPricesWithLoading = (
   fetchPrices: (value: string[]) => Promise<{ [key: string]: number | undefined }>
   refetch: () => void
 } => {
-  const tokenPrices = useAppSelector(state => state.tokenPrices)
   const dispatch = useAppDispatch()
+  const queryClient = useQueryClient()
+  const tokenPrices = useAppSelector(state => state.tokenPrices)
   const { chainId: currentChain } = useActiveWeb3React()
   const chainId = customChain || currentChain
 
@@ -71,35 +73,43 @@ export const useTokenPricesWithLoading = (
 
   const fetchPrices = useCallback(
     async (list: string[]) => {
-      if (list.length === 0) {
+      const normalizedList = Array.from(new Set(list.filter(Boolean).map(address => address.toLowerCase()))).sort()
+
+      if (!chainId || normalizedList.length === 0) {
+        setLoading(false)
         return {}
       }
 
       try {
         setLoading(true)
-        const chunks = chunkList(list, CHUNK_SIZE)
-        const responses = await Promise.all(
+        const chunks = chunkList(normalizedList, CHUNK_SIZE)
+        const responses = await Promise.all<PriceResponse>(
           chunks.map(chunk =>
-            fetch(`${TOKEN_API_URL}/v1/public/tokens/prices`, {
-              method: 'POST',
-              body: JSON.stringify({
-                [chainId]: chunk,
-              }),
-            }).then(res => res.json()),
+            queryClient.fetchQuery({
+              queryKey: ['tokenPrices', chainId, chunk],
+              queryFn: async () => {
+                return fetch(`${TOKEN_API_URL}/v1/public/tokens/prices`, {
+                  method: 'POST',
+                  body: JSON.stringify({
+                    [chainId]: chunk,
+                  }),
+                }).then(res => res.json())
+              },
+              retry: false,
+            }),
           ),
         )
 
         const prices: { address: string; price: number }[] = responses.flatMap((r: PriceResponse) =>
-          Object.keys(r?.data?.[chainId] || {}).map(address => ({
-            address,
-            price:
-              priceType === PriceType.Average
-                ? (r.data[chainId][address].PriceBuy + r.data[chainId][address].PriceSell) / 2
-                : r.data[chainId][address].PriceBuy,
-          })),
+          Object.entries(r?.data?.[chainId] || {}).map(([address, price]) => {
+            return {
+              address,
+              price: priceType === PriceType.Average ? (price.PriceBuy + price.PriceSell) / 2 : price.PriceBuy,
+            }
+          }),
         )
 
-        const formattedPrices = list.map(address => {
+        const formattedPrices = normalizedList.map(address => {
           const price = prices.find(
             (p: { address: string; price: number }) => p.address.toLowerCase() === address.toLowerCase(),
           )
@@ -132,7 +142,7 @@ export const useTokenPricesWithLoading = (
         setLoading(false)
       }
     },
-    [chainId, dispatch, priceType],
+    [chainId, dispatch, priceType, queryClient],
   )
 
   useEffect(() => {

--- a/apps/kyberswap-interface/src/state/tokenPrices/index.ts
+++ b/apps/kyberswap-interface/src/state/tokenPrices/index.ts
@@ -10,7 +10,7 @@ const slice = createSlice({
   reducers: {
     updatePrices(state, { payload }: { payload: Array<{ address: string; chainId: number; price: number }> }) {
       payload.forEach(item => {
-        state[item.address + '_' + item.chainId] = item.price
+        state[item.address.toLowerCase() + '_' + item.chainId] = item.price
       })
     },
   },


### PR DESCRIPTION
## Summary
- Use React Query to dedupe token price requests by chain and normalized token chunk
- Normalize requested token addresses before chunking so equivalent requests share the same cache entry
- Store token price state keys in lowercase for consistent lookups