### PR TITLE
fix(wallet): hide safepal without provider

### DIFF
--- a/apps/kyberswap-interface/src/components/Header/web3/WalletModal/useConnections.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/WalletModal/useConnections.tsx
@@ -2,7 +2,13 @@ import { useMemo } from 'react'
 import { isMobile } from 'react-device-detect'
 import { Connector, useConnectors } from 'wagmi'
 
-import { CONNECTION, CONNECTION_ORDER, HardCodedConnectors, getConnectorWithId } from 'components/Web3Provider'
+import {
+  CONNECTION,
+  CONNECTION_ORDER,
+  HardCodedConnectors,
+  getConnectorWithId,
+  getSafepalProvider,
+} from 'components/Web3Provider'
 import { isInSafeApp } from 'utils'
 
 function getInjectedConnectors(connectors: readonly Connector[]) {
@@ -23,10 +29,14 @@ function getInjectedConnectors(connectors: readonly Connector[]) {
       return false
     }
 
-    // SafePal's custom connector pins SafePal's EIP-6963 rdns, so wagmi's mipd dedup
-    // collapses the announced provider onto it instead of creating a second URL-keyed
-    // connector. Always surface this one — its own `connect()` opens the download page
-    // when no provider has injected yet, mirroring HardCodedConnectors install behavior.
+    // SafePal is always registered so its connect() can open the install page,
+    // but the wallet modal must only count it as an injected provider when the
+    // real EVM provider exists. Otherwise mobile in-wallet filtering can return
+    // only SafePal even in unrelated wallets.
+    if (c.id === CONNECTION.SAFEPAL && !getSafepalProvider()) {
+      return false
+    }
+
     return c.type === CONNECTION.INJECTED_CONNECTOR_TYPE && c.id !== CONNECTION.INJECTED_CONNECTOR_ID
   })
 

--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -273,7 +273,7 @@ const createPriorityConnector = ({ id, name, logo, url }: (typeof HardCodedConne
 // carries an `isSafePal: true` flag even when it shims MetaMask via
 // `isMetaMask: true` / `__isMetaMaskShim__`, so use that to discriminate from
 // other wallets that may be active under the same bootstrap.
-function getSafepalProvider(): typeof window.safepalProvider {
+export function getSafepalProvider(): typeof window.safepalProvider {
   if (typeof window === 'undefined') return undefined
   const active = window.__safepalEthereumBootstrap__?.activeProvider
   if (active?.isSafePal) return active as typeof window.safepalProvider


### PR DESCRIPTION
## Summary
- Reuse SafePal provider detection in the wallet modal connection filter
- Hide the SafePal injected connector when no real SafePal EVM provider is available