### PR TITLE
fix(zap-out): stop -32003 StackUnderflow spam on RPC and handle malformed errors

### DIFF
--- a/packages/hooks/src/use-nft-approval-all.ts
+++ b/packages/hooks/src/use-nft-approval-all.ts
@@ -100,7 +100,11 @@ export function useNftApprovalAll({
   }, [chainId, currentApprovePendingTx, rpcUrl, txStatus]);
 
   const checkApprovalAll = useCallback(async () => {
-    if (!spender || !userAddress || approvePendingTx) return;
+    // Bail when the NFT manager address is missing (e.g. non-NFT pools or a dex
+    // with no manager configured on this chain). Otherwise the eth_call goes out
+    // with an empty `to`, the node runs the calldata as contract-creation init
+    // code and underflows the stack (-32003 StackUnderflow).
+    if (!spender || !userAddress || !nftManagerContract || approvePendingTx) return;
     setIsChecking(true);
 
     const methodSignature = getFunctionSelector('isApprovedForAll(address,address)');

--- a/packages/hooks/src/use-nft-approval.ts
+++ b/packages/hooks/src/use-nft-approval.ts
@@ -110,7 +110,11 @@ export function useNftApproval({
   }, [chainId, currentApprovePendingTx, rpcUrl, txStatus]);
 
   const checkApproval = useCallback(async () => {
-    if (!spender || !userAddress || !tokenId || approvePendingTx) return;
+    // Bail when the NFT manager address is missing (e.g. non-NFT pools or a dex
+    // with no manager configured on this chain). Otherwise the eth_call goes out
+    // with an empty `to`, the node runs the calldata as contract-creation init
+    // code and underflows the stack (-32003 StackUnderflow).
+    if (!spender || !userAddress || !tokenId || !nftManagerContract || approvePendingTx) return;
     setIsChecking(true);
 
     const methodSignature = getFunctionSelector('getApproved(uint256)');

--- a/packages/rpc-client/src/client.ts
+++ b/packages/rpc-client/src/client.ts
@@ -32,6 +32,28 @@ export function buildRpcErrorMessage(endpoint: string, method: string, detail: s
 }
 
 /**
+ * Coerce a JSON-RPC `error` field into a consistent `{ code, message, data }`.
+ *
+ * Spec-compliant providers return an object `{ code, message }`, but some public
+ * endpoints (e.g. zan.top for unregistered accounts) return `error` as a bare
+ * string. Those are coerced to a retryable internal-error code so rotation moves
+ * on to the next endpoint, and the original text is kept as the message instead
+ * of surfacing "undefined: undefined".
+ */
+function normalizeRpcError(error: unknown): { code: number; message: string; data?: unknown } {
+  if (typeof error === 'string') {
+    return { code: -32603, message: error };
+  }
+  if (error && typeof error === 'object') {
+    const e = error as { code?: unknown; message?: unknown; data?: unknown };
+    const code = typeof e.code === 'number' ? e.code : -32603;
+    const message = typeof e.message === 'string' ? e.message : JSON.stringify(error);
+    return { code, message, data: e.data };
+  }
+  return { code: -32603, message: String(error) };
+}
+
+/**
  * RPC Client with automatic endpoint rotation, health probing, and fallback.
  *
  * Features:
@@ -537,11 +559,8 @@ export class RpcClient {
       const data = (await response.json()) as JsonRpcResponse<T>;
 
       if (data.error) {
-        throw new RpcError(
-          data.error.code,
-          buildRpcErrorMessage(endpoint, method, `JSON-RPC error ${data.error.code}: ${data.error.message}`),
-          data.error.data,
-        );
+        const { code, message, data: errData } = normalizeRpcError(data.error);
+        throw new RpcError(code, buildRpcErrorMessage(endpoint, method, `JSON-RPC error ${code}: ${message}`), errData);
       }
 
       if (data.result === undefined) {
@@ -630,10 +649,11 @@ export class RpcClient {
           const rawId = Number(item.id);
           const idx = Number.isFinite(rawId) ? rawId - 1 : -1;
           const failedMethod = calls[idx]?.method ?? 'batch';
+          const { code, message, data: errData } = normalizeRpcError(item.error);
           throw new RpcError(
-            item.error.code,
-            buildRpcErrorMessage(endpoint, failedMethod, `JSON-RPC error ${item.error.code}: ${item.error.message}`),
-            item.error.data,
+            code,
+            buildRpcErrorMessage(endpoint, failedMethod, `JSON-RPC error ${code}: ${message}`),
+            errData,
           );
         }
         results.push(item.result);

--- a/packages/zap-out-widgets/src/stores/index.tsx
+++ b/packages/zap-out-widgets/src/stores/index.tsx
@@ -68,40 +68,46 @@ const createZapOutStore = (initProps: InnerZapOutProps) => {
       const { success: isUniV3, data: univ3PoolInfo } = univ3PoolNormalize.safeParse(pool);
       const { success: isUniV2, data: univ2PoolInfo } = univ2PoolNormalize.safeParse(pool);
 
-      if (isUniV3) {
-        const positionInfo = await getUniv3PositionInfo({
-          poolType,
-          positionId,
-          chainId,
-          tickCurrent: univ3PoolInfo.tick,
-          sqrtPriceX96: univ3PoolInfo.sqrtPriceX96,
-        });
+      try {
+        if (isUniV3) {
+          const positionInfo = await getUniv3PositionInfo({
+            poolType,
+            positionId,
+            chainId,
+            tickCurrent: univ3PoolInfo.tick,
+            sqrtPriceX96: univ3PoolInfo.sqrtPriceX96,
+          });
 
-        if (positionInfo.error) set({ errorMsg: positionInfo.error, position: null });
-        else {
-          set({ position: positionInfo.position as Position });
+          if (positionInfo.error) set({ errorMsg: positionInfo.error, position: null });
+          else {
+            set({ position: positionInfo.position as Position });
+          }
+
+          return;
         }
 
-        return;
+        if (isUniV2) {
+          const positionInfo = await getUniv2PositionInfo({
+            poolType,
+            positionId,
+            chainId,
+            poolAddress: univ2PoolInfo.address,
+            reserve0: univ2PoolInfo.reserves[0],
+            reserve1: univ2PoolInfo.reserves[1],
+          });
+
+          if (positionInfo.error) set({ errorMsg: positionInfo.error, position: null });
+          else set({ position: positionInfo.position as Position });
+
+          return;
+        }
+
+        set({ errorMsg: 'Invalid pool type' });
+      } catch (error) {
+        // Swallow RPC failures (e.g. a flaky public endpoint) so they don't surface
+        // as unhandled promise rejections; the 15s poll in the provider retries.
+        console.error('Failed to fetch position info:', error);
       }
-
-      if (isUniV2) {
-        const positionInfo = await getUniv2PositionInfo({
-          poolType,
-          positionId,
-          chainId,
-          poolAddress: univ2PoolInfo.address,
-          reserve0: univ2PoolInfo.reserves[0],
-          reserve1: univ2PoolInfo.reserves[1],
-        });
-
-        if (positionInfo.error) set({ errorMsg: positionInfo.error, position: null });
-        else set({ position: positionInfo.position as Position });
-
-        return;
-      }
-
-      set({ errorMsg: 'Invalid pool type' });
     },
     toggleRevertPrice: () => {
       set(state => ({ revertPrice: !state.revertPrice }));


### PR DESCRIPTION
The NFT approval checks fired an eth_call even when nftManagerContract was undefined (non-NFT pools, or a dex with no manager on the chain), sending the request with an empty `to`. Nodes then executed the calldata as contract- creation init code and underflowed the stack (-32003 StackUnderflow) across every public RPC. Guard checkApproval/checkApprovalAll on nftManagerContract.

Also normalize non-spec RPC error bodies (e.g. zan.top returns `error` as a bare string for unregistered accounts) so they surface real text instead of "undefined: undefined" and rotate to the next endpoint, and wrap the zap-out getPosition call in try/catch so a flaky endpoint no longer becomes an unhandled promise rejection.