### PR TITLE
fix(earns): refresh add liquidity route after tx failure

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidget.tsx
@@ -220,7 +220,9 @@ const AddLiquidityWidget = ({
           onClick={() => void actions.handlePrimaryAction()}
           disabled={actions.isPrimaryActionDisabled}
         >
-          {actions.primaryActionText}
+          <span className={actions.showRouteLoadingDots ? 'ks-loading-dots' : undefined}>
+            {actions.primaryActionText}
+          </span>
         </PrimaryActionButton>
       </HStack>
     </Stack>

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/ReviewModal/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/ReviewModal/index.tsx
@@ -37,6 +37,7 @@ type AddLiquidityReviewModalProps = {
   tokenInput: ZapState['tokenInput']
   warnings: ReviewWarningItem[]
   onDismiss?: () => void
+  onRefreshRoute?: () => void
   onTrackEvent?: (eventName: string, data?: Record<string, unknown>) => void
   onAddTrackedTxHash?: (hash: string) => void
   onAddTransactionWithType?: (transaction: TransactionHistory) => void
@@ -58,6 +59,11 @@ const getStatusDialogType = (statusPhase: ReviewTransactionStatusPhase) => {
   }
 }
 
+const isUserRejectedError = (message?: string | null) => {
+  const normalizedMessage = message?.toLowerCase() || ''
+  return normalizedMessage.includes('reject') || normalizedMessage.includes('denied')
+}
+
 const StatusContent = ({
   statusPhase,
   txError,
@@ -74,13 +80,14 @@ const StatusContent = ({
   const translatedErrorMessage = getStatusErrorMessage(txError)
   const canDismiss = statusPhase !== 'waiting_wallet'
   const canViewPosition = statusPhase === 'success' && Boolean(onViewPosition)
+  const showRefreshLabel = statusPhase === 'failed' && !isUserRejectedError(txError)
 
   const statusAction =
     canDismiss || canViewPosition ? (
       <>
         {canDismiss && (
           <Button className="h-10 flex-1 border-subText" variant="outline" onClick={onDismiss}>
-            Close
+            {showRefreshLabel ? 'Close & Refresh' : 'Close'}
           </Button>
         )}
         {canViewPosition && (
@@ -114,6 +121,7 @@ const AddLiquidityReviewModal = ({
   tokenInput,
   warnings,
   onDismiss,
+  onRefreshRoute,
   onTrackEvent,
   onAddTrackedTxHash,
   onAddTransactionWithType,
@@ -173,6 +181,12 @@ const AddLiquidityReviewModal = ({
     const shouldDismiss = transaction.statusPhase === 'processing' || transaction.statusPhase === 'success'
 
     transaction.resetTransactionState()
+
+    if (transaction.statusPhase === 'failed') {
+      onDismiss?.()
+      onRefreshRoute?.()
+      return
+    }
 
     if (shouldDismiss) {
       onDismiss?.()

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/hooks/useZapActions.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/hooks/useZapActions.ts
@@ -75,13 +75,13 @@ export const useZapActions = ({
       return `Switch to ${NETWORKS_INFO[poolChainId as keyof typeof NETWORKS_INFO]?.name || poolChainId}`
     }
 
-    if (tokenApprovalPending) return 'Approving...'
-    if (previewLoading) return 'Building...'
+    if (tokenApprovalPending) return 'Approving'
+    if (previewLoading) return 'Building'
     if (validationError) return validationError
 
     if (nextTokenToApprove) return `Approve ${nextTokenToApprove.symbol}`
     if (isZapImpactBlocked) return 'Zap Anyway'
-    if (routeLoading && !route) return 'Fetching Route...'
+    if (routeLoading && !route) return 'Fetching Route'
     if (routeError) return 'No route found'
     if (!route && hasPositiveInput && !validationError && !routeLoading) return 'No route found'
     if (isHighZapImpact) return 'Zap Anyway'
@@ -104,6 +104,7 @@ export const useZapActions = ({
   ])
 
   const primaryActionVariant = !nextTokenToApprove && (isZapImpactBlocked || isHighZapImpact) ? 'error' : 'primary'
+  const showRouteLoadingDots = routeLoading && Boolean(route)
   const isPrimaryActionDisabled =
     !!account &&
     walletChainId === poolChainId &&
@@ -152,6 +153,7 @@ export const useZapActions = ({
   return {
     primaryActionText,
     primaryActionVariant,
+    showRouteLoadingDots,
     isPrimaryActionDisabled,
     handlePrimaryAction,
   }

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/index.tsx
@@ -56,6 +56,7 @@ type AddLiquidityBodyProps = AddLiquidityProps & {
   onTrackEvent?: (eventName: string, data?: Record<string, unknown>) => void
   onDismissReview: () => void
   onPreview: () => Promise<void>
+  onRefreshRoute?: () => void
   previewError?: string | null
   reviewState: ReviewState | null
   tracking: AddLiquidityTracking
@@ -103,6 +104,7 @@ const AddLiquidityBody = ({
   onTrackEvent,
   onDismissReview,
   onPreview,
+  onRefreshRoute,
   previewError,
   reviewState,
   normalizedPool,
@@ -158,6 +160,7 @@ const AddLiquidityBody = ({
           tokenInput={state.tokenInput}
           warnings={reviewState.warnings}
           onDismiss={onDismissReview}
+          onRefreshRoute={onRefreshRoute}
           onTrackEvent={onTrackEvent}
           onAddTrackedTxHash={tracking.addTrackedTxHash}
           onAddTransactionWithType={tracking.addTransactionWithType}
@@ -404,6 +407,7 @@ const AddLiquidity = ({ children }: AddLiquidityProps) => {
           onTrackEvent={handleTrackEvent}
           onDismissReview={handleDismissReview}
           onPreview={handlePreview}
+          onRefreshRoute={state.route.refetch}
           previewError={previewError}
           reviewState={reviewState}
           normalizedPool={normalizedPool.data}

--- a/apps/kyberswap-interface/src/tailwind.css
+++ b/apps/kyberswap-interface/src/tailwind.css
@@ -15,6 +15,35 @@
   @apply disabled:!cursor-not-allowed disabled:!bg-buttonGray disabled:!text-border;
 }
 
+@keyframes ks-loading-dots {
+  0% {
+    content: '.';
+  }
+  33% {
+    content: '..';
+  }
+  66%,
+  100% {
+    content: '...';
+  }
+}
+
+.ks-loading-dots {
+  position: relative;
+  display: inline-block;
+}
+
+.ks-loading-dots::after {
+  content: '.';
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  width: 1rem;
+  transform: translateY(-50%);
+  text-align: left;
+  animation: ks-loading-dots 1.2s steps(1, end) infinite;
+}
+
 @layer components {
   /* Native browser checkbox tinted with theme primary; pseudo-elements handle the indeterminate state. */
   .ks-checkbox-native {


### PR DESCRIPTION
## Summary
- Refresh the add liquidity route after closing a failed transaction status
- Show Close & Refresh for non-rejected failures while keeping rejected wallet actions labeled Close