### PR TITLE
chore: show wallet icon in SelectWallet

### DIFF
--- a/apps/kyberswap-interface/src/components/Header/web3/SelectWallet.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/SelectWallet.tsx
@@ -21,7 +21,7 @@ import { shortenAddress } from 'utils'
 import { cn } from 'utils/cn'
 
 const STATUS_BASE_CLASS = cn(
-  'flex w-fit flex-row gap-2 flex-nowrap cursor-pointer select-none items-center rounded-full px-3 py-2 font-medium focus:outline-none',
+  'flex w-fit cursor-pointer select-none flex-row flex-nowrap items-center gap-2 rounded-full px-3 py-2 font-medium focus:outline-none',
 )
 
 const Text = ({

--- a/apps/kyberswap-interface/src/components/Header/web3/SelectWallet.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/SelectWallet.tsx
@@ -3,29 +3,26 @@ import { useMemo } from 'react'
 import { Activity } from 'react-feather'
 import { useMedia } from 'react-use'
 
-import { ReactComponent as WarningInfo } from 'assets/svg/wallet_warning_icon.svg'
 import { ButtonLight } from 'components/Button'
 import CoinbaseSubscribeBtn from 'components/CoinbaseSubscribeBtn'
 import WalletModal from 'components/Header/web3/WalletModal'
 import Loader from 'components/Loader'
 import { RowBetween } from 'components/Row'
-import { MouseoverTooltip } from 'components/Tooltip'
 import { TutorialIds } from 'components/Tutorial/TutorialSwap/constant'
 import { CONNECTOR_ICON_OVERRIDE_MAP } from 'components/Web3Provider'
 import { useActiveWeb3React, useWeb3React } from 'hooks'
 import useENSName from 'hooks/useENSName'
-import useLogin from 'hooks/useLogin'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { useNetworkModalToggle, useWalletModalToggle } from 'state/application/hooks'
-import { useSignedAccountInfo } from 'state/profile/hooks'
 import { isTransactionRecent, newTransactionsFirst, useAllTransactions } from 'state/transactions/hooks'
 import { TransactionDetails } from 'state/transactions/type'
 import { MEDIA_WIDTHS } from 'theme'
 import { shortenAddress } from 'utils'
 import { cn } from 'utils/cn'
 
-const STATUS_BASE_CLASS =
-  'flex w-fit flex-row flex-nowrap cursor-pointer select-none items-center rounded-full px-3 py-2 font-medium focus:outline-none'
+const STATUS_BASE_CLASS = cn(
+  'flex w-fit flex-row gap-2 flex-nowrap cursor-pointer select-none items-center rounded-full px-3 py-2 font-medium focus:outline-none',
+)
 
 const Text = ({
   className,
@@ -36,7 +33,7 @@ const Text = ({
   children: React.ReactNode
   style?: React.CSSProperties
 }) => (
-  <p style={style} className={cn('m-0 ml-2 mr-1 w-max shrink-0 whitespace-nowrap text-base font-medium', className)}>
+  <p style={style} className={cn('w-max shrink-0 whitespace-nowrap text-base font-medium', className)}>
     {children}
   </p>
 )
@@ -46,7 +43,6 @@ function Web3StatusInner() {
   const { connector } = useWeb3React()
   const { trackingHandler } = useTracking()
   const uptoMedium = useMedia(`(max-width: ${MEDIA_WIDTHS.upToMedium}px)`)
-  const { signIn } = useLogin()
   const { ENSName } = useENSName(account ?? undefined)
 
   const allTransactions = useAllTransactions()
@@ -63,7 +59,6 @@ function Web3StatusInner() {
   const hasPendingTransactions = !!pendingLength
   const toggleWalletModal = useWalletModalToggle()
   const toggleNetworkModal = useNetworkModalToggle()
-  const { isSignInDifferentWallet } = useSignedAccountInfo()
 
   const icon = CONNECTOR_ICON_OVERRIDE_MAP[connector?.id || ''] ?? connector?.icon
 
@@ -118,32 +113,7 @@ function Web3StatusInner() {
           </RowBetween>
         ) : (
           <>
-            {isSignInDifferentWallet ? (
-              <MouseoverTooltip
-                placement="bottom"
-                text={
-                  <Text className="whitespace-normal text-left text-xs">
-                    <Trans>
-                      You are not signed in with this wallet address. If you wish, you can{' '}
-                      <span
-                        className="cursor-pointer text-xs text-primary"
-                        onClick={e => {
-                          e.stopPropagation()
-                          signIn({ account })
-                        }}
-                      >
-                        sign-in
-                      </span>{' '}
-                      to link your wallet to a profile. This will allow us to offer you a better experience.
-                    </Trans>
-                  </Text>
-                }
-              >
-                <WarningInfo width={20} height={20} />
-              </MouseoverTooltip>
-            ) : (
-              walletKey && <img src={icon} alt="" className="size-5 shrink-0 rounded-full" />
-            )}
+            {walletKey && <img src={icon} alt="" className="size-5 min-w-5 shrink-0" />}
             <Text>{ENSName || shortenAddress(chainId, account, uptoMedium ? 2 : undefined)}</Text>
             <CoinbaseSubscribeBtn onlyShowIfNotSubscribe />
           </>


### PR DESCRIPTION
## Summary
- Always render the connected wallet icon in SelectWallet when a wallet key is available
- Remove the signed-in-different-wallet warning tooltip from the connected wallet button
- Use gap spacing and a fixed minimum icon width to keep the wallet button layout stable