### PR TITLE
fix(swap): show low activity warning inline

### DIFF
--- a/apps/kyberswap-interface/src/pages/SwapV3/Components/TokenPriceChart.tsx
+++ b/apps/kyberswap-interface/src/pages/SwapV3/Components/TokenPriceChart.tsx
@@ -280,17 +280,9 @@ const TokenPriceChart = ({ tokens }: TokenPriceChartProps) => {
 
             <div className="relative rounded-lg">
               {shouldShowLowActivityWarning && (
-                <HStack className="absolute top-0 z-10 items-center justify-center rounded-lg border border-warning/25 bg-warning/10 p-2 text-warning">
-                  <MouseoverTooltip
-                    placement="top"
-                    text={
-                      <span className="text-xs">
-                        <Trans>Limited on-chain activity in the past 24h - price may not reflect tradable rates</Trans>
-                      </span>
-                    }
-                  >
-                    <AlertTriangle size={14} />
-                  </MouseoverTooltip>
+                <HStack className="absolute top-0 z-10 items-center justify-center gap-1 rounded-lg border border-warning/25 bg-warning-10 px-3 py-2 text-center text-xs font-medium text-warning">
+                  <AlertTriangle size={14} />
+                  <Trans>Limited on-chain activity in the past 24h - price may not reflect tradable rates</Trans>
                 </HStack>
               )}
 


### PR DESCRIPTION
## Summary
- Show the swap price chart low-activity warning as an inline alert with icon and message
- Remove the tooltip-only warning presentation