### PR TITLE
fix(tip-link): validate creator display names

### DIFF
--- a/apps/kyberswap-interface/src/components/FeeControlGroup/index.tsx
+++ b/apps/kyberswap-interface/src/components/FeeControlGroup/index.tsx
@@ -4,11 +4,11 @@ import { useSearchParams } from 'react-router-dom'
 
 import CustomFeeInput from 'components/FeeControlGroup/CustomFeeInput'
 import useGetFeeConfig from 'components/SwapForm/hooks/useGetFeeConfig'
-import { ClientNameMapping, DEFAULT_TIPS } from 'constants/index'
+import { DEFAULT_TIPS } from 'constants/index'
 import { cn } from 'utils/cn'
 
 const FeeControlGroup = () => {
-  const { feeAmount, enableTip, clientId, clientName } = useGetFeeConfig() ?? {}
+  const { feeAmount, enableTip, creatorName } = useGetFeeConfig() ?? {}
   const [searchParams, setSearchParams] = useSearchParams()
   const feeValue = Number.parseFloat(feeAmount ?? '0')
   const [isCustomActive, setIsCustomActive] = useState(!DEFAULT_TIPS.includes(feeValue))
@@ -30,11 +30,6 @@ const FeeControlGroup = () => {
     return null
   }
 
-  const configuredClientName = clientName && clientName !== clientId ? clientName : ''
-  const mappedClientName = ClientNameMapping[clientId || '']
-  const tipRecipientName = configuredClientName || mappedClientName || 'the link sharer'
-  const hasTipRecipientName = Boolean(configuredClientName || mappedClientName)
-
   return (
     <div className="flex w-full flex-col gap-2 rounded-lg bg-white-04 p-3">
       <p className="flex min-w-0 items-center text-xs font-medium text-subText">
@@ -44,7 +39,7 @@ const FeeControlGroup = () => {
           </Trans>
           &nbsp;
         </span>
-        <span className={cn('min-w-0 truncate', hasTipRecipientName && 'text-text')}>{tipRecipientName}</span>
+        <span className={cn('min-w-0 truncate', !!creatorName && 'text-text')}>{creatorName || 'the link sharer'}</span>
       </p>
 
       <div className="flex items-stretch rounded-[20px] border border-border bg-background">

--- a/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
@@ -10,7 +10,7 @@ import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import useGetFeeConfig from 'components/SwapForm/hooks/useGetFeeConfig'
 import { MouseoverTooltip, TextDashed } from 'components/Tooltip'
 import TradePrice from 'components/swapv2/TradePrice'
-import { BIPS_BASE, ClientNameMapping } from 'constants/index'
+import { BIPS_BASE } from 'constants/index'
 import useTheme from 'hooks/useTheme'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
 import { ExternalLink } from 'theme'
@@ -55,15 +55,11 @@ export const TooltipTextOfSwapFee: React.FC<TooltipTextOfSwapFeeProps> = ({ feeB
   }
 
   if (feeConfig?.enableTip) {
-    const tipRecipientName = feeConfig.clientName || 'the link sharer'
     return (
       <Trans>
-        You&apos;re adding a {feePercent} tip ({feeAmountText}) to this swap for{' '}
-        <span title={tipRecipientName} className="inline-block max-w-[120px] truncate align-bottom">
-          {tipRecipientName}
-        </span>
-        . This is deducted from your output - the Est. Output above already includes it. Tips are optional and go
-        directly to the link sharer&apos;s wallet.
+        You&apos;re adding a {feePercent} tip ({feeAmountText}) to this swap for the link sharer. This is deducted from
+        your output - the Est. Output above already includes it. Tips are optional and go directly to the link
+        sharer&apos;s wallet.
       </Trans>
     )
   }
@@ -84,16 +80,12 @@ export const SwapFeeLabel = () => {
   const feeConfig = useGetFeeConfig()
 
   if (feeConfig?.enableTip) {
-    const configuredClientName =
-      feeConfig.clientName && feeConfig.clientName !== feeConfig.clientId ? feeConfig.clientName : ''
-    const tipRecipientName = configuredClientName || ClientNameMapping[feeConfig.clientId || ''] || 'the link sharer'
-
     return (
       <span className="inline-flex min-w-0 max-w-[180px] items-center align-bottom">
         <span className="shrink-0">
           <Trans>Tip for</Trans>&nbsp;
         </span>
-        <span className="min-w-0 truncate">{tipRecipientName}</span>
+        <span className="min-w-0 truncate">{feeConfig.creatorName || 'the link sharer'}</span>
       </span>
     )
   }

--- a/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
@@ -8,7 +8,6 @@ import RefreshLoading from 'components/RefreshLoading'
 import { RowBetween, RowFixed } from 'components/Row'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import useGetFeeConfig from 'components/SwapForm/hooks/useGetFeeConfig'
-import { TIP_LINK_CLIENT_ID } from 'components/TipLinkGeneratorModal/shared'
 import { MouseoverTooltip, TextDashed } from 'components/Tooltip'
 import TradePrice from 'components/swapv2/TradePrice'
 import { BIPS_BASE, ClientNameMapping } from 'constants/index'
@@ -55,8 +54,8 @@ export const TooltipTextOfSwapFee: React.FC<TooltipTextOfSwapFeeProps> = ({ feeB
     return <Trans>Read more about the fees {hereLink}</Trans>
   }
 
-  if (clientId === TIP_LINK_CLIENT_ID) {
-    const tipRecipientName = feeConfig?.clientName || 'the link sharer'
+  if (feeConfig?.enableTip) {
+    const tipRecipientName = feeConfig.clientName || 'the link sharer'
     return (
       <Trans>
         You&apos;re adding a {feePercent} tip ({feeAmountText}) to this swap for{' '}

--- a/apps/kyberswap-interface/src/components/SwapForm/hooks/useGetFeeConfig.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/hooks/useGetFeeConfig.tsx
@@ -9,6 +9,10 @@ import { ChargeFeeBy } from 'types/route'
 import { isAddressString } from 'utils'
 import { convertStringToBoolean } from 'utils/string'
 
+const ClientNameMapping: { [key: string]: string } = {
+  dexscreener: 'DEX Screener',
+}
+
 const useGetFeeConfig = () => {
   const [searchParams] = useSearchParams()
 
@@ -53,7 +57,7 @@ const useGetFeeConfig = () => {
   const enableTip = convertStringToBoolean(searchParams.get('enableTip') || '')
   const isInBps = searchParams.get('isInBps') || ''
   const feeReceiver = searchParams.get('feeReceiver') || ''
-  const creatorName = searchParams.get('creatorName') || ''
+  const creatorName = searchParams.get('creatorName') || ClientNameMapping[clientId] || ''
 
   const feeConfigFromUrl = useMemo(() => {
     if (feeAmount && chargeFeeBy && (enableTip || isInBps) && feeReceiver)
@@ -64,7 +68,7 @@ const useGetFeeConfig = () => {
         isInBps: enableTip ? '1' : isInBps,
         feeReceiver,
         clientId,
-        clientName: creatorName || clientId,
+        creatorName,
       }
     return null
   }, [feeAmount, chargeFeeBy, enableTip, isInBps, feeReceiver, clientId, creatorName])

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/TipConfigForm.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/TipConfigForm.tsx
@@ -21,6 +21,7 @@ type Props = {
   chainId: ChainId
   creatorName: string
   inputToken: TokenSchema
+  isCreatorNameValid: boolean
   isReceiverValid: boolean
   isUsingConnectedAddress: boolean
   onChainSelect: (chainId: ChainId) => void
@@ -41,6 +42,7 @@ export default function TipConfigForm({
   chainId,
   creatorName,
   inputToken,
+  isCreatorNameValid,
   isReceiverValid,
   isUsingConnectedAddress,
   onChainSelect,
@@ -152,14 +154,16 @@ export default function TipConfigForm({
 
       <Stack className="gap-2">
         <SectionLabel optional>Display Name</SectionLabel>
-        <FieldShell>
-          <input
-            value={creatorName}
-            onChange={event => onCreatorNameChange(event.target.value)}
-            placeholder="e.g. DefiAlpha"
-            className="w-full bg-transparent text-sm outline-none placeholder:text-subText/60"
-          />
-        </FieldShell>
+        <Tooltip text="Use another name" show={!isCreatorNameValid} placement="bottom" width="fit-content">
+          <FieldShell className={cn('border', isCreatorNameValid ? 'border-transparent' : 'border-warning/50')}>
+            <input
+              value={creatorName}
+              onChange={event => onCreatorNameChange(event.target.value)}
+              placeholder="e.g. DefiAlpha"
+              className="w-full bg-transparent text-sm outline-none placeholder:text-subText/60"
+            />
+          </FieldShell>
+        </Tooltip>
       </Stack>
     </Stack>
   )

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
@@ -33,8 +33,8 @@ import {
   getCurrencyParam,
   getDefaultInputToken,
   getDefaultOutputToken,
-  isSameToken,
   isCreatorNameValid,
+  isSameToken,
 } from 'components/TipLinkGeneratorModal/shared'
 import { APP_PATHS } from 'constants/index'
 import { NETWORKS_INFO } from 'constants/networks'

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
@@ -34,6 +34,7 @@ import {
   getDefaultInputToken,
   getDefaultOutputToken,
   isSameToken,
+  isCreatorNameValid,
 } from 'components/TipLinkGeneratorModal/shared'
 import { APP_PATHS } from 'constants/index'
 import { NETWORKS_INFO } from 'constants/networks'
@@ -80,7 +81,8 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
   const trimmedReceiver = receiver.trim()
   const trimmedCreatorName = creatorName.trim()
   const isReceiverValid = !trimmedReceiver || Boolean(isAddress(chainId, trimmedReceiver))
-  const canGenerate = Boolean(trimmedReceiver && isReceiverValid && inputToken && outputToken)
+  const isDisplayNameValid = isCreatorNameValid(trimmedCreatorName)
+  const canGenerate = Boolean(trimmedReceiver && isReceiverValid && isDisplayNameValid && inputToken && outputToken)
   const selectedTokenAddress = tokenSelectorTarget === 'input' ? inputToken?.address : outputToken?.address
   const isUsingConnectedAddress = !!account && trimmedReceiver.toLowerCase() === account.toLowerCase()
   const isCustomColor = backgroundMode === 'solid' && !SOLID_COLORS.includes(backgroundColor)
@@ -285,6 +287,7 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
             chainId={chainId}
             creatorName={creatorName}
             inputToken={inputToken}
+            isCreatorNameValid={isDisplayNameValid}
             isReceiverValid={isReceiverValid}
             isUsingConnectedAddress={isUsingConnectedAddress}
             onChainSelect={handleChainSelect}

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/shared.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/shared.tsx
@@ -24,7 +24,21 @@ export const TIP_LINK_CHAINS: ChainId[] = SUPPORTED_NETWORKS.filter(
 export const SOLID_COLORS: string[] = ['#235F52', '#244666', '#6D3345', '#715825', '#412762', '#6D3F70', '#3E653F']
 export const MAX_IMAGE_SIZE = 1024 * 1024
 export const LINK_PLACEHOLDER = `https://kyberswap.com${APP_PATHS.USER_SWAP}/...`
-export const TIP_LINK_CLIENT_ID = 'community'
+export const TIP_LINK_CLIENT_ID = 'kyberswap'
+
+export const isCreatorNameValid = (value: string) => {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]/g, '')
+  const words = value.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+  const hasReservedKS = words.includes('ks') || words.some((word, index) => word === 'k' && words[index + 1] === 's')
+
+  return (
+    !normalized ||
+    (!normalized.includes('kyber') &&
+      !normalized.includes('kswap') &&
+      normalized !== 'ks' &&
+      !hasReservedKS)
+  )
+}
 
 export type BackgroundMode = 'default' | 'solid' | 'image'
 export type TokenSelectorTarget = 'input' | 'output'

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/shared.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/shared.tsx
@@ -28,15 +28,15 @@ export const TIP_LINK_CLIENT_ID = 'kyberswap'
 
 export const isCreatorNameValid = (value: string) => {
   const normalized = value.toLowerCase().replace(/[^a-z0-9]/g, '')
-  const words = value.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+  const words = value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
   const hasReservedKS = words.includes('ks') || words.some((word, index) => word === 'k' && words[index + 1] === 's')
 
   return (
     !normalized ||
-    (!normalized.includes('kyber') &&
-      !normalized.includes('kswap') &&
-      normalized !== 'ks' &&
-      !hasReservedKS)
+    (!normalized.includes('kyber') && !normalized.includes('kswap') && normalized !== 'ks' && !hasReservedKS)
   )
 }
 

--- a/apps/kyberswap-interface/src/constants/index.ts
+++ b/apps/kyberswap-interface/src/constants/index.ts
@@ -295,10 +295,6 @@ export const ICON_IDS = [
 ] as const
 export type ICON_ID = (typeof ICON_IDS)[number]
 
-export const ClientNameMapping: { [key: string]: string } = {
-  dexscreener: 'DEX Screener',
-}
-
 export const SAFE_APP_FEE_RECEIVER_ADDRESS = '0x55602F3057be52BFB6F98fFE799CFDec58Af5130'
 export const SAFE_APP_CLIENT_ID = 'app.safe.global'
 

--- a/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
+++ b/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
@@ -8,7 +8,7 @@ import { useGetTipLinkQuery } from 'services/tipLink'
 import Banner from 'components/Banner'
 import SwapForm, { SwapFormProps } from 'components/SwapForm'
 import { SwitchLocaleLink } from 'components/SwitchLocaleLink'
-import { TIP_LINK_CLIENT_ID } from 'components/TipLinkGeneratorModal/shared'
+import { TIP_LINK_CLIENT_ID, isCreatorNameValid } from 'components/TipLinkGeneratorModal/shared'
 import LimitOrderForm from 'components/swapv2/LimitOrder/LimitOrderForm'
 import ListLimitOrder from 'components/swapv2/LimitOrder/ListLimitOrder'
 import LiquiditySourcesPanel from 'components/swapv2/LiquiditySourcesPanel'
@@ -139,7 +139,9 @@ export default function PartnerSwap({ mode = 'partner' }: Props) {
     nextSearchParams.set('enableTip', 'true')
     nextSearchParams.set('feeReceiver', tipConfig.tipReceiver)
     nextSearchParams.set('clientId', TIP_LINK_CLIENT_ID)
-    if (tipConfig.creatorName) nextSearchParams.set('creatorName', tipConfig.creatorName)
+    const creatorName = tipConfig.creatorName?.trim()
+    if (creatorName && isCreatorNameValid(creatorName)) nextSearchParams.set('creatorName', creatorName)
+    else nextSearchParams.delete('creatorName')
     if (!nextSearchParams.get('feeAmount')) nextSearchParams.set('feeAmount', '0')
     if (!nextSearchParams.get('chargeFeeBy')) nextSearchParams.set('chargeFeeBy', ChargeFeeBy.CURRENCY_OUT)
 
@@ -150,14 +152,17 @@ export default function PartnerSwap({ mode = 'partner' }: Props) {
   useEffect(() => {
     const feeAmount = searchParams.get('feeAmount')
     const feeReceiver = searchParams.get('feeReceiver')
+    const creatorName = searchParams.get('creatorName')
     const hasFeeConfig = Boolean(
       searchParams.get('enableTip') || searchParams.get('isInBps') || feeAmount || feeReceiver,
     )
     const fallbackFeeAmount = hasFeeConfig ? getFeeAmountFallback(feeAmount) : null
+    const shouldRemoveCreatorName = Boolean(creatorName && !isCreatorNameValid(creatorName))
 
-    if (fallbackFeeAmount !== null) {
+    if (shouldRemoveCreatorName || fallbackFeeAmount !== null) {
       const nextSearchParams = new URLSearchParams(searchParams)
-      nextSearchParams.set('feeAmount', fallbackFeeAmount)
+      if (shouldRemoveCreatorName) nextSearchParams.delete('creatorName')
+      if (fallbackFeeAmount !== null) nextSearchParams.set('feeAmount', fallbackFeeAmount)
       setSearchParams(nextSearchParams, { replace: true })
       return
     }


### PR DESCRIPTION
## Summary
- Validate Tip Link display names against reserved KyberSwap-related patterns before generating links
- Remove invalid creator names from PartnerSwap tip URLs so fee labels fall back cleanly
- Use kyberswap as the Tip Link client ID and detect tip fee copy from enableTip