### PR TITLE
feat(tip-link): add generated link actions

### DIFF
--- a/apps/kyberswap-interface/src/components/Copy/index.tsx
+++ b/apps/kyberswap-interface/src/components/Copy/index.tsx
@@ -17,7 +17,7 @@ type Props = {
 }
 
 const CopyHelper = forwardRef<HTMLDivElement, Props>(function CopyHelper(
-  { toCopy, margin, style = {}, size, text, color, className },
+  { toCopy, margin, style = {}, size = 14, text, color, className },
   ref,
 ) {
   const [isCopied, setCopied] = useCopyClipboard(2000)
@@ -37,10 +37,10 @@ const CopyHelper = forwardRef<HTMLDivElement, Props>(function CopyHelper(
         className={cn('ks-copy-icon absolute left-0 flex items-center', isCopied && 'copied')}
         style={color ? { color } : undefined}
       >
-        <CopyIcon size={size || 14} />
+        <CopyIcon size={size} />
       </div>
       <div className={cn('ks-check-icon flex items-center text-primary', isCopied && 'copied')}>
-        <CheckCircle size={size || 14} />
+        <CheckCircle size={size} />
       </div>
     </>
   )
@@ -60,8 +60,11 @@ const CopyHelper = forwardRef<HTMLDivElement, Props>(function CopyHelper(
       )}
     >
       {text ? (
-        <RowFit>
-          {copyIcon}&nbsp;{text}
+        <RowFit className="gap-1">
+          <span className="relative flex shrink-0 items-center overflow-hidden" style={{ width: size, height: size }}>
+            {copyIcon}
+          </span>
+          <span>{text}</span>
         </RowFit>
       ) : (
         copyIcon

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/TipConfigOutput.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/TipConfigOutput.tsx
@@ -1,16 +1,15 @@
-import { Check, Copy, Loader } from 'react-feather'
+import { ExternalLink, Loader } from 'react-feather'
 
 import { ButtonPrimary } from 'components/Button'
+import CopyHelper from 'components/Copy'
 import { HStack, Stack } from 'components/Stack'
 import { LINK_PLACEHOLDER, enablePreview } from 'components/TipLinkGeneratorModal/shared'
 import Toggle from 'components/Toggle'
 
 type Props = {
   canGenerate: boolean
-  copied: boolean
   generatedLink: string
   isLoading: boolean
-  onCopy: () => void
   onGenerate: () => void
   onShortLinkChange: () => void
   shortLink: boolean
@@ -18,10 +17,8 @@ type Props = {
 
 export default function TipConfigOutput({
   canGenerate,
-  copied,
   generatedLink,
   isLoading,
-  onCopy,
   onGenerate,
   onShortLinkChange,
   shortLink,
@@ -51,15 +48,29 @@ export default function TipConfigOutput({
         </HStack>
         <HStack className="items-center gap-2">
           <div className="min-w-0 flex-1 truncate text-sm text-subText">{generatedLink || LINK_PLACEHOLDER}</div>
-          <HStack
-            as="button"
-            onClick={onCopy}
-            disabled={!generatedLink}
-            className="h-7 items-center gap-1 rounded-full bg-white/10 px-3 text-xs font-medium text-text transition-colors hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white/10"
-          >
-            {copied ? <Check size={13} /> : <Copy size={13} />}
-            {copied ? 'Copied' : 'Copy'}
-          </HStack>
+          {generatedLink && (
+            <a
+              href={generatedLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open generated link in new tab"
+              title="Open in new tab"
+              className="flex size-7 shrink-0 items-center justify-center rounded-full bg-white/10 text-text transition-colors hover:bg-white/15"
+            >
+              <ExternalLink size={13} />
+            </a>
+          )}
+          <CopyHelper
+            toCopy={generatedLink}
+            margin="0"
+            size={13}
+            text="Copy"
+            className={
+              generatedLink
+                ? 'h-7 rounded-full bg-white/10 px-3 text-xs font-medium text-text transition-colors hover:bg-white/15'
+                : 'pointer-events-none h-7 cursor-not-allowed rounded-full bg-white/10 px-3 text-xs font-medium text-text opacity-50'
+            }
+          />
         </HStack>
       </Stack>
     </Stack>

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
@@ -66,7 +66,6 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
   const [showBackground, setShowBackground] = useState(false)
   const [shortLink, setShortLink] = useState(false)
   const [generatedLink, setGeneratedLink] = useState('')
-  const [copied, setCopied] = useState(false)
   const [showNetworkModal, setShowNetworkModal] = useState(false)
   const [inputToken, setInputToken] = useState<TokenSchema>(() => getDefaultInputToken(defaultChainId))
   const [outputToken, setOutputToken] = useState<TokenSchema | undefined>(() => getDefaultOutputToken(defaultChainId))
@@ -98,7 +97,6 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
     setShowBackground(false)
     setShortLink(false)
     setGeneratedLink('')
-    setCopied(false)
     setShowNetworkModal(false)
     setInputToken(getDefaultInputToken(defaultChainId))
     setOutputToken(getDefaultOutputToken(defaultChainId))
@@ -135,7 +133,6 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
 
   useEffect(() => {
     setGeneratedLink('')
-    setCopied(false)
   }, [
     backgroundColor,
     backgroundMode,
@@ -247,21 +244,6 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
     }
   }
 
-  const handleCopy = async () => {
-    if (!generatedLink) return
-    try {
-      await navigator.clipboard.writeText(generatedLink)
-      setCopied(true)
-      window.setTimeout(() => setCopied(false), 1200)
-    } catch {
-      notify({
-        title: t`Copy failed`,
-        summary: t`Please copy the generated link manually.`,
-        type: NotificationType.ERROR,
-      })
-    }
-  }
-
   const handleTokenSelect = (token: TokenSchema) => {
     if (tokenSelectorTarget === 'input') {
       if (isSameToken(token, outputToken)) setOutputToken(inputToken)
@@ -346,10 +328,8 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
 
           <TipConfigOutput
             canGenerate={canGenerate}
-            copied={copied}
             generatedLink={generatedLink}
             isLoading={isLoading}
-            onCopy={handleCopy}
             onGenerate={handleGenerate}
             onShortLinkChange={() => setShortLink(prev => !prev)}
             shortLink={shortLink}


### PR DESCRIPTION
## Summary
- Add an open-in-new-tab action for generated Tip Link URLs
- Use CopyHelper for generated link copy behavior
- Align CopyHelper icon positioning when rendered with text