### PR TITLE
fix(earns): sync migration price orientation

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityTokenInput.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityTokenInput.tsx
@@ -86,11 +86,13 @@ interface AddLiquidityTokenInputProps {
     slippage?: number
     tickLower?: number | null
     tickUpper?: number | null
+    revertPrice?: boolean
   }
   onTrackEvent?: (eventName: string, data?: Record<string, unknown>) => void
   onOpenZapMigration?: (
     position: { exchange: string; poolId: string; positionId: string | number },
     initialTick?: { tickUpper: number; tickLower: number },
+    initialRevertPrice?: boolean,
     initialSlippage?: number,
   ) => void
   onTokensChange?: (nextTokens: Token[]) => void
@@ -121,6 +123,7 @@ const AddLiquidityTokenInput = ({
   const currentSlippage = value?.slippage
   const tickLower = value?.tickLower
   const tickUpper = value?.tickUpper
+  const revertPrice = value?.revertPrice
   const amountList = useMemo(() => currentAmounts.split(','), [currentAmounts])
 
   const onCloseTokenSelectModal = useCallback(() => {
@@ -201,10 +204,11 @@ const AddLiquidityTokenInput = ({
       onOpenZapMigration(
         position,
         typeof tickLower === 'number' && typeof tickUpper === 'number' ? { tickLower, tickUpper } : undefined,
+        revertPrice,
         initialSlippage,
       )
     },
-    [chainId, onOpenZapMigration, onTrackEvent, pool, poolType, tickLower, tickUpper],
+    [chainId, onOpenZapMigration, onTrackEvent, pool, poolType, revertPrice, tickLower, tickUpper],
   )
 
   return (

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidget.tsx
@@ -49,6 +49,7 @@ type AddLiquidityWidgetProps = {
   onOpenZapMigration?: (
     position: { exchange: string; poolId: string; positionId: string | number },
     initialTick?: { tickUpper: number; tickLower: number },
+    initialRevertPrice?: boolean,
     initialSlippage?: number,
   ) => void
 }
@@ -141,6 +142,7 @@ const AddLiquidityWidget = ({
             slippage: state.slippage.value,
             tickLower: state.priceRange.tickLower,
             tickUpper: state.priceRange.tickUpper,
+            revertPrice: state.priceRange.revertPrice,
           }}
           onTrackEvent={onTrackEvent}
           onOpenZapMigration={onOpenZapMigration}

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/PriceSection/RangePresetSelector.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/PriceSection/RangePresetSelector.tsx
@@ -1,6 +1,6 @@
 import { DEXES_INFO, NETWORKS_INFO, Pool, PoolType } from '@kyber/schema'
 import { rgba } from 'polished'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import InfoHelper from 'components/InfoHelper'
@@ -106,7 +106,7 @@ const RangePresetSelector = ({
     ],
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (
       revertPrice !== previousRevertPrice.current &&
       rangeSelected !== previousRangeSelected.current &&

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/index.tsx
@@ -51,6 +51,7 @@ type AddLiquidityBodyProps = AddLiquidityProps & {
   onOpenZapMigration?: (
     position: { exchange: string; poolId: string; positionId: string | number },
     initialTick?: { tickUpper: number; tickLower: number },
+    initialRevertPrice?: boolean,
     initialSlippage?: number,
   ) => void
   onTrackEvent?: (eventName: string, data?: Record<string, unknown>) => void
@@ -367,6 +368,7 @@ const AddLiquidity = ({ children }: AddLiquidityProps) => {
     (
       position: { exchange: string; poolId: string; positionId: string | number },
       initialTick?: { tickUpper: number; tickLower: number },
+      initialRevertPrice?: boolean,
       initialSlippage?: number,
     ) => {
       openZapMigrationWidget({
@@ -383,6 +385,7 @@ const AddLiquidity = ({ children }: AddLiquidityProps) => {
         },
         chainId,
         initialTick,
+        initialRevertPrice,
         initialSlippage,
       })
     },

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
@@ -48,6 +48,7 @@ interface MigrateLiquidityPureParams {
   }
   chainId: ZapMigrationChainId
   initialTick?: { tickUpper: number; tickLower: number }
+  initialRevertPrice?: boolean
   initialSlippage?: number
   rePositionMode?: boolean
 }
@@ -82,6 +83,7 @@ export interface ZapMigrationInfo {
   }
   chainId: number
   initialTick?: { tickUpper: number; tickLower: number }
+  initialRevertPrice?: boolean
   initialSlippage?: number
   rePositionMode?: boolean
 }
@@ -151,6 +153,7 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
     to,
     chainId,
     initialTick,
+    initialRevertPrice,
     initialSlippage,
     rePositionMode,
   }: ZapMigrationInfo) => {
@@ -185,6 +188,7 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
         : undefined,
       chainId: chainId as ZapMigrationChainId,
       initialTick,
+      initialRevertPrice,
       initialSlippage,
       rePositionMode,
     })

--- a/packages/zap-migration-widgets/src/hooks/useInitWidget.ts
+++ b/packages/zap-migration-widgets/src/hooks/useInitWidget.ts
@@ -17,6 +17,7 @@ export default function useInitWidget(widgetProps: ZapMigrationProps) {
     theme: themeProps,
     rePositionMode,
     initialSlippage,
+    initialRevertPrice,
     connectedAccount,
     client,
     rpcUrl,
@@ -117,14 +118,14 @@ export default function useInitWidget(widgetProps: ZapMigrationProps) {
 
   useEffect(() => {
     if (!hasReseted) return;
-    getPools({ chainId, source: from, target: to, rePositionMode });
+    getPools({ chainId, source: from, target: to, rePositionMode, initialRevertPrice });
 
     const getPoolsInterval = setInterval(() => {
-      getPools({ chainId, source: from, target: to, rePositionMode });
+      getPools({ chainId, source: from, target: to, rePositionMode, initialRevertPrice });
     }, 15_000);
 
     return () => clearInterval(getPoolsInterval);
-  }, [chainId, getPools, from, to, rePositionMode, hasReseted]);
+  }, [chainId, getPools, from, to, rePositionMode, initialRevertPrice, hasReseted]);
 
   useEffect(() => {
     if (!hasReseted) return;

--- a/packages/zap-migration-widgets/src/stores/usePoolStore.ts
+++ b/packages/zap-migration-widgets/src/stores/usePoolStore.ts
@@ -19,6 +19,7 @@ interface PoolState {
 interface getPoolsProps {
   chainId: ChainId;
   rePositionMode?: boolean;
+  initialRevertPrice?: boolean;
   source: {
     poolAddress: string;
     poolType: PoolType;
@@ -53,7 +54,7 @@ const initState: Omit<PoolState, 'getPools' | 'toggleRevertPrice' | 'reset'> = {
 export const usePoolRawStore = create<PoolState>((set, get) => ({
   ...initState,
   reset: () => set(initState),
-  getPools: async ({ chainId, source, target, rePositionMode }: getPoolsProps) => {
+  getPools: async ({ chainId, source, target, rePositionMode, initialRevertPrice }: getPoolsProps) => {
     if (!target && !rePositionMode) {
       set({ error: POOL_ERROR.MISSING_TARGET_POOL });
       return;
@@ -87,7 +88,11 @@ export const usePoolRawStore = create<PoolState>((set, get) => ({
     }
 
     if (targetPool) {
-      const revertPrice = getDefaultRevertPrice({ pool: targetPool, chainId });
+      const currentState = get();
+      const isSameTargetPool = currentState.targetPool?.address.toLowerCase() === targetPool.address.toLowerCase();
+      const revertPrice = isSameTargetPool
+        ? currentState.revertPrice
+        : (initialRevertPrice ?? getDefaultRevertPrice({ pool: targetPool, chainId }));
       const price = getPoolPrice({ pool: targetPool, revertPrice });
       set({ targetPool, revertPrice, targetPoolPrice: price });
     }

--- a/packages/zap-migration-widgets/src/stores/usePoolStore.ts
+++ b/packages/zap-migration-widgets/src/stores/usePoolStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/shallow';
 
-import { ChainId, Pool, PoolType } from '@kyber/schema';
+import { ChainId, NATIVE_TOKEN_ADDRESS, NETWORKS_INFO, Pool, PoolType } from '@kyber/schema';
 import { POOL_ERROR, getPoolInfo, getPoolPrice } from '@kyber/utils';
 
 interface PoolState {
@@ -28,6 +28,18 @@ interface getPoolsProps {
     poolType: PoolType;
   };
 }
+
+const getDefaultRevertPrice = ({ pool, chainId }: { pool: Pool | null; chainId: ChainId }) => {
+  if (!pool) return false;
+
+  const token0Address = pool.token0.address.toLowerCase();
+  const wrappedNativeAddress = NETWORKS_INFO[chainId]?.wrappedToken.address.toLowerCase();
+  const isToken0Native = token0Address === wrappedNativeAddress || token0Address === NATIVE_TOKEN_ADDRESS.toLowerCase();
+  const isToken0Stable = pool.token0.isStable;
+  const isToken1Stable = pool.token1.isStable;
+
+  return Boolean(isToken0Stable || (isToken0Native && !isToken1Stable));
+};
 
 const initState: Omit<PoolState, 'getPools' | 'toggleRevertPrice' | 'reset'> = {
   loading: false,
@@ -75,10 +87,9 @@ export const usePoolRawStore = create<PoolState>((set, get) => ({
     }
 
     if (targetPool) {
-      set({ targetPool });
-      const revertPrice = get().revertPrice;
+      const revertPrice = getDefaultRevertPrice({ pool: targetPool, chainId });
       const price = getPoolPrice({ pool: targetPool, revertPrice });
-      if (price !== null) set({ targetPoolPrice: price });
+      set({ targetPool, revertPrice, targetPoolPrice: price });
     }
 
     set({ loading: false });

--- a/packages/zap-migration-widgets/src/types/index.ts
+++ b/packages/zap-migration-widgets/src/types/index.ts
@@ -55,6 +55,7 @@ export interface ZapMigrationProps {
     tickLower: number;
     tickUpper: number;
   };
+  initialRevertPrice?: boolean;
   connectedAccount: {
     address: string | undefined;
     chainId: number;


### PR DESCRIPTION
## Summary
- Pass Add Liquidity price orientation into the migration widget when selecting an existing position
- Initialize migration pool pricing with the provided orientation or stable/native default
- Sync Add Liquidity range preset ticks before paint when toggling price orientation