### PR TITLE
fix(earns): open add liquidity selector in add mode

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityTokenInput.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityTokenInput.tsx
@@ -84,7 +84,6 @@ const AddLiquidityTokenInput = ({
 }: AddLiquidityTokenInputProps) => {
   const theme = useTheme()
   const [openTokenSelectModal, setOpenTokenSelectModal] = useState(false)
-  const [tokenAddressSelected, setTokenAddressSelected] = useState<string>()
 
   const { chainId, poolType, poolAddress, pool } = context
   const { token0, token1 } = pool
@@ -102,11 +101,9 @@ const AddLiquidityTokenInput = ({
 
   const onCloseTokenSelectModal = useCallback(() => {
     setOpenTokenSelectModal(false)
-    setTokenAddressSelected(undefined)
   }, [])
 
-  const openTokenSelectModalForToken = useCallback((address?: string) => {
-    setTokenAddressSelected(address)
+  const openTokenSelectModalForToken = useCallback(() => {
     setOpenTokenSelectModal(true)
   }, [])
 
@@ -241,8 +238,7 @@ const AddLiquidityTokenInput = ({
               amountsIn: currentAmounts,
               setTokensIn: handleWrappedSetTokensIn,
               setAmountsIn: nextAmounts => onAmountsChange?.(nextAmounts),
-              mode: tokenAddressSelected ? TOKEN_SELECT_MODE.SELECT : TOKEN_SELECT_MODE.ADD,
-              selectedTokenAddress: tokenAddressSelected,
+              mode: TOKEN_SELECT_MODE.ADD,
               token0Address: token0.address,
               token1Address: token1.address,
             }}


### PR DESCRIPTION
## Summary
- Open the add-liquidity token selector in add mode from token panels and add-token actions
- Remove selected-token replacement state from the add-liquidity token input