### PR TITLE
fix(earns): sync APR badges with active APR

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/components/PoolAprBadges.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/PoolAprBadges.tsx
@@ -15,8 +15,11 @@ type Props = {
 }
 
 const PoolAprBadges = ({ pool }: Props) => {
-  const showEgReward = pool.programs?.includes(ProgramType.EG) && pool.kemEGApr > 0
-  const showLmReward = pool.programs?.includes(ProgramType.LM) && pool.kemLMApr > 0
+  const hasActiveApr = !!pool.activeApr
+  const egApr = hasActiveApr ? pool.activeEgApr || 0 : pool.kemEGApr
+  const lmApr = hasActiveApr ? pool.activeLmApr || 0 : pool.kemLMApr
+  const showEgReward = pool.programs?.includes(ProgramType.EG) && egApr > 0
+  const showLmReward = pool.programs?.includes(ProgramType.LM) && lmApr > 0
   const merklOpportunity = pool.merklOpportunity
 
   if (!showEgReward && !showLmReward && !merklOpportunity) return null
@@ -29,11 +32,11 @@ const PoolAprBadges = ({ pool }: Props) => {
         <MouseoverTooltipDesktopOnly
           placement="bottom"
           width="fit-content"
-          text={`${t`FairFlow EG Rewards`}: ${formatAprNumber(pool.kemEGApr)}%`}
+          text={`${t`FairFlow EG Rewards`}: ${formatAprNumber(egApr)}%`}
         >
           <Badge>
             <UniBonusIcon width={16} height={16} />
-            <Text>+{formatAprNumber(pool.kemEGApr)}%</Text>
+            <Text>+{formatAprNumber(egApr)}%</Text>
           </Badge>
         </MouseoverTooltipDesktopOnly>
       )}
@@ -41,11 +44,11 @@ const PoolAprBadges = ({ pool }: Props) => {
         <MouseoverTooltipDesktopOnly
           placement="bottom"
           width="fit-content"
-          text={`${t`LM Reward`}: ${formatAprNumber(pool.kemLMApr)}%`}
+          text={`${t`LM Reward`}: ${formatAprNumber(lmApr)}%`}
         >
           <Badge>
             <KyberBonusIcon width={16} height={16} />
-            <Text>+{formatAprNumber(pool.kemLMApr)}%</Text>
+            <Text>+{formatAprNumber(lmApr)}%</Text>
           </Badge>
         </MouseoverTooltipDesktopOnly>
       )}

--- a/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
@@ -13,15 +13,15 @@ import { ExternalLink } from 'theme/components'
 
 const AprTooltipContent = ({ pool, type }: { pool: ParsedEarnPool; type: 'total' | 'active' }) => {
   const theme = useTheme()
-  const isActive = type === 'active'
-  const lpApr = isActive ? pool.activeFeeApr : pool.lpApr
-  const egApr = isActive ? pool.activeEgApr : pool.kemEGApr
-  const lmApr = isActive ? pool.activeLmApr : pool.kemLMApr
+  const hasActiveApr = type === 'active'
+  const lpApr = hasActiveApr ? pool.activeFeeApr : pool.lpApr
+  const egApr = hasActiveApr ? pool.activeEgApr : pool.kemEGApr
+  const lmApr = hasActiveApr ? pool.activeLmApr : pool.kemLMApr
   const bonusApr = pool.bonusApr
 
   return (
     <Stack gap={2}>
-      {isActive ? (
+      {hasActiveApr ? (
         <Text>
           <Trans>
             Earning per{' '}


### PR DESCRIPTION
## Summary
- Use active EG and LM APR values for pool APR badges when active APR is available
- Align APR tooltip variable naming with active APR handling