### PR TITLE
fix(swap): reset pair on network route sync

### DIFF
--- a/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
@@ -36,13 +36,6 @@ export const CurrencySelect = forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement> & CurrencySelectStyleProps
 >(({ tight, selected, hideInput, isDisable, className, children, ...rest }, ref) => {
-  const hoverShift = isDisable
-    ? '' // disabled hover keeps brightness unchanged
-    : selected
-    ? hideInput
-      ? 'hover:brightness-95 focus:brightness-95'
-      : 'hover:brightness-105 focus:brightness-105'
-    : 'hover:brightness-95 focus:brightness-95'
   return (
     <button
       ref={ref}
@@ -54,8 +47,7 @@ export const CurrencySelect = forwardRef<
         !selected && 'shadow-[0px_6px_10px_rgba(0,0,0,0.075)]',
         isDisable ? 'cursor-default' : 'cursor-pointer',
         hideInput && !tight ? 'pr-2' : 'pr-0',
-        hoverShift,
-        selected ? 'hover:text-subText focus:text-subText' : 'hover:text-textReverse focus:text-textReverse',
+        !isDisable && 'hover:brightness-125 focus:brightness-125',
         className,
       )}
     >

--- a/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
@@ -122,12 +122,16 @@ const DraggableNetworkButton = ({
       }
 
       changeNetwork(chainId, () => {
-        navigate(
-          {
-            search: new URLSearchParams(filteredParams).toString(),
-          },
-          { replace: true },
-        )
+        const nextSearch = new URLSearchParams(filteredParams).toString()
+
+        if (nextSearch !== window.location.search.replace(/^\?/, '')) {
+          navigate(
+            {
+              search: nextSearch,
+            },
+            { replace: true },
+          )
+        }
         onChangedNetwork?.()
       })
     }

--- a/apps/kyberswap-interface/src/hooks/web3/useSyncNetworkParamWithStore.ts
+++ b/apps/kyberswap-interface/src/hooks/web3/useSyncNetworkParamWithStore.ts
@@ -1,12 +1,27 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
+import { APP_PATHS } from 'constants/index'
 import { NETWORKS_INFO } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
 import { useAccount } from 'hooks/useAccount'
 import { getChainIdFromSlug } from 'utils/string'
 
 import { useChangeNetwork } from './useChangeNetwork'
+
+const getSyncedNetworkPathname = (pathname: string, networkParam: string, networkRoute: string) => {
+  const syncedPathname = pathname.replace(encodeURIComponent(networkParam), networkRoute)
+
+  if (syncedPathname.startsWith(`${APP_PATHS.SWAP}/${networkRoute}/`)) {
+    return `${APP_PATHS.SWAP}/${networkRoute}`
+  }
+
+  if (syncedPathname.startsWith(`${APP_PATHS.LIMIT}/${networkRoute}/`)) {
+    return `${APP_PATHS.LIMIT}/${networkRoute}`
+  }
+
+  return syncedPathname
+}
 
 export function useSyncNetworkParamWithStore() {
   const { network: networkParam } = useParams<{ network?: string }>()
@@ -40,7 +55,10 @@ export function useSyncNetworkParamWithStore() {
       setRequestingNetwork(networkParamKeeper.current)
       await changeNetwork(chainIdKeeper.current, undefined, () => {
         navigate(
-          { ...location, pathname: location.pathname.replace(networkParamKeeper.current, networkInfo.route) },
+          {
+            ...location,
+            pathname: getSyncedNetworkPathname(location.pathname, networkParamKeeper.current, networkInfo.route),
+          },
           { replace: true },
         )
       })
@@ -76,7 +94,7 @@ export function useSyncNetworkParamWithStore() {
       triedSync.current
     ) {
       navigate(
-        { ...location, pathname: location.pathname.replace(encodeURIComponent(networkParam), networkInfo.route) },
+        { ...location, pathname: getSyncedNetworkPathname(location.pathname, networkParam, networkInfo.route) },
         { replace: true },
       )
     }


### PR DESCRIPTION
## Summary
- Reset stale swap and limit currency path segments when syncing the active network route
- Avoid no-op URL search replacements after selecting a header network
- Keep currency selector hover feedback via brightness instead of changing token text color