### PR TITLE
feat: pool list show active apr

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/EstimatedPositionApr.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/EstimatedPositionApr.tsx
@@ -1,5 +1,4 @@
 import { ZapRouteDetail } from '@kyber/schema'
-import { MouseoverTooltip } from '@kyber/ui'
 import { formatAprNumber } from '@kyber/utils/number'
 import { Trans } from '@lingui/macro'
 import { skipToken } from '@reduxjs/toolkit/query'
@@ -10,21 +9,14 @@ import styled from 'styled-components'
 
 import Skeleton from 'components/Skeleton'
 import { HStack, Stack } from 'components/Stack'
+import { MouseoverTooltip } from 'components/Tooltip'
 import useDebounce from 'hooks/useDebounce'
 import useTheme from 'hooks/useTheme'
+import { ExternalLink } from 'theme/components'
 
 const TooltipContent = styled(Stack)`
   gap: 4px;
   font-size: 12px;
-
-  a {
-    border-bottom: 1px dotted ${({ theme }) => theme.subText};
-    text-decoration: none;
-  }
-
-  a:hover {
-    color: ${({ theme }) => theme.primary};
-  }
 `
 
 const AprBanner = styled(HStack)`
@@ -120,13 +112,9 @@ const EstimatedPositionApr = ({
       <Text>
         <i>
           <Trans>
-            <a
-              href="https://docs.kyberswap.com/kyberswap-solutions/kyberswap-fairflow/position-apr-estimation"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <ExternalLink href="https://docs.kyberswap.com/kyberswap-solutions/kyberswap-fairflow/position-apr-estimation">
               See more details
-            </a>{' '}
+            </ExternalLink>{' '}
             on how this estimate is calculated.
           </Trans>
         </i>

--- a/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
@@ -1,5 +1,6 @@
 import { formatAprNumber } from '@kyber/utils/dist/number'
-import { t } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
+import { Info } from 'react-feather'
 import { Text } from 'rebass'
 
 import { ReactComponent as FarmingIcon } from 'assets/svg/kyber/kem.svg'
@@ -7,64 +8,57 @@ import { ReactComponent as FarmingLmIcon } from 'assets/svg/kyber/kemLm.svg'
 import { HStack, Stack } from 'components/Stack'
 import { MouseoverTooltipDesktopOnly } from 'components/Tooltip'
 import useTheme from 'hooks/useTheme'
-import { Apr } from 'pages/Earns/PoolExplorer/styles'
 import { ParsedEarnPool, ProgramType } from 'pages/Earns/types'
-
-const getAprColor = (value: number, positiveColor: string, zeroColor: string, negativeColor: string) => {
-  if (value > 0) return positiveColor
-  if (value < 0) return negativeColor
-  return zeroColor
-}
-
-const getActiveAllApr = (pool: ParsedEarnPool) => {
-  if (pool.activeAllApr !== undefined) return pool.activeAllApr
-
-  const hasActiveBreakdown =
-    pool.activeLpApr !== undefined || pool.activeKemEGApr !== undefined || pool.activeKemLMApr !== undefined
-
-  if (!hasActiveBreakdown) return undefined
-
-  return (
-    Number(pool.activeLpApr || 0) +
-    Number(pool.activeKemEGApr || 0) +
-    Number(pool.activeKemLMApr || 0) +
-    Number(pool.bonusApr ?? 0)
-  )
-}
+import { ExternalLink } from 'theme/components'
 
 const AprTooltipContent = ({ pool, type }: { pool: ParsedEarnPool; type: 'total' | 'active' }) => {
   const theme = useTheme()
   const isActive = type === 'active'
-  const lpApr = isActive ? pool.activeLpApr : pool.lpApr
-  const egApr = isActive ? pool.activeKemEGApr : pool.kemEGApr
-  const lmApr = isActive ? pool.activeKemLMApr : pool.kemLMApr
+  const lpApr = isActive ? pool.activeFeeApr : pool.lpApr
+  const egApr = isActive ? pool.activeEgApr : pool.kemEGApr
+  const lmApr = isActive ? pool.activeLmApr : pool.kemLMApr
   const bonusApr = pool.bonusApr
 
   return (
     <Stack gap={2}>
-      <Text>
-        {t`Earning per`}{' '}
-        <Text as="span" color={isActive ? theme.blue : theme.primary}>
-          {isActive ? t`Active` : t`Total`}
-        </Text>{' '}
-        {t`TVL`}
-      </Text>
-      {lpApr !== undefined && (
+      {isActive ? (
+        <Text>
+          <Trans>
+            Earning per{' '}
+            <ExternalLink
+              style={{ color: theme.blue }}
+              href="https://docs.kyberswap.com/user-guide/kyber-earn/apr-metrics#active-apr"
+            >
+              Active TVL <Info size={12} style={{ marginBottom: -2 }} />
+            </ExternalLink>
+          </Trans>
+        </Text>
+      ) : (
+        <Text>
+          <Trans>
+            Earning per{' '}
+            <Text as="span" color={theme.primary}>
+              Total TVL
+            </Text>
+          </Trans>
+        </Text>
+      )}
+      {!!lpApr && (
         <Text>
           {t`LP Fee APR`}: {formatAprNumber(lpApr)}%
         </Text>
       )}
-      {egApr !== undefined && (
+      {!!egApr && (
         <Text>
           {t`FairFlow EG Rewards`}: {formatAprNumber(egApr)}%
         </Text>
       )}
-      {lmApr !== undefined && (
+      {!!lmApr && (
         <Text>
           {t`LM Reward`}: {formatAprNumber(lmApr)}%
         </Text>
       )}
-      {bonusApr !== undefined && (
+      {!!bonusApr && (
         <Text>
           {t`Bonus APR`}: {formatAprNumber(bonusApr)}%
         </Text>
@@ -89,32 +83,26 @@ const FarmingMarker = ({ pool }: { pool: ParsedEarnPool }) => {
 
 const PoolAprInfo = ({ pool }: { pool: ParsedEarnPool }) => {
   const theme = useTheme()
-  const activeAllApr = getActiveAllApr(pool)
 
   return (
-    <HStack align="center" gap={4} wrap="wrap">
-      <MouseoverTooltipDesktopOnly
-        placement="left"
-        width="fit-content"
-        text={<AprTooltipContent pool={pool} type="total" />}
-      >
-        <Apr value={pool.allApr}>{formatAprNumber(pool.allApr)}%</Apr>
-      </MouseoverTooltipDesktopOnly>
-
-      {activeAllApr !== undefined ? (
-        <>
-          <Text color={theme.subText}>|</Text>
-          <MouseoverTooltipDesktopOnly
-            placement="bottom"
-            width="fit-content"
-            text={<AprTooltipContent pool={pool} type="active" />}
-          >
-            <Text color={getAprColor(activeAllApr, theme.blue, theme.blue, theme.red)} fontWeight={500}>
-              {formatAprNumber(activeAllApr)}%
-            </Text>
-          </MouseoverTooltipDesktopOnly>
-        </>
-      ) : null}
+    <HStack align="center" gap={4} wrap="nowrap">
+      {pool.activeApr ? (
+        <MouseoverTooltipDesktopOnly
+          placement="left"
+          width="fit-content"
+          text={<AprTooltipContent pool={pool} type="active" />}
+        >
+          <Text color={theme.blue}>{formatAprNumber(pool.activeApr + (pool.bonusApr || 0))}%</Text>
+        </MouseoverTooltipDesktopOnly>
+      ) : (
+        <MouseoverTooltipDesktopOnly
+          placement="left"
+          width="fit-content"
+          text={<AprTooltipContent pool={pool} type="total" />}
+        >
+          <Text color={theme.green}>{formatAprNumber(pool.allApr)}%</Text>
+        </MouseoverTooltipDesktopOnly>
+      )}
 
       <FarmingMarker pool={pool} />
     </HStack>

--- a/apps/kyberswap-interface/src/pages/Earns/types/pool.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/types/pool.ts
@@ -25,10 +25,10 @@ export interface EarnPool {
   kemEGApr: number
   kemLMApr: number
   bonusApr?: number
-  activeAllApr?: number
-  activeLpApr?: number
-  activeKemEGApr?: number
-  activeKemLMApr?: number
+  activeApr?: number
+  activeFeeApr?: number
+  activeEgApr?: number
+  activeLmApr?: number
   liquidity: number
   tvl: number
   chainId?: number


### PR DESCRIPTION
## Summary
- Show active APR in earn pool APR info when active APR data is available
- Update APR tooltip breakdown to use active fee, EG, and LM APR fields
- Link active TVL tooltip copy to the APR metrics documentation
- Use the app tooltip and external link components for estimated position APR details