### PR TITLE
fix(swap): stop trade summary refresh loop

### DIFF
--- a/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 import WarningIcon from 'components/Icons/WarningIcon'
@@ -191,10 +191,17 @@ const TradeSummary: React.FC<Props> = ({
   routeLoading,
   isFeeTampered,
 }) => {
+  const [alreadyVisible, setAlreadyVisible] = useState(false)
   const { parsedAmountOut, priceImpact } = routeSummary || {}
-  const hasRoute = !!routeSummary?.route
-  const hasTrade = routeLoading || hasRoute
-  const hidden = !hasTrade
+  const hasTrade = !!routeSummary?.route
+
+  useEffect(() => {
+    if (hasTrade) {
+      setAlreadyVisible(true)
+    }
+  }, [hasTrade])
+
+  const hidden = !alreadyVisible
   const priceImpactResult = checkPriceImpact(priceImpact)
 
   const minimumAmountOut = parsedAmountOut ? minimumAmountAfterSlippage(parsedAmountOut, slippage) : undefined
@@ -225,7 +232,7 @@ const TradeSummary: React.FC<Props> = ({
             <RefreshLoading
               refetchLoading={routeLoading}
               onRefresh={refreshCallback}
-              disableRefresh={disableRefresh || !hasTrade}
+              disableRefresh={disableRefresh}
               clickable
             />
             <TradePrice price={routeSummary?.executionPrice} className="text-text" />

--- a/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/TradeSummary.tsx
@@ -4,7 +4,6 @@ import { useSearchParams } from 'react-router-dom'
 
 import WarningIcon from 'components/Icons/WarningIcon'
 import RefreshLoading from 'components/RefreshLoading'
-import Skeleton from 'components/Skeleton'
 import { HStack, Stack } from 'components/Stack'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import useGetFeeConfig from 'components/SwapForm/hooks/useGetFeeConfig'
@@ -92,23 +91,6 @@ export const SwapFeeLabel = () => {
 
   return <Trans>Est. Swap Fee</Trans>
 }
-
-const TradeSummarySkeleton = () => (
-  <Stack className="gap-3">
-    <HStack className="min-h-[19px] w-full items-center justify-between">
-      <Skeleton height={16} width="60px" />
-      <Skeleton height={16} width="160px" />
-    </HStack>
-    <HStack className="min-h-[19px] w-full items-center justify-between">
-      <Skeleton height={16} width="120px" />
-      <Skeleton height={16} width="120px" />
-    </HStack>
-    <HStack className="min-h-[19px] w-full items-center justify-between">
-      <Skeleton height={16} width="80px" />
-      <Skeleton height={16} width="60px" />
-    </HStack>
-  </Stack>
-)
 
 const SwapFee: React.FC<{ isFeeTampered?: boolean }> = ({ isFeeTampered }) => {
   const theme = useTheme()
@@ -211,9 +193,8 @@ const TradeSummary: React.FC<Props> = ({
 }) => {
   const { parsedAmountOut, priceImpact } = routeSummary || {}
   const hasRoute = !!routeSummary?.route
-  const showSkeleton = routeLoading && !hasRoute
-  const hidden = !routeLoading && !hasRoute
-
+  const hasTrade = routeLoading || hasRoute
+  const hidden = !hasTrade
   const priceImpactResult = checkPriceImpact(priceImpact)
 
   const minimumAmountOut = parsedAmountOut ? minimumAmountAfterSlippage(parsedAmountOut, slippage) : undefined
@@ -230,122 +211,118 @@ const TradeSummary: React.FC<Props> = ({
   return (
     <div
       className={cn(
-        'w-full max-w-[425px] overflow-hidden rounded-2xl border border-solid border-border/60 p-3 text-text',
+        'w-full max-w-[425px] overflow-hidden rounded-2xl border border-border/60 p-3 text-text',
         hidden && 'hidden',
       )}
     >
-      {showSkeleton ? (
-        <TradeSummarySkeleton />
-      ) : (
-        <Stack className="gap-3">
-          <HStack className="min-h-[19px] w-full items-center justify-between">
-            <span className="text-xs font-normal text-subText">
-              <Trans>Rate</Trans>
-            </span>
+      <Stack className="gap-3">
+        <HStack className="min-h-[19px] w-full items-center justify-between">
+          <span className="text-xs font-normal text-subText">
+            <Trans>Rate</Trans>
+          </span>
 
-            <div className="-my-1 flex items-center gap-1">
-              <RefreshLoading
-                refetchLoading={routeLoading}
-                onRefresh={refreshCallback}
-                disableRefresh={disableRefresh}
-                clickable
-              />
-              <TradePrice price={routeSummary?.executionPrice} className="text-text" />
-            </div>
-          </HStack>
-          <HStack className="w-full items-center justify-between">
-            <HStack className="w-fit items-center">
-              <TextHelper
-                fontSize={12}
-                fontWeight={400}
-                className="text-subText"
-                tooltipWidth="280px"
-                tooltip={
-                  <>
-                    <div>
-                      <Trans>You will receive at least this amount, or your transaction will revert.</Trans>
-                    </div>
-                    <div>
-                      <Trans>
-                        Any{' '}
-                        <a
-                          href="https://docs.kyberswap.com/kyberswap-solutions/kyberswap-aggregator/aggregator-api-specification/evm-swaps#kyberswap-positive-slippage-surplus-collection"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          positive slippage
-                        </a>{' '}
-                        will accrue to KyberSwap.
-                      </Trans>
-                    </div>
-                  </>
-                }
-                placement="right"
-              >
-                <Trans>Minimum Received</Trans>
-              </TextHelper>
-            </HStack>
-            <HStack className="w-fit items-center">
-              <p className="m-0 text-[12px] font-medium text-text">{minimumAmountOutStr || '--'}</p>
-            </HStack>
-          </HStack>
-
-          <HStack className="w-full items-center justify-between">
-            <HStack className="w-fit items-center">
-              <TextHelper
-                fontSize={12}
-                fontWeight={400}
-                className="text-subText"
-                tooltip={
+          <div className="-my-1 flex items-center gap-1">
+            <RefreshLoading
+              refetchLoading={routeLoading}
+              onRefresh={refreshCallback}
+              disableRefresh={disableRefresh || !hasTrade}
+              clickable
+            />
+            <TradePrice price={routeSummary?.executionPrice} className="text-text" />
+          </div>
+        </HStack>
+        <HStack className="w-full items-center justify-between">
+          <HStack className="w-fit items-center">
+            <TextHelper
+              fontSize={12}
+              fontWeight={400}
+              className="text-subText"
+              tooltipWidth="280px"
+              tooltip={
+                <>
                   <div>
-                    <Trans>Estimated change in price due to the size of your transaction.</Trans>
-                    <div className="text-xs">
-                      <Trans>
-                        Read more{' '}
-                        <a
-                          href="https://docs.kyberswap.com/getting-started/foundational-topics/decentralized-finance/price-impact"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          <b>here ↗</b>
-                        </a>
-                      </Trans>
-                    </div>
+                    <Trans>You will receive at least this amount, or your transaction will revert.</Trans>
                   </div>
-                }
-                placement="right"
-              >
-                <Trans>Price Impact</Trans>
-              </TextHelper>
-            </HStack>
-            <p
-              className={cn(
-                'm-0 text-[12px] font-medium',
-                priceImpactResult.isVeryHigh ? 'text-red' : priceImpactResult.isHigh ? 'text-warning' : 'text-text',
-              )}
+                  <div>
+                    <Trans>
+                      Any{' '}
+                      <a
+                        href="https://docs.kyberswap.com/kyberswap-solutions/kyberswap-aggregator/aggregator-api-specification/evm-swaps#kyberswap-positive-slippage-surplus-collection"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        positive slippage
+                      </a>{' '}
+                      will accrue to KyberSwap.
+                    </Trans>
+                  </div>
+                </>
+              }
+              placement="right"
             >
-              {priceImpactResult.isInvalid || typeof priceImpact !== 'number' ? '--' : formatPriceImpact(priceImpact)}
-            </p>
+              <Trans>Minimum Received</Trans>
+            </TextHelper>
           </HStack>
+          <HStack className="w-fit items-center">
+            <p className="m-0 text-[12px] font-medium text-text">{minimumAmountOutStr || '--'}</p>
+          </HStack>
+        </HStack>
 
-          <SwapFee isFeeTampered={isFeeTampered} />
+        <HStack className="w-full items-center justify-between">
+          <HStack className="w-fit items-center">
+            <TextHelper
+              fontSize={12}
+              fontWeight={400}
+              className="text-subText"
+              tooltip={
+                <div>
+                  <Trans>Estimated change in price due to the size of your transaction.</Trans>
+                  <div className="text-xs">
+                    <Trans>
+                      Read more{' '}
+                      <a
+                        href="https://docs.kyberswap.com/getting-started/foundational-topics/decentralized-finance/price-impact"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <b>here ↗</b>
+                      </a>
+                    </Trans>
+                  </div>
+                </div>
+              }
+              placement="right"
+            >
+              <Trans>Price Impact</Trans>
+            </TextHelper>
+          </HStack>
+          <p
+            className={cn(
+              'm-0 text-[12px] font-medium',
+              priceImpactResult.isVeryHigh ? 'text-red' : priceImpactResult.isHigh ? 'text-warning' : 'text-text',
+            )}
+          >
+            {priceImpactResult.isInvalid || typeof priceImpact !== 'number' ? '--' : formatPriceImpact(priceImpact)}
+          </p>
+        </HStack>
 
-          {isFeeTampered && (
-            <div className="flex gap-2 rounded-xl bg-warning-30 px-3 py-2.5">
-              <WarningIcon className="text-warning" size={16} />
-              <span className="flex-1 text-xs">
-                <Trans>
-                  <b>Third-party fee detected</b>
-                  <br />
-                  An additional fee appears to have been added by a browser extension or other third-party modification,
-                  not by KyberSwap. KyberSwap does not charge a flat fee for this trade by default. Please review your
-                  browser extensions before proceeding.
-                </Trans>
-              </span>
-            </div>
-          )}
-        </Stack>
-      )}
+        <SwapFee isFeeTampered={isFeeTampered} />
+
+        {isFeeTampered && (
+          <div className="flex gap-2 rounded-xl bg-warning-30 px-3 py-2.5">
+            <WarningIcon className="text-warning" size={16} />
+            <span className="flex-1 text-xs">
+              <Trans>
+                <b>Third-party fee detected</b>
+                <br />
+                An additional fee appears to have been added by a browser extension or other third-party modification,
+                not by KyberSwap. KyberSwap does not charge a flat fee for this trade by default. Please review your
+                browser extensions before proceeding.
+              </Trans>
+            </span>
+          </div>
+        )}
+      </Stack>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Remove the trade summary skeleton branch so refresh stays in the normal render flow
- Hide the trade summary when there is no active route/loading state
- Disable trade summary refresh when there is no active trade to avoid repeated route requests