### PR TITLE
chore(earns): remove pool liquidity metric

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 
 import { ReactComponent as BagIcon } from 'assets/svg/earn/ic_bag.svg'
 import { HStack, Stack } from 'components/Stack'
-import { formatUsd, getPoolLiquidityUsd } from 'pages/Earns/PoolDetail/Information/utils'
+import { formatUsd } from 'pages/Earns/PoolDetail/Information/utils'
 import AprHistoryChart from 'pages/Earns/PoolDetail/components/AprHistoryChart'
 import TopMetricsStrip, { type TopMetricItem } from 'pages/Earns/PoolDetail/components/TopMetricsStrip'
 import { getParsedRewardAmount } from 'pages/Earns/PoolDetail/components/utils'
@@ -15,11 +15,6 @@ const DAY_SECONDS = 24 * 60 * 60
 
 const InformationTab = () => {
   const { chainId, pool, poolAddress } = usePoolDetailContext()
-
-  const tokenPrices = useTokenPrices(
-    pool.tokens.map(token => token.address),
-    chainId,
-  )
 
   const poolStats = pool.poolStats
   const bonusApr = poolStats?.bonusApr ?? 0
@@ -57,12 +52,9 @@ const InformationTab = () => {
   const merklRewards = pool.merklOpportunity?.dailyRewards ?? 0
   const rewards24hUsd = egRewards + lmRewards + merklRewards
 
-  const liquidityUsdValue = getPoolLiquidityUsd(pool, tokenPrices)
-
   const tvlValue = formatUsd(poolStats?.tvl)
   const volumeValue = formatUsd(poolStats?.volume24h)
   const feesValue = formatUsd(poolStats?.fees24h)
-  const liquidityValue = formatUsd(liquidityUsdValue)
 
   const rewardsValue = (
     <HStack className="items-center gap-1">
@@ -76,7 +68,6 @@ const InformationTab = () => {
     { label: '24h Volume', value: volumeValue },
     { label: '24h Fees', value: feesValue },
     ...(rewards24hUsd > 0 ? [{ label: '24h Rewards', value: rewardsValue }] : []),
-    { label: 'Liquidity', value: liquidityValue },
   ]
 
   return (

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/utils.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/utils.ts
@@ -1,7 +1,6 @@
-import { formatAprNumber, formatUnits } from '@kyber/utils/number'
-import { MAX_TICK, MIN_TICK, getPositionAmounts, nearestUsableTick } from '@kyber/utils/uniswapv3'
+import { formatAprNumber } from '@kyber/utils/number'
 import dayjs from 'dayjs'
-import { type PoolAnalyticsWindow, type PoolDetail } from 'services/zapEarn'
+import { type PoolAnalyticsWindow } from 'services/zapEarn'
 
 import { type SegmentedControlOption } from 'components/SegmentedControl'
 import { formatDisplayNumber } from 'utils/numbers'
@@ -14,45 +13,6 @@ export const CHART_WINDOW_OPTIONS: readonly SegmentedControlOption<PoolAnalytics
 
 const hasValue = (value?: number | null): value is number =>
   value !== undefined && value !== null && !Number.isNaN(value)
-
-const getCurrentTickRange = (tick: number, tickSpacing: number) => {
-  const minTick = nearestUsableTick(MIN_TICK, tickSpacing)
-  const maxTick = nearestUsableTick(MAX_TICK, tickSpacing)
-  const tickLower = Math.min(Math.max(Math.floor(tick / tickSpacing) * tickSpacing, minTick), maxTick - tickSpacing)
-
-  return {
-    tickLower,
-    tickUpper: tickLower + tickSpacing,
-  }
-}
-
-export const getPoolLiquidityUsd = (pool: PoolDetail, tokenPrices: Record<string, number>) => {
-  const token0 = pool.tokens[0]
-  const token1 = pool.tokens[1]
-  const positionInfo = pool.positionInfo
-
-  if (!positionInfo?.liquidity || !positionInfo?.sqrtPriceX96 || !positionInfo?.tickSpacing) {
-    return undefined
-  }
-
-  const { tickLower, tickUpper } = getCurrentTickRange(positionInfo.tick, positionInfo.tickSpacing)
-  const { amount0, amount1 } = getPositionAmounts(
-    positionInfo.tick,
-    tickLower,
-    tickUpper,
-    BigInt(positionInfo.sqrtPriceX96),
-    BigInt(positionInfo.liquidity),
-  )
-
-  const token0Amount = parseFloat(formatUnits(amount0.toString(), token0.decimals))
-  const token1Amount = parseFloat(formatUnits(amount1.toString(), token1.decimals))
-  const token0Price = tokenPrices[token0.address] || 0
-  const token1Price = tokenPrices[token1.address] || 0
-
-  const liquidityUsd = token0Amount * token0Price + token1Amount * token1Price
-
-  return hasValue(liquidityUsd) && liquidityUsd > 0 ? liquidityUsd : undefined
-}
 
 export const formatUsd = (value?: number, options?: { allowDisplayNegative?: boolean }) => {
   if (!hasValue(value)) return '--'

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/utils.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/utils.ts
@@ -29,7 +29,14 @@ export const formatPrice = (value?: number) => {
   if (!hasValue(value)) return '--'
   return formatDisplayNumber(value, {
     style: 'currency',
-    significantDigits: value !== 0 && Math.abs(value) < 1 ? 6 : 4,
+    significantDigits: value !== 0 && Math.abs(value) < 1 ? 8 : 6,
+  })
+}
+
+export const formatRate = (value?: number) => {
+  if (!hasValue(value)) return '--'
+  return formatDisplayNumber(value, {
+    significantDigits: value !== 0 && Math.abs(value) < 1 ? 8 : 6,
   })
 }
 

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolPriceChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolPriceChart.tsx
@@ -20,7 +20,7 @@ import useTheme from 'hooks/useTheme'
 import {
   CHART_WINDOW_OPTIONS,
   formatAxisTimeLabel,
-  formatPrice,
+  formatRate,
   formatSignedPercent,
 } from 'pages/Earns/PoolDetail/Information/utils'
 import PoolChartState, { PoolChartWrapper } from 'pages/Earns/PoolDetail/components/PoolChartState'
@@ -221,24 +221,16 @@ const PriceChartTooltip = ({ tooltip, window }: { tooltip: TooltipState; window:
 
       <div className="grid grid-cols-[auto_auto] gap-x-4 gap-y-2">
         <span className="text-xs text-subText">Open</span>
-        <span className="text-right text-xs font-medium text-text">
-          {formatDisplayNumber(candle.open, { fractionDigits: 4 })}
-        </span>
+        <span className="text-right text-xs font-medium text-text">{formatRate(candle.open)}</span>
 
         <span className="text-xs text-subText">High</span>
-        <span className="text-right text-xs font-medium text-text">
-          {formatDisplayNumber(candle.high, { fractionDigits: 4 })}
-        </span>
+        <span className="text-right text-xs font-medium text-text">{formatRate(candle.high)}</span>
 
         <span className="text-xs text-subText">Low</span>
-        <span className="text-right text-xs font-medium text-text">
-          {formatDisplayNumber(candle.low, { fractionDigits: 4 })}
-        </span>
+        <span className="text-right text-xs font-medium text-text">{formatRate(candle.low)}</span>
 
         <span className="text-xs text-subText">Close</span>
-        <span className="text-right text-xs font-medium text-text">
-          {formatDisplayNumber(candle.close, { fractionDigits: 4 })}
-        </span>
+        <span className="text-right text-xs font-medium text-text">{formatRate(candle.close)}</span>
 
         <span className="text-xs text-subText">%Change</span>
         <span className={cn('text-right text-xs font-medium', priceChange >= 0 ? 'text-primary' : 'text-red')}>
@@ -517,7 +509,7 @@ const PoolPriceChart = ({ chainId, poolAddress }: PoolPriceChartProps) => {
           {lastCandle && priceChange !== undefined ? (
             <HStack className="flex-wrap items-baseline gap-2.5">
               <>
-                <span className="text-2xl font-medium text-text">{formatPrice(lastCandle.close)}</span>
+                <span className="text-2xl font-medium text-text">{formatRate(lastCandle.close)}</span>
 
                 <HStack className="items-center gap-1.5">
                   <span className="text-base font-medium" style={{ color: priceChangeColor }}>


### PR DESCRIPTION
## Summary
- Remove the Liquidity card from pool detail top metrics
- Delete current-tick liquidity USD calculation and unused token price lookup

## Test
- pnpm type-check