### PR TITLE
fix: prevent network hover replay

### DIFF
--- a/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
@@ -203,7 +203,6 @@ const DraggableNetworkButton = ({
             border: '1px solid ' + theme.primary,
             scale: 1.05,
           }}
-          whileHover={selected ? undefined : { backgroundColor: theme.tableHeader }}
           animate={animationControls}
           variants={variants}
           style={{ boxShadow: '0 0px 0px #00000060', zIndex: 1 }}
@@ -216,9 +215,10 @@ const DraggableNetworkButton = ({
             'max-sm:h-[54px] max-sm:p-2 max-sm:text-xs',
             selected && '!bg-buttonBlack [&>div]:text-text',
             disabled && '!cursor-not-allowed text-subText/40',
+            !selected && !disabled && 'hover:bg-tableHeader',
           )}
         >
-          <img src={icon} alt="Switch Network" style={{ height: '20px', width: '20px', borderRadius: '4px' }} />
+          <img src={icon} alt="Switch Network" className="size-5 min-w-5 rounded" />
           <Row className="grow gap-1.5">
             <span className="relative text-left">
               {name}


### PR DESCRIPTION
## Summary
- Use Tailwind hover styling for network buttons instead of Framer hover animation
- Keep network icon sizing in Tailwind classes