### PR TITLE
feat: pool list show kem rewards

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningReward.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningReward.tsx
@@ -137,10 +137,11 @@ const buildMerklRewardCards = ({ merklOpportunity }: { merklOpportunity?: MerklO
 const PoolEarningReward = () => {
   const { chainId, chainInfo, dexInfo, pool, poolAddress } = usePoolDetailContext()
   const hasLmProgram = pool?.programs?.some(program => program === 'lm') ?? false
+  const kyberDataChain = chainInfo.ksSettingRoute || chainInfo.route
 
   const { data: cycleConfig } = useCycleConfigQuery(
-    { chain: chainInfo.route, poolAddress },
-    { skip: !pool || !hasLmProgram || !chainInfo.route },
+    { chain: kyberDataChain, poolAddress },
+    { skip: !pool || !hasLmProgram || !kyberDataChain },
   )
 
   const rewardTokenAddresses = useMemo(

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/TableContent.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/TableContent.tsx
@@ -84,6 +84,7 @@ const TableContent = ({ onOpenZapInWidget, filters, showRewards = true, showPool
 
       return {
         ...pool,
+        chainId: poolChainId,
         dexLogo: dexInfo?.logoURL || '',
         dexName: dexInfo?.name || pool.exchange,
         favorite: { chainId: poolChainId, isFavorite: getFavoriteStatus(pool) },

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/index.tsx
@@ -76,7 +76,11 @@ const PoolExplorer = () => {
     const pools = poolData?.data?.pools || []
     if (!pools.length) return true
 
-    return pools.some(pool => (pool.egUsd || 0) + (pool.merklOpportunity?.rewardsRecord?.total || 0) > 0)
+    return pools.some(pool => {
+      if (pool.egUsd || pool.merklOpportunity?.rewardsRecord?.total) return true
+      if (pool.kemReward?.rewardCfg) return true
+      return false
+    })
   }, [poolData?.data?.pools])
 
   const showPoolPrice = useMemo(() => {

--- a/apps/kyberswap-interface/src/pages/Earns/components/PoolRewardsInfo.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/PoolRewardsInfo.tsx
@@ -8,17 +8,22 @@ import { HStack, Stack } from 'components/Stack'
 import TokenLogo from 'components/TokenLogo'
 import { MouseoverTooltipDesktopOnly } from 'components/Tooltip'
 import useTheme from 'hooks/useTheme'
+import { getParsedRewardAmount } from 'pages/Earns/PoolDetail/components/utils'
 import { Badge } from 'pages/Earns/PoolExplorer/styles'
 import { EarnPool } from 'pages/Earns/types'
+import { useTokenPrices } from 'state/tokenPrices/hooks'
 import { getFullDisplayBalance } from 'utils/formatBalance'
 import { formatDisplayNumber } from 'utils/numbers'
+
+const BLOCKS_PER_CYCLE = 2016
+const WEEK_SECONDS = 7 * 24 * 60 * 60
 
 type Props = {
   pool: EarnPool
   showEstimate?: boolean
 }
 
-const RewardTooltipContent = ({ egRewards, bonusRewards }: { egRewards: number; bonusRewards: number }) => {
+const RewardTooltipContent = ({ bonusRewards, egRewards }: { bonusRewards: number; egRewards: number }) => {
   return (
     <Stack gap={2}>
       {egRewards > 0 && (
@@ -41,9 +46,36 @@ const PoolRewardsInfo = ({ pool, showEstimate = true }: Props) => {
   const egRewards = pool.egUsd || 0
   const bonusRewards = pool.merklOpportunity?.dailyRewards ?? 0
   const totalRewards = egRewards + bonusRewards
-  const hasRewards = totalRewards > 0
+  const depositAmount = 1_000
 
-  const depositAmount = 1000
+  const kemRewardTokens = useMemo(() => {
+    const cycleDuration = (pool.kemReward?.endTime || 0) - (pool.kemReward?.startTime || 0)
+    const depositShare = pool.tvl > 0 ? depositAmount / (pool.tvl + depositAmount) : 0
+
+    return (pool.kemReward?.rewardCfg || [])
+      .map(reward => {
+        const decimals = reward.tokenInfo?.decimals
+        const amountPerBlock = decimals !== undefined ? getParsedRewardAmount(reward.amountReward, decimals) : 0
+        const totalAmount = amountPerBlock * BLOCKS_PER_CYCLE
+        const weeklyTotalAmount = cycleDuration > 0 ? totalAmount * (WEEK_SECONDS / cycleDuration) : 0
+
+        return {
+          address: reward.tokenInfo?.address || reward.tokenAddress,
+          estWeeklyAmount: weeklyTotalAmount * depositShare,
+          logoURI: reward.tokenInfo?.logoURL,
+          symbol: reward.tokenInfo?.symbol,
+          totalAmount,
+          weeklyTotalAmount,
+        }
+      })
+      .filter(token => token.totalAmount > 0)
+  }, [depositAmount, pool.kemReward?.endTime, pool.kemReward?.rewardCfg, pool.kemReward?.startTime, pool.tvl])
+
+  const kemRewardTokenAddresses = useMemo(() => kemRewardTokens.map(token => token.address), [kemRewardTokens])
+  const kemRewardTokenPrices = useTokenPrices(kemRewardTokenAddresses, pool.chainId)
+
+  const hasRewards = totalRewards > 0 || kemRewardTokens.length > 0
+
   const merklTvl = pool.merklOpportunity?.tvl || 0
   const weeklyRewards = bonusRewards * 7
   const weeklyRewardsEst = (depositAmount / (merklTvl + depositAmount)) * weeklyRewards
@@ -70,7 +102,7 @@ const PoolRewardsInfo = ({ pool, showEstimate = true }: Props) => {
         <Text>{formatDisplayNumber(totalRewards, { style: 'currency', significantDigits: 4 })}</Text>
       )}
 
-      {rewardTokens.length > 0 && showEstimate && weeklyRewards > 0 && (
+      {(rewardTokens.length > 0 || kemRewardTokens.length > 0) && (
         <HStack align="center" gap={4} justify="flex-end">
           {rewardTokens.length > 0 && (
             <MouseoverTooltipDesktopOnly
@@ -80,7 +112,7 @@ const PoolRewardsInfo = ({ pool, showEstimate = true }: Props) => {
                     <HStack align="center" gap={4} key={`${token.chainId}-${token.address}`}>
                       {token.icon ? <TokenLogo src={token.icon} size={16} /> : null}
                       <Text>
-                        {token.amount} {token.symbol}
+                        {formatDisplayNumber(token.amount, { significantDigits: 6 })} {token.symbol}
                       </Text>
                     </HStack>
                   ))}
@@ -92,6 +124,33 @@ const PoolRewardsInfo = ({ pool, showEstimate = true }: Props) => {
               <HStack align="center" gap={4} wrap="wrap" justify="flex-end">
                 {rewardTokens.map(token => (
                   <TokenLogo key={`${token.chainId}-${token.address}`} src={token.icon} size={16} />
+                ))}
+              </HStack>
+            </MouseoverTooltipDesktopOnly>
+          )}
+
+          {kemRewardTokens.length > 0 && (
+            <MouseoverTooltipDesktopOnly
+              text={
+                <Stack gap={4}>
+                  {kemRewardTokens.map(token => (
+                    <Stack gap={2} key={token.address}>
+                      <HStack align="center" gap={4}>
+                        {token.logoURI ? <TokenLogo src={token.logoURI} size={16} /> : null}
+                        <Text>
+                          {formatDisplayNumber(token.totalAmount, { significantDigits: 6 })} {token.symbol}
+                        </Text>
+                      </HStack>
+                    </Stack>
+                  ))}
+                </Stack>
+              }
+              width="fit-content"
+              placement="bottom"
+            >
+              <HStack align="center" gap={4} wrap="wrap" justify="flex-end">
+                {kemRewardTokens.map(token => (
+                  <TokenLogo key={token.address} src={token.logoURI} size={16} />
                 ))}
               </HStack>
             </MouseoverTooltipDesktopOnly>
@@ -118,6 +177,35 @@ const PoolRewardsInfo = ({ pool, showEstimate = true }: Props) => {
               </Badge>
             </MouseoverTooltipDesktopOnly>
           )}
+
+          {showEstimate &&
+            kemRewardTokens.map(token => {
+              const tokenPrice = kemRewardTokenPrices[token.address] || 0
+              const weeklyTotalUsd = token.weeklyTotalAmount * tokenPrice
+
+              return (
+                <MouseoverTooltipDesktopOnly
+                  key={token.address}
+                  text={
+                    <Text>
+                      <Text as="span" color={theme.blue3} fontWeight={500}>
+                        {formatDisplayNumber(token.estWeeklyAmount, { significantDigits: 6 })} {token.symbol}/week
+                      </Text>{' '}
+                      {`when adding $${depositAmount} liquidity (est)`}
+                    </Text>
+                  }
+                  width="fit-content"
+                  placement="bottom"
+                >
+                  <Badge style={{ padding: '4px 6px' }}>
+                    <RewardIcon width={16} height={16} />
+                    <Text sx={{ whiteSpace: 'nowrap' }}>
+                      {formatDisplayNumber(weeklyTotalUsd, { style: 'currency', significantDigits: 4 })}/week
+                    </Text>
+                  </Badge>
+                </MouseoverTooltipDesktopOnly>
+              )
+            })}
         </HStack>
       )}
     </Stack>

--- a/apps/kyberswap-interface/src/pages/Earns/types/pool.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/types/pool.ts
@@ -13,6 +13,27 @@ export enum PAIR_CATEGORY {
   DEFAULT_EMPTY = '', // For Krystal data
 }
 
+export interface KemReward {
+  rewardCfg: Array<{
+    tokenAddress: string
+    amountReward: string | number
+    weightFee: number
+    weightAt: number
+    weightAtFee3: number
+    weightAt3Fee: number
+    weightFeeEg: number
+    tokenInfo?: {
+      address: string
+      symbol: string
+      decimals: number
+      logoURL?: string
+    }
+  }>
+  startTime: number
+  endTime: number
+  egSharingPercentage: number
+}
+
 export interface EarnPool {
   address: string
   earnFee: number
@@ -43,6 +64,7 @@ export interface EarnPool {
   }
   category?: PAIR_CATEGORY
   programs?: Array<ProgramType>
+  kemReward?: KemReward
   merklOpportunity?: MerklOpportunity
   tokens: Array<{
     address: string


### PR DESCRIPTION
## Summary
- Add KEM reward metadata to earn pool types and reward display logic
- Show KEM reward token icons and total reward amounts in pool reward info
- Estimate weekly KEM rewards for a sample liquidity deposit using token prices
- Include KEM reward config when deciding whether pool rewards should be shown
- Use the Kyber data chain route when fetching cycle config