### PR TITLE
feat(earns): update pool APR displays

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
@@ -19,7 +19,12 @@ const InformationTab = () => {
   )
 
   const poolStats = pool.poolStats
-  const rewardApr = (poolStats?.kemEGApr ?? 0) + (poolStats?.kemLMApr ?? 0) + (poolStats?.bonusApr ?? 0)
+  const bonusApr = poolStats?.bonusApr ?? 0
+  const currentApr = {
+    totalApr: poolStats?.allApr24h,
+    activeApr: poolStats?.activeApr ? poolStats.activeApr + bonusApr : undefined,
+  }
+  const rewardApr = (poolStats?.kemEGApr ?? 0) + (poolStats?.kemLMApr ?? 0) + bonusApr
   const liquidityUsdValue = getPoolLiquidityUsd(pool, tokenPrices)
 
   const tvlValue = formatUsd(poolStats?.tvl)
@@ -48,7 +53,7 @@ const InformationTab = () => {
     <Stack gap={20}>
       <TopMetricsStrip items={topMetrics} split={true} />
 
-      <AprHistoryChart chainId={chainId} poolAddress={poolAddress} />
+      <AprHistoryChart chainId={chainId} currentApr={currentApr} poolAddress={poolAddress} />
     </Stack>
   )
 }

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
@@ -32,7 +32,7 @@ const InformationTab = () => {
       <Text as="span" color={theme.text} fontWeight={500}>
         {formatApr(rewardApr)}
       </Text>
-      {rewardApr > 0 ? <BagIcon height={20} width={20} /> : null}
+      {rewardApr > 0 ? <BagIcon height={18} width={18} /> : null}
     </HStack>
   )
 

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
@@ -46,17 +46,6 @@ const BaselineRow = styled(HStack)`
 
 export const formatAprValue = (value?: number) => (value || value === 0 ? `${formatAprNumber(value)}%` : '--')
 
-export const getLatestAprValues = (points?: PoolAprHistoryPoint[]) => {
-  const latestTotalApr = [...(points ?? [])].reverse().find(point => point.totalApr !== undefined)?.totalApr
-  const latestActiveApr = [...(points ?? [])].reverse().find(point => point.activeApr !== undefined)?.activeApr
-
-  return {
-    hasActiveApr: latestActiveApr !== undefined,
-    latestActiveApr,
-    latestTotalApr,
-  }
-}
-
 const AprHistoryTooltip = ({
   active,
   point,
@@ -111,9 +100,13 @@ type AprHistoryChartProps = {
   chainId: number
   poolAddress?: string
   positionId?: string
+  currentApr?: {
+    totalApr?: number
+    activeApr?: number
+  }
 }
 
-const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartProps) => {
+const AprHistoryChart = ({ chainId, poolAddress, positionId, currentApr }: AprHistoryChartProps) => {
   const theme = useTheme()
 
   const [window, setWindow] = useState<PoolAnalyticsWindow>('7d')
@@ -154,19 +147,21 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartPr
     [aprHistoryData?.points, volumeDownColor, volumeUpColor],
   )
 
-  const { hasActiveApr, latestActiveApr, latestTotalApr } = useMemo(() => getLatestAprValues(chartData), [chartData])
+  const hasActiveApr = currentApr?.activeApr !== undefined
+  const activeApr = currentApr?.activeApr
+  const totalApr = currentApr?.totalApr
 
   return (
     <Stack gap={16}>
       <HStack align="flex-start" gap={16} justify="space-between" wrap="wrap">
         <Stack gap={4} minHeight={48}>
-          {hasActiveApr && latestTotalApr !== undefined && (
+          {hasActiveApr && totalApr !== undefined && (
             <BaselineRow gap={4}>
               <Text color={theme.subText} fontSize={14}>
                 APR
               </Text>
               <Text color={theme.text} fontSize={14} fontWeight={500}>
-                {formatAprValue(latestTotalApr)}
+                {formatAprValue(totalApr)}
               </Text>
             </BaselineRow>
           )}
@@ -177,7 +172,7 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartPr
                 {positionId ? 'Position Active APR' : 'Active APR'}
               </Text>
               <Text color={theme.primary} fontSize={20} fontWeight={500} lineHeight={1}>
-                {formatAprValue(latestActiveApr)}
+                {formatAprValue(activeApr)}
               </Text>
               <Text color={theme.subText} fontSize={14}>
                 (Earning Per Active TVL)
@@ -189,7 +184,7 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartPr
                 APR
               </Text>
               <Text color={theme.blue} fontSize={20} fontWeight={500} lineHeight={1}>
-                {formatAprValue(latestTotalApr)}
+                {formatAprValue(totalApr)}
               </Text>
               <Text color={theme.subText} fontSize={14}>
                 (Earning Per Total TVL)

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
@@ -81,7 +81,7 @@ const AprHistoryTooltip = ({
             <Text color={theme.subText} fontSize={12}>
               Active APR
             </Text>
-            <Text color={theme.blue} fontSize={12} fontWeight={500} textAlign="right">
+            <Text color={theme.primary} fontSize={12} fontWeight={500} textAlign="right">
               {formatAprNumber(point.activeApr)}%
             </Text>
           </>
@@ -89,7 +89,7 @@ const AprHistoryTooltip = ({
         <Text color={theme.subText} fontSize={12}>
           APR
         </Text>
-        <Text color={theme.primary} fontSize={12} fontWeight={500} textAlign="right">
+        <Text color={theme.blue} fontSize={12} fontWeight={500} textAlign="right">
           {formatAprNumber(point.totalApr)}%
         </Text>
         {point.volumeUsd || point.volumeUsd === 0 ? (
@@ -122,8 +122,8 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartPr
   const chartHeight = upToSmall ? 280 : 360
 
   const activeDotStroke = theme.buttonBlack
-  const aprLineColor = theme.primary
-  const activeAprLineColor = theme.blue
+  const aprLineColor = theme.blue
+  const activeAprLineColor = theme.primary
   const volumeUpColor = rgba(theme.darkGreen, 0.8)
   const volumeDownColor = rgba(theme.red, 0.5)
   const cursorColor = rgba(theme.text, 0.12)
@@ -176,7 +176,7 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartPr
               <Text color={theme.text} fontSize={16} fontWeight={500}>
                 {positionId ? 'Position Active APR' : 'Active APR'}
               </Text>
-              <Text color={theme.blue} fontSize={20} fontWeight={500} lineHeight={1}>
+              <Text color={theme.primary} fontSize={20} fontWeight={500} lineHeight={1}>
                 {formatAprValue(latestActiveApr)}
               </Text>
               <Text color={theme.subText} fontSize={14}>
@@ -188,7 +188,7 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartPr
               <Text color={theme.text} fontSize={16} fontWeight={500}>
                 APR
               </Text>
-              <Text color={theme.primary} fontSize={20} fontWeight={500} lineHeight={1}>
+              <Text color={theme.blue} fontSize={20} fontWeight={500} lineHeight={1}>
                 {formatAprValue(latestTotalApr)}
               </Text>
               <Text color={theme.subText} fontSize={14}>

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
@@ -154,39 +154,22 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId }: AprHistoryChartPr
     [aprHistoryData?.points, volumeDownColor, volumeUpColor],
   )
 
-  const intervalMaxApr = useMemo(() => {
-    const values = chartData
-      .map(point => point.totalApr)
-      .filter((value): value is number => value !== undefined && !Number.isNaN(value))
-    return values.length ? Math.max(...values) : undefined
-  }, [chartData])
-
   const { hasActiveApr, latestActiveApr, latestTotalApr } = useMemo(() => getLatestAprValues(chartData), [chartData])
 
   return (
     <Stack gap={16}>
       <HStack align="flex-start" gap={16} justify="space-between" wrap="wrap">
-        <Stack gap={12}>
-          <HStack align="center" gap="12px 24px" wrap="wrap">
-            {hasActiveApr && latestTotalApr !== undefined ? (
-              <BaselineRow gap={4}>
-                <Text color={theme.subText} fontSize={14}>
-                  APR
-                </Text>
-                <Text color={theme.text} fontSize={14} fontWeight={500}>
-                  {formatAprValue(latestTotalApr)}
-                </Text>
-              </BaselineRow>
-            ) : null}
+        <Stack gap={4} minHeight={48}>
+          {hasActiveApr && latestTotalApr !== undefined && (
             <BaselineRow gap={4}>
               <Text color={theme.subText} fontSize={14}>
-                Max APR
+                APR
               </Text>
               <Text color={theme.text} fontSize={14} fontWeight={500}>
-                {formatAprValue(intervalMaxApr)}
+                {formatAprValue(latestTotalApr)}
               </Text>
             </BaselineRow>
-          </HStack>
+          )}
 
           {hasActiveApr ? (
             <BaselineRow gap={8} wrap="wrap">

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolDetailPageSkeleton.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolDetailPageSkeleton.tsx
@@ -23,18 +23,18 @@ const PoolInformationSkeleton = () => {
 
   return (
     <Stack width="100%" gap={20} p={16} borderRadius={12} background={theme.background}>
-      <Stack gap={30}>
+      <Stack gap={32}>
         <HStack gap={24} wrap="wrap">
           <Skeleton width={96} height={24} />
           <Skeleton width={96} height={24} />
           <Skeleton width={96} height={24} />
         </HStack>
 
-        <HStack gap={12} wrap="wrap">
+        <HStack gap={12}>
           {Array.from({ length: 5 }).map((_, index) => (
             <Stack key={index} flex="1 1 160px" gap={8} p={16} borderRadius={16} background={theme.buttonGray}>
               <Skeleton width={80} height={16} />
-              <Skeleton width={120} height={17} />
+              <Skeleton width={120} height={16} />
             </Stack>
           ))}
         </HStack>
@@ -42,7 +42,7 @@ const PoolInformationSkeleton = () => {
 
       <Stack gap={16}>
         <Stack gap={12}>
-          <Skeleton width={200} height={18} />
+          <Skeleton width={200} height={16} />
           <Skeleton width={320} height={20} />
         </Stack>
 

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningApr.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningApr.tsx
@@ -10,13 +10,13 @@ import { formatAprValue } from 'pages/Earns/PoolDetail/components/AprHistoryChar
 import { usePoolDetailContext } from 'pages/Earns/PoolDetail/context'
 
 const AprBadge = styled(Stack)`
-  background: ${({ theme }) => rgba(theme.primary, 0.12)};
+  background: ${({ theme }) => rgba(theme.blue, 0.12)};
   border-radius: 12px;
   padding: 4px 12px;
 `
 
 const ActiveAprBadge = styled(AprBadge)`
-  background: ${({ theme }) => rgba(theme.blue, 0.12)};
+  background: ${({ theme }) => rgba(theme.primary, 0.12)};
 `
 
 const AprSection = styled(HStack)`
@@ -77,7 +77,7 @@ const PoolEarningApr = () => {
             <InfoHelper text="Earning Per Total TVL" size={14} placement="top" />
           </HStack>
           <AprBadge>
-            <Text color={theme.primary} fontSize={24} fontWeight={600}>
+            <Text color={theme.blue} fontSize={24} fontWeight={600}>
               {formatAprValue(aprSummary.totalApr)}
             </Text>
           </AprBadge>
@@ -115,7 +115,7 @@ const PoolEarningApr = () => {
               <InfoHelper text="Earning Per Active TVL" size={14} placement="top" />
             </HStack>
             <ActiveAprBadge>
-              <Text color={theme.blue} fontSize={24} fontWeight={600}>
+              <Text color={theme.primary} fontSize={24} fontWeight={600}>
                 {formatAprValue(aprSummary.activeApr)}
               </Text>
             </ActiveAprBadge>

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolHeader.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolHeader.tsx
@@ -112,7 +112,7 @@ const PoolHeaderPage = () => {
         token0: { symbol: primaryToken.symbol, logo: primaryToken.logoURI || '' },
         token1: { symbol: secondaryToken.symbol, logo: secondaryToken.logoURI || '' },
         apr: {
-          fees: (poolStats?.apr24h || 0) + bonusApr,
+          fees: (poolStats?.lpApr24h || 0) + bonusApr,
           eg: poolStats?.kemEGApr24h || 0,
           lm: poolStats?.kemLMApr24h || 0,
           activeTotal,

--- a/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
@@ -26,7 +26,7 @@ const AprTooltipContent = ({ pool, type }: { pool: ParsedEarnPool; type: 'total'
           <Trans>
             Earning per{' '}
             <ExternalLink
-              style={{ color: theme.blue }}
+              style={{ color: theme.primary }}
               href="https://docs.kyberswap.com/user-guide/kyber-earn/apr-metrics#active-apr"
             >
               Active TVL <Info size={12} style={{ marginBottom: -2 }} />
@@ -37,7 +37,7 @@ const AprTooltipContent = ({ pool, type }: { pool: ParsedEarnPool; type: 'total'
         <Text>
           <Trans>
             Earning per{' '}
-            <Text as="span" color={theme.primary}>
+            <Text as="span" color={theme.blue}>
               Total TVL
             </Text>
           </Trans>
@@ -92,7 +92,7 @@ const PoolAprInfo = ({ pool }: { pool: ParsedEarnPool }) => {
           width="fit-content"
           text={<AprTooltipContent pool={pool} type="active" />}
         >
-          <Text color={theme.blue}>{formatAprNumber(pool.activeApr + (pool.bonusApr || 0))}%</Text>
+          <Text color={theme.primary}>{formatAprNumber(pool.activeApr + (pool.bonusApr || 0))}%</Text>
         </MouseoverTooltipDesktopOnly>
       ) : (
         <MouseoverTooltipDesktopOnly
@@ -100,7 +100,7 @@ const PoolAprInfo = ({ pool }: { pool: ParsedEarnPool }) => {
           width="fit-content"
           text={<AprTooltipContent pool={pool} type="total" />}
         >
-          <Text color={theme.green}>{formatAprNumber(pool.allApr)}%</Text>
+          <Text color={theme.blue}>{formatAprNumber(pool.allApr)}%</Text>
         </MouseoverTooltipDesktopOnly>
       )}
 


### PR DESCRIPTION
## Summary
- Swap pool APR color mapping so active APR uses primary and total APR uses blue across explorer, detail summary, and history chart
- Simplify APR history header to show the latest APR instead of max APR
- Use LP fee APR for pool share data and tighten related pool detail icon and skeleton sizing