### PR TITLE
feat(tip-link): Formo analytics for tip link generator + attributed trades

### DIFF
--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/index.tsx
@@ -40,6 +40,7 @@ import { NETWORKS_INFO } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
 import { useAllTokens } from 'hooks/Tokens'
 import useChainsConfig from 'hooks/useChainsConfig'
+import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { useNotify, useWalletModalToggle } from 'state/application/hooks'
 import { ChargeFeeBy } from 'types/route'
 import { isAddress } from 'utils'
@@ -54,6 +55,7 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
   const { supportedChains } = useChainsConfig()
   const toggleWalletModal = useWalletModalToggle()
   const notify = useNotify()
+  const { trackingHandler } = useTracking()
   const defaultChainId = TIP_LINK_CHAINS.includes(selectedChainId) ? selectedChainId : PRIMARY_CHAINS[0]
 
   const [chainId, setChainId] = useState<ChainId>(defaultChainId)
@@ -201,6 +203,17 @@ export default function TipLinkGeneratorModal({ isOpen, onDismiss }: { isOpen: b
 
   const handleGenerate = async () => {
     if (!canGenerate || !outputToken) return
+
+    trackingHandler(TRACKING_EVENT_TYPE.TIP_LINK_GENERATE_LINK_CLICK, {
+      receiver_wallet: trimmedReceiver,
+      input_token: inputToken.symbol,
+      input_token_address: inputToken.address,
+      output_token: outputToken.symbol,
+      output_token_address: outputToken.address,
+      pair: `${inputToken.symbol}/${outputToken.symbol}`,
+      chain_id: chainId,
+      chain: networkInfo.name,
+    })
 
     if (!enablePreview || !shortLink) {
       const params = new URLSearchParams({

--- a/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/shared.tsx
+++ b/apps/kyberswap-interface/src/components/TipLinkGeneratorModal/shared.tsx
@@ -29,6 +29,31 @@ export const TIP_LINK_CLIENT_ID = 'community'
 export type BackgroundMode = 'default' | 'solid' | 'image'
 export type TokenSelectorTarget = 'input' | 'output'
 
+export type TipLinkTradeType = 'swap' | 'limit_order' | 'cross_chain'
+
+export type TipLinkAttribution = {
+  tip_receiver: string
+  tip_client_id: string
+  tip_creator_name?: string
+}
+
+/**
+ * Derive tip-link attribution from the current swap URL params. Returns null for any
+ * trade that did not originate from a community tip link (a regular swap, or a partner
+ * swap with a different clientId), so callers can simply skip tracking on null.
+ */
+export const getTipLinkAttribution = (searchParams: URLSearchParams): TipLinkAttribution | null => {
+  const clientId = searchParams.get('clientId')
+  const feeReceiver = searchParams.get('feeReceiver')
+  if (clientId !== TIP_LINK_CLIENT_ID || !feeReceiver) return null
+  const creatorName = searchParams.get('creatorName')?.trim()
+  return {
+    tip_receiver: feeReceiver,
+    tip_client_id: clientId,
+    tip_creator_name: creatorName || undefined,
+  }
+}
+
 export const getChainLabel = (chainId: ChainId) => {
   return NETWORKS_INFO[chainId].name
 }

--- a/apps/kyberswap-interface/src/components/swapv2/LimitOrder/LimitOrderForm.tsx
+++ b/apps/kyberswap-interface/src/components/swapv2/LimitOrder/LimitOrderForm.tsx
@@ -17,6 +17,7 @@ import { NetworkSelector } from 'components/NetworkSelector'
 import NumericalInput from 'components/NumericalInput'
 import { RowBetween } from 'components/Row'
 import { DefaultSlippageOption } from 'components/SlippageControl'
+import { getTipLinkAttribution } from 'components/TipLinkGeneratorModal/shared'
 import Tooltip, { MouseoverTooltip, TextDashed } from 'components/Tooltip'
 import ActionButtonLimitOrder from 'components/swapv2/LimitOrder/ActionButtonLimitOrder'
 import DeltaRate, { useGetDeltaRateLimitOrder } from 'components/swapv2/LimitOrder/DeltaRate'
@@ -772,6 +773,27 @@ const LimitOrderForm = forwardRef<LimitOrderFormHandle, Props>(function LimitOrd
         order_id,
         volume: estimateUSD.rawInput || undefined,
       })
+
+      // Tip is not charged on limit orders, so this attributes referral volume only
+      // (tracked at placement — `Limit Order Filled` fires off-page with no tip context).
+      const tipLink = getTipLinkAttribution(searchParams)
+      if (tipLink) {
+        trackingHandler(TRACKING_EVENT_TYPE.TIP_LINK_TRADE, {
+          trade_type: 'limit_order',
+          trade_status: 'placed',
+          tip_charged: false,
+          ...tipLink,
+          input_token: currencyIn?.symbol,
+          output_token: currencyOut?.symbol,
+          input_token_address: getTokenAddress(currencyIn),
+          output_token_address: getTokenAddress(currencyOut),
+          pair: currencyIn && currencyOut ? `${currencyIn.symbol}/${currencyOut.symbol}` : undefined,
+          chain: networkInfo.name,
+          chain_id: chainId,
+          volume: estimateUSD.rawInput || undefined,
+          order_id,
+        })
+      }
     }
   }
 

--- a/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
+++ b/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
+import { getTipLinkAttribution } from 'components/TipLinkGeneratorModal/shared'
 import { ETHER_ADDRESS } from 'constants/index'
 import { useActiveWeb3React, useWeb3React } from 'hooks'
 import useENS from 'hooks/useENS'
@@ -24,6 +26,7 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
   const { parsedAmountIn: inputAmount, parsedAmountOut: outputAmount, priceImpact } = routeSummary || {}
 
   const [allowedSlippage] = useUserSlippageTolerance()
+  const [searchParams] = useSearchParams()
 
   const addTransactionWithType = useTransactionAdder()
 
@@ -87,6 +90,9 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
           tradeRouteDexes: [...new Set(routeSummary?.route?.flat().map(r => r.exchange) || [])],
           chain: networkInfo.name,
           volume: routeSummary?.amountInUsd ? Number(routeSummary.amountInUsd) : undefined,
+          // Persisted so the deferred `Swap Completed` updater can attribute the trade
+          // back to a community tip link (null for non-tip-link swaps).
+          tipLink: getTipLinkAttribution(searchParams) || undefined,
         },
       } as TransactionExtraInfo2Token,
     }
@@ -102,6 +108,7 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
     recipient,
     recipientAddressOrName,
     routeSummary,
+    searchParams,
   ])
 
   const handleSwapResponse = useCallback(

--- a/apps/kyberswap-interface/src/hooks/useTracking.ts
+++ b/apps/kyberswap-interface/src/hooks/useTracking.ts
@@ -332,6 +332,10 @@ export enum TRACKING_EVENT_TYPE {
   MENU_LINK_CLICKED,
   NOTIFICATION_CENTER_OPENED,
   LANGUAGE_CHANGED,
+
+  // Tip Link Generator
+  TIP_LINK_GENERATE_LINK_CLICK,
+  TIP_LINK_TRADE,
 }
 
 export const NEED_CHECK_SUBGRAPH_TRANSACTION_TYPES: readonly TRANSACTION_TYPE[] = [
@@ -412,6 +416,16 @@ export default function useTracking(currencies?: { [field in Field]?: Currency }
         }
         case TRACKING_EVENT_TYPE.WALLET_CONNECT_WALLET_CLICK: {
           formoTrack('Wallet Connect - Wallet click', payload)
+          break
+        }
+        case TRACKING_EVENT_TYPE.TIP_LINK_GENERATE_LINK_CLICK: {
+          formoTrack('Tip Link - Generate Link Click', payload)
+          break
+        }
+        // Tip-link attributed trade (swap / limit order / cross-chain). The trade type is
+        // carried in `payload.trade_type` so all three flows roll up into one event.
+        case TRACKING_EVENT_TYPE.TIP_LINK_TRADE: {
+          formoTrack('Tip Link Trade', payload)
           break
         }
       }

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/ConfirmationPopup.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/ConfirmationPopup.tsx
@@ -13,6 +13,7 @@ import { formatUnits } from 'viem'
 import { ButtonEmpty, ButtonPrimary } from 'components/Button'
 import CopyHelper from 'components/Copy'
 import CurrencyLogo from 'components/CurrencyLogo'
+import { getTipLinkAttribution } from 'components/TipLinkGeneratorModal/shared'
 import TransactionConfirmationModal, { TransactionErrorContent } from 'components/TransactionConfirmationModal'
 import { useBitcoinWallet } from 'components/Web3Provider/BitcoinProvider'
 import { ETHER_ADDRESS } from 'constants/index'
@@ -293,6 +294,26 @@ export const ConfirmationPopup = ({ isOpen, onDismiss }: { isOpen: boolean; onDi
       }
       crossChainMixpanelHandler(CROSS_CHAIN_MIXPANEL_TYPE.CROSS_CHAIN_SWAP_INIT, swapDetails)
       trackingHandler(TRACKING_EVENT_TYPE.CC_SWAP_INITIATED, swapDetails)
+
+      // Tip is not charged on cross-chain swaps — attribute referral volume at initiation
+      // (completion fires from an off-page poller that has lost the tip-link URL context).
+      const tipLink = getTipLinkAttribution(searchParams)
+      if (tipLink) {
+        trackingHandler(TRACKING_EVENT_TYPE.TIP_LINK_TRADE, {
+          trade_type: 'cross_chain',
+          trade_status: 'initiated',
+          tip_charged: false,
+          ...tipLink,
+          input_token: currencyIn?.symbol,
+          output_token: currencyOut?.symbol,
+          pair: currencyIn?.symbol && currencyOut?.symbol ? `${currencyIn.symbol}/${currencyOut.symbol}` : undefined,
+          chain: getChainName(fromChainId),
+          from_chain: getChainName(fromChainId),
+          to_chain: getChainName(toChainId),
+          volume: selectedQuote.quote.inputUsd,
+          tx_hash: res.sourceTxHash,
+        })
+      }
     }
     setTxHash(res?.sourceTxHash || '')
     setSubmittingTx(false)

--- a/apps/kyberswap-interface/src/state/transactions/updater.tsx
+++ b/apps/kyberswap-interface/src/state/transactions/updater.tsx
@@ -247,6 +247,25 @@ export default function Updater(): null {
               tx_hash: receipt.transactionHash,
               feeInfo: arbitrary.feeInfo,
             })
+            if (arbitrary.tipLink) {
+              trackingHandler(TRACKING_EVENT_TYPE.TIP_LINK_TRADE, {
+                trade_type: 'swap',
+                trade_status: 'completed',
+                tip_charged: true,
+                ...arbitrary.tipLink,
+                input_token: arbitrary.inputSymbol,
+                output_token: arbitrary.outputSymbol,
+                input_token_address: arbitrary.inputAddress,
+                output_token_address: arbitrary.outputAddress,
+                pair:
+                  arbitrary.inputSymbol && arbitrary.outputSymbol
+                    ? `${arbitrary.inputSymbol}/${arbitrary.outputSymbol}`
+                    : undefined,
+                chain: arbitrary.chain,
+                volume: arbitrary.volume,
+                tx_hash: receipt.transactionHash,
+              })
+            }
             break
           }
           case TRANSACTION_TYPE.APPROVE: {


### PR DESCRIPTION
## Summary

Adds Formo analytics for the community **Tip Link** feature so we can measure both generator usage and the trades a tip link drives. Two custom events:

### 1. `Tip Link - Generate Link Click`
Fires when a user clicks **Generate Link** in the Tip Link Generator modal. Payload: `receiver_wallet`, token pair (`input_token`/`output_token` + addresses, `pair`), and chain (`chain_id`, `chain`).

### 2. `Tip Link Trade`
One **normalized** event that attributes a trade back to a community tip link, so all trade types roll up into a single event you can slice by `trade_type`.

| Field | Notes |
|---|---|
| `trade_type` | `swap` \| `limit_order` \| `cross_chain` |
| `trade_status` | `completed` (swap) / `placed` (LO) / `initiated` (CC) |
| `tip_charged` | `true` for swap, `false` for LO/CC |
| `tip_receiver`, `tip_client_id`, `tip_creator_name` | attribution, from the tip-link URL |
| `input_token`/`output_token` (+ `_address`), `pair` | token pair |
| `chain` (+ `from_chain`/`to_chain` for CC), `chain_id` | chain |
| `volume` (USD) | route `amountInUsd` / LO `estimateUSD` / CC quote `inputUsd` |
| `tx_hash` / `order_id` | per trade type |

## How attribution works

`getTipLinkAttribution(searchParams)` (in `TipLinkGeneratorModal/shared.tsx`) is the single discriminator: `clientId === 'community'` + a valid `feeReceiver`. It returns `null` for any non-tip-link trade (regular swap, or partner swap with another `clientId`), so callers just skip tracking.

The event is fired per trade type at the point the tip-link context is actually available:

- **Swap** — attribution is persisted into the tx `arbitrary` at submit (`useSwapCallbackV3`), then the event fires on **confirmed completion** from the global transactions updater. ✅ real completion + actual tip earned.
- **Limit order** — fired at **placement**, next to `Limit Order Placed` (the form has the live URL).
- **Cross-chain** — fired at **initiation**, next to `CC Swap Initiated` (completion fires from an off-page poller with no tip-link URL context).

## Notes for analytics

- **Tip is only charged on swaps.** `enableTip`/`feeReceiver` is read solely by the aggregator swap flow — LO/cross-chain never charge it. So LO/CC rows are **referral volume only**, not earnings. Use `tip_charged` / `trade_type` to keep them separate; sum earnings only where `tip_charged = true`.
- **LO/CC are not "completed" trades.** LO is counted at placement (a placed order may never fill; `Limit Order Filled` fires off-page with no USD/tip context) and CC at initiation. True filled/completed attribution there would need server-side persistence — out of scope here, surfaced via `trade_status`.
