### PR TITLE
feat(earns): navigate to pool detail from zap widget token pair

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useCompounding.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useCompounding.tsx
@@ -18,7 +18,7 @@ import { EARN_DEXES, Exchange } from 'pages/Earns/constants'
 import useAccountChanged from 'pages/Earns/hooks/useAccountChanged'
 import useTransactionReplacement from 'pages/Earns/hooks/useTransactionReplacement'
 import { submitTransaction } from 'pages/Earns/utils'
-import { navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
+import { navigateToPoolDetail, navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
 import { useKyberSwapConfig, useNotify, useWalletModalToggle } from 'state/application/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { TRANSACTION_TYPE } from 'state/transactions/type'
@@ -46,6 +46,7 @@ interface CompoundingParams extends CompoundingPureParams {
   onSwitchChain: () => void
   onSubmitTx: (txData: { from: string; to: string; value: string; data: string; gasLimit: string }) => Promise<string>
   onViewPosition?: (txHash: string) => void
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void
 }
 
 export interface CompoundingInfo {
@@ -165,6 +166,11 @@ const useCompounding = ({
             txStatus,
             txHashMapping: originalToCurrentHash,
             onSwitchChain: () => changeNetwork(compoundingPureParams.chainId as number),
+            onOpenPoolDetail: (pool: { chainId: number; poolAddress: string; dexId?: string }) => {
+              if (!pool.dexId) return
+              handleCloseCompounding()
+              navigateToPoolDetail(pool, navigate)
+            },
             onViewPosition: (txHash: string) => {
               const { chainId, poolType, poolAddress, positionId } = compoundingPureParams
               handleCloseCompounding()
@@ -260,6 +266,7 @@ const useCompounding = ({
       handleCloseCompounding,
       handleNavigateToPosition,
       locale,
+      navigate,
       isSmartConnector,
       onRefreshPosition,
       toggleWalletModal,

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapInWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapInWidget.tsx
@@ -28,7 +28,7 @@ import { DEFAULT_PARSED_POSITION, ParsedPosition } from 'pages/Earns/types'
 import { getNftManagerContractAddress, getTokenId, submitTransaction } from 'pages/Earns/utils'
 import { getDexVersion } from 'pages/Earns/utils/position'
 import { updateUnfinalizedPosition } from 'pages/Earns/utils/unfinalizedPosition'
-import { navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
+import { navigateToPoolDetail, navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
 import { useKyberSwapConfig, useNotify, useWalletModalToggle } from 'state/application/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { TRANSACTION_TYPE } from 'state/transactions/type'
@@ -58,6 +58,7 @@ interface AddLiquidityParams extends AddLiquidityPureParams {
   onConnectWallet: () => void
   onSwitchChain: () => void
   onOpenZapMigration?: (position: { exchange: string; poolId: string; positionId: string | number }) => void
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void
   onSubmitTx: (txData: { from: string; to: string; value: string; data: string; gasLimit: string }) => Promise<string>
 }
 
@@ -237,6 +238,11 @@ const useZapInWidget = ({
             },
             onConnectWallet: toggleWalletModal,
             onSwitchChain: () => changeNetwork(addLiquidityPureParams.chainId as number),
+            onOpenPoolDetail: (pool: { chainId: number; poolAddress: string; dexId?: string }) => {
+              if (!pool.dexId) return
+              handleCloseZapInWidget()
+              navigateToPoolDetail(pool, navigate)
+            },
             onEvent: (eventName: string, data?: Record<string, any>) => {
               const eventMap: Record<string, TRACKING_EVENT_TYPE> = {
                 PRICE_RANGE_PRESET_SELECTED: TRACKING_EVENT_TYPE.LIQ_PRICE_RANGE_PRESET_SELECTED,
@@ -433,6 +439,7 @@ const useZapInWidget = ({
       isSmartConnector,
       isSmartExitSupported,
       locale,
+      navigate,
       onOpenSmartExit,
       onRefreshPosition,
       originalToCurrentHash,

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
@@ -27,7 +27,7 @@ import { DEFAULT_PARSED_POSITION } from 'pages/Earns/types'
 import { getNftManagerContractAddress, getTokenId, submitTransaction } from 'pages/Earns/utils'
 import { getDexVersion } from 'pages/Earns/utils/position'
 import { updateUnfinalizedPosition } from 'pages/Earns/utils/unfinalizedPosition'
-import { navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
+import { navigateToPoolDetail, navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
 import { useKyberSwapConfig, useNotify, useWalletModalToggle } from 'state/application/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { TRANSACTION_TYPE } from 'state/transactions/type'
@@ -68,6 +68,7 @@ interface MigrateLiquidityParams extends MigrateLiquidityPureParams {
   onCloseSuccess?: () => void
   onConnectWallet: () => void
   onSwitchChain: () => void
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void
   onSubmitTx: (txData: { from: string; to: string; value: string; data: string }) => Promise<string>
 }
 
@@ -241,6 +242,13 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
             },
             onConnectWallet: toggleWalletModal,
             onSwitchChain: () => changeNetwork(migrateLiquidityPureParams.chainId as number),
+            onOpenPoolDetail: (pool: { chainId: number; poolAddress: string; dexId?: string }) => {
+              if (!pool.dexId) return
+              setTriggerClose(true)
+              setMigrateLiquidityPureParams(null)
+              clearTracking()
+              navigateToPoolDetail(pool, navigate)
+            },
             onSubmitTx: async (
               txData: { from: string; to: string; value: string; data: string },
               additionalInfo?:

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapOutWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapOutWidget.tsx
@@ -17,6 +17,7 @@ import useAccountChanged from 'pages/Earns/hooks/useAccountChanged'
 import { CheckClosedPositionParams } from 'pages/Earns/hooks/useClosedPositions'
 import useTransactionReplacement from 'pages/Earns/hooks/useTransactionReplacement'
 import { submitTransaction } from 'pages/Earns/utils'
+import { navigateToPoolDetail } from 'pages/Earns/utils/zap'
 import { useKyberSwapConfig, useNotify, useWalletModalToggle } from 'state/application/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { TRANSACTION_TYPE } from 'state/transactions/type'
@@ -163,6 +164,12 @@ const useZapOutWidget = (
             },
             onConnectWallet: toggleWalletModal,
             onSwitchChain: () => changeNetwork(zapOutPureParams.chainId as number),
+            onOpenPoolDetail: (pool: { chainId: number; poolAddress: string; dexId?: string }) => {
+              if (!pool.dexId) return
+              setZapOutPureParams(null)
+              clearTracking()
+              navigateToPoolDetail(pool, navigate)
+            },
             onSubmitTx: async (
               txData: { from: string; to: string; value: string; data: string },
               additionalInfo?:

--- a/apps/kyberswap-interface/src/pages/Earns/utils/zap.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/utils/zap.ts
@@ -63,6 +63,14 @@ export const fetchExistingPoolAddress = async (input: {
     })
 }
 
+export const navigateToPoolDetail = (
+  { chainId, poolAddress, dexId }: { chainId: number; poolAddress: string; dexId?: string },
+  navigateFunc: (url: string) => void,
+) => {
+  if (!dexId) return
+  navigateFunc(`${APP_PATHS.ADD_LIQUIDITY}?exchange=${dexId}&poolChainId=${chainId}&poolAddress=${poolAddress}`)
+}
+
 export const navigateToPositionAfterZap = async (
   txHash: string,
   chainId: number,

--- a/packages/compounding-widget/src/components/Header/index.tsx
+++ b/packages/compounding-widget/src/components/Header/index.tsx
@@ -11,6 +11,7 @@ import {
   univ3Position,
 } from '@kyber/schema';
 import { MouseoverTooltip, Skeleton, TokenLogo } from '@kyber/ui';
+import { cn } from '@kyber/utils/tailwind-helpers';
 
 import IconBack from '@/assets/svg/arrow-left.svg';
 import SettingIcon from '@/assets/svg/setting.svg';
@@ -21,7 +22,7 @@ import { usePositionStore } from '@/stores/usePositionStore';
 import { useWidgetStore } from '@/stores/useWidgetStore';
 
 const Header = () => {
-  const { theme, chainId, onClose, poolType, positionId, dexId } = useWidgetStore(
+  const { theme, chainId, onClose, poolType, positionId, dexId, poolAddress, onOpenPoolDetail } = useWidgetStore(
     useShallow(s => ({
       theme: s.theme,
       chainId: s.chainId,
@@ -29,6 +30,8 @@ const Header = () => {
       poolType: s.poolType,
       positionId: s.positionId,
       dexId: s.dexId,
+      poolAddress: s.poolAddress,
+      onOpenPoolDetail: s.onOpenPoolDetail,
     })),
   );
   const { pool } = usePoolStore(
@@ -87,19 +90,24 @@ const Header = () => {
           </>
         ) : (
           <div className="flex items-center flex-wrap gap-1 text-sm max-sm:gap-y-2">
-            <div className="flex items-end">
-              <TokenLogo src={token0.logo} size={26} className="border-[2px] border-layer1" />
-              <TokenLogo src={token1.logo} size={26} className="border-[2px] border-layer1 -ml-[6px]" />
-              <TokenLogo
-                src={NETWORKS_INFO[chainId].logo}
-                size={14}
-                className="border-[2px] border-layer1 max-sm:w-[18px] max-sm:h-[18px] max-sm:-ml-2 -ml-1"
-              />
-            </div>
+            <div
+              className={cn('flex items-center gap-1', onOpenPoolDetail && 'cursor-pointer')}
+              onClick={onOpenPoolDetail ? () => onOpenPoolDetail({ chainId, poolAddress, dexId }) : undefined}
+            >
+              <div className="flex items-end">
+                <TokenLogo src={token0.logo} size={26} className="border-[2px] border-layer1" />
+                <TokenLogo src={token1.logo} size={26} className="border-[2px] border-layer1 -ml-[6px]" />
+                <TokenLogo
+                  src={NETWORKS_INFO[chainId].logo}
+                  size={14}
+                  className="border-[2px] border-layer1 max-sm:w-[18px] max-sm:h-[18px] max-sm:-ml-2 -ml-1"
+                />
+              </div>
 
-            <span className="text-xl">
-              {token0.symbol}/{token1.symbol}
-            </span>
+              <span className="text-xl">
+                {token0.symbol}/{token1.symbol}
+              </span>
+            </div>
 
             <div className="flex flex-wrap ml-[2px] gap-[6px] text-subText items-center">
               {isUniV3 && (

--- a/packages/compounding-widget/src/stores/useWidgetStore.ts
+++ b/packages/compounding-widget/src/stores/useWidgetStore.ts
@@ -59,6 +59,7 @@ const initState = {
   ) => Promise.resolve(''),
   onOpenZapMigration: undefined,
   onViewPosition: undefined,
+  onOpenPoolDetail: undefined,
   nativeToken: defaultToken,
   wrappedNativeToken: defaultToken,
 };

--- a/packages/compounding-widget/src/types/index.ts
+++ b/packages/compounding-widget/src/types/index.ts
@@ -37,6 +37,7 @@ export interface WidgetProps {
       | ApprovalAdditionalInfo,
   ) => Promise<string>;
   onViewPosition?: (txHash: string) => void;
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void;
 }
 
 export interface ZapState {

--- a/packages/liquidity-widgets/src/components/Header/index.tsx
+++ b/packages/liquidity-widgets/src/components/Header/index.tsx
@@ -6,6 +6,7 @@ import { useCopy } from '@kyber/hooks';
 import { DEXES_INFO, NATIVE_TOKEN_ADDRESS, NETWORKS_INFO, defaultToken, getDexName, univ3Types } from '@kyber/schema';
 import { InfoHelper, LoadingCounter, MouseoverTooltip, Skeleton, TokenLogo, TokenSymbol } from '@kyber/ui';
 import { shortenAddress } from '@kyber/utils/crypto';
+import { cn } from '@kyber/utils/tailwind-helpers';
 
 import IconBack from '@/assets/svg/arrow-left.svg';
 import SettingIcon from '@/assets/svg/setting.svg';
@@ -16,15 +17,9 @@ import { usePositionStore } from '@/stores/usePositionStore';
 import { useWidgetStore } from '@/stores/useWidgetStore';
 
 const Header = () => {
-  const { theme, chainId, onClose, poolType, positionId, fromCreatePoolFlow, dexId } = useWidgetStore([
-    'theme',
-    'chainId',
-    'onClose',
-    'poolType',
-    'positionId',
-    'fromCreatePoolFlow',
-    'dexId',
-  ]);
+  const { theme, chainId, onClose, poolType, positionId, fromCreatePoolFlow, dexId, onOpenPoolDetail } = useWidgetStore(
+    ['theme', 'chainId', 'onClose', 'poolType', 'positionId', 'fromCreatePoolFlow', 'dexId', 'onOpenPoolDetail'],
+  );
   const { pool, poolPrice } = usePoolStore(['pool', 'poolPrice']);
   const { position } = usePositionStore(['position']);
 
@@ -136,20 +131,25 @@ const Header = () => {
           </>
         ) : (
           <div className="flex items-center flex-wrap gap-1 text-sm max-sm:gap-y-2">
-            <div className="flex items-end">
-              <TokenLogo src={token0.logo} size={26} className="border-[2px] border-layer1" />
-              <TokenLogo src={token1.logo} size={26} className="border-[2px] border-layer1 -ml-[6px]" />
-              <TokenLogo
-                src={NETWORKS_INFO[chainId].logo}
-                size={14}
-                className="border-[2px] border-layer1 max-sm:w-[18px] max-sm:h-[18px] max-sm:-ml-2 -ml-1"
-              />
-            </div>
+            <div
+              className={cn('flex items-center gap-1', onOpenPoolDetail && 'cursor-pointer')}
+              onClick={onOpenPoolDetail ? () => onOpenPoolDetail({ chainId, poolAddress, dexId }) : undefined}
+            >
+              <div className="flex items-end">
+                <TokenLogo src={token0.logo} size={26} className="border-[2px] border-layer1" />
+                <TokenLogo src={token1.logo} size={26} className="border-[2px] border-layer1 -ml-[6px]" />
+                <TokenLogo
+                  src={NETWORKS_INFO[chainId].logo}
+                  size={14}
+                  className="border-[2px] border-layer1 max-sm:w-[18px] max-sm:h-[18px] max-sm:-ml-2 -ml-1"
+                />
+              </div>
 
-            <div className="text-xl flex items-center gap-1">
-              <TokenSymbol symbol={token0.symbol} />
-              <span>/</span>
-              <TokenSymbol symbol={token1.symbol} />
+              <div className="text-xl flex items-center gap-1">
+                <TokenSymbol symbol={token0.symbol} />
+                <span>/</span>
+                <TokenSymbol symbol={token1.symbol} />
+              </div>
             </div>
 
             <div className="flex flex-wrap ml-[2px] gap-[6px] text-subText items-center">

--- a/packages/liquidity-widgets/src/stores/useWidgetStore.ts
+++ b/packages/liquidity-widgets/src/stores/useWidgetStore.ts
@@ -52,6 +52,7 @@ const initState = {
   onSuccess: undefined,
   onViewPosition: undefined,
   onSetUpSmartExit: undefined,
+  onOpenPoolDetail: undefined,
   nativeToken: defaultToken,
   wrappedNativeToken: defaultToken,
   error: undefined,

--- a/packages/liquidity-widgets/src/types/index.ts
+++ b/packages/liquidity-widgets/src/types/index.ts
@@ -62,6 +62,7 @@ export interface WidgetProps {
   onViewPosition?: (txHash: string) => void;
   onSetUpSmartExit?: (params: { tokenId: string; chainId: ChainId; poolType: PoolType } | undefined) => void;
   onEvent?: (eventName: string, data?: Record<string, any>) => void;
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void;
 }
 
 export interface OnSuccessProps {

--- a/packages/zap-migration-widgets/src/components/PoolInfo.tsx
+++ b/packages/zap-migration-widgets/src/components/PoolInfo.tsx
@@ -14,6 +14,7 @@ import {
 } from '@kyber/schema';
 import { InfoHelper, Skeleton, TokenLogo, TokenSymbol } from '@kyber/ui';
 import { shortenAddress } from '@kyber/utils/crypto';
+import { cn } from '@kyber/utils/tailwind-helpers';
 import { sqrtToPrice, tickToPrice } from '@kyber/utils/uniswapv3';
 
 import { usePoolStore } from '@/stores/usePoolStore';
@@ -26,11 +27,12 @@ export enum PoolInfoType {
 }
 
 export function PoolInfo({ type }: { type: PoolInfoType }) {
-  const { theme, chainId, sourceDexId, targetDexId } = useWidgetStore([
+  const { theme, chainId, sourceDexId, targetDexId, onOpenPoolDetail } = useWidgetStore([
     'theme',
     'chainId',
     'sourceDexId',
     'targetDexId',
+    'onOpenPoolDetail',
   ]);
   const { sourcePool, targetPool } = usePoolStore(['sourcePool', 'targetPool']);
   const { sourcePosition, targetPosition, sourcePositionId, targetPositionId } = usePositionStore([
@@ -87,19 +89,24 @@ export function PoolInfo({ type }: { type: PoolInfoType }) {
   return (
     <div className="flex flex-col gap-2 rounded-md bg-[#ffffff0a] px-4 py-3 w-full">
       <div className="flex gap-1.5 items-center flex-wrap">
-        <div className="flex items-end">
-          <TokenLogo src={token0.logo} size={24} alt={token0.symbol} className="z-0" />
-          <TokenLogo src={token1.logo} size={24} alt={token1.symbol} className="-ml-2 z-10" />
-          <TokenLogo
-            src={NETWORKS_INFO[chainId].logo}
-            alt={NETWORKS_INFO[chainId].name}
-            size={12}
-            className="-ml-1.5 z-20"
-          />
-        </div>
-        <div className="flex items-center gap-1">
-          <TokenSymbol symbol={token0.symbol} className="text-xl" maxWidth={90} />/
-          <TokenSymbol symbol={token1.symbol} className="text-xl" maxWidth={90} />
+        <div
+          className={cn('flex items-center gap-1.5', onOpenPoolDetail && 'cursor-pointer')}
+          onClick={onOpenPoolDetail ? () => onOpenPoolDetail({ chainId, poolAddress: pool.address, dexId }) : undefined}
+        >
+          <div className="flex items-end">
+            <TokenLogo src={token0.logo} size={24} alt={token0.symbol} className="z-0" />
+            <TokenLogo src={token1.logo} size={24} alt={token1.symbol} className="-ml-2 z-10" />
+            <TokenLogo
+              src={NETWORKS_INFO[chainId].logo}
+              alt={NETWORKS_INFO[chainId].name}
+              size={12}
+              className="-ml-1.5 z-20"
+            />
+          </div>
+          <div className="flex items-center gap-1">
+            <TokenSymbol symbol={token0.symbol} className="text-xl" maxWidth={90} />/
+            <TokenSymbol symbol={token1.symbol} className="text-xl" maxWidth={90} />
+          </div>
         </div>
         <div className="flex items-center justify-center px-1.5 py-1 bg-layer2 rounded-full">
           <InfoHelper

--- a/packages/zap-migration-widgets/src/hooks/useInitWidget.ts
+++ b/packages/zap-migration-widgets/src/hooks/useInitWidget.ts
@@ -27,6 +27,7 @@ export default function useInitWidget(widgetProps: ZapMigrationProps) {
     signTypedData,
     txStatus,
     txHashMapping,
+    onOpenPoolDetail,
   } = widgetProps;
 
   const [hasReseted, setHasReseted] = useState(false);
@@ -94,6 +95,7 @@ export default function useInitWidget(widgetProps: ZapMigrationProps) {
       signTypedData,
       txStatus,
       txHashMapping,
+      onOpenPoolDetail,
     });
   }, [
     themeProps,
@@ -114,6 +116,7 @@ export default function useInitWidget(widgetProps: ZapMigrationProps) {
     signTypedData,
     txStatus,
     txHashMapping,
+    onOpenPoolDetail,
   ]);
 
   useEffect(() => {

--- a/packages/zap-migration-widgets/src/stores/useWidgetStore.ts
+++ b/packages/zap-migration-widgets/src/stores/useWidgetStore.ts
@@ -26,6 +26,7 @@ interface WidgetProps {
   onSubmitTx: (txData: { from: string; to: string; value: string; data: string; gasLimit: string }) => Promise<string>;
   signTypedData?: (account: string, typedDataJson: string) => Promise<string>;
   onSuccess?: (props: OnSuccessProps) => void;
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void;
 }
 
 interface WidgetState extends WidgetProps {
@@ -56,6 +57,7 @@ const initState = {
   onSubmitTx: async () => '',
   signTypedData: undefined,
   onSuccess: undefined,
+  onOpenPoolDetail: undefined,
 };
 
 const useWidgetRawStore = create<WidgetState>((set, _get) => ({
@@ -79,6 +81,7 @@ const useWidgetRawStore = create<WidgetState>((set, _get) => ({
     onSubmitTx,
     signTypedData,
     onSuccess,
+    onOpenPoolDetail,
   }: WidgetProps) => {
     const themeToApply =
       theme && typeof theme === 'object'
@@ -106,6 +109,7 @@ const useWidgetRawStore = create<WidgetState>((set, _get) => ({
       onSubmitTx,
       signTypedData,
       onSuccess,
+      onOpenPoolDetail,
     });
   },
   setWidgetError: (error: string) => set({ widgetError: error }),

--- a/packages/zap-migration-widgets/src/types/index.ts
+++ b/packages/zap-migration-widgets/src/types/index.ts
@@ -94,4 +94,5 @@ export interface ZapMigrationProps {
   onCloseSuccess?: () => void;
   onBack?: () => void;
   onClose: () => void;
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void;
 }

--- a/packages/zap-out-widgets/src/components/Header.tsx
+++ b/packages/zap-out-widgets/src/components/Header.tsx
@@ -16,8 +16,19 @@ import { useZapOutContext } from '@/stores';
 import { useZapOutUserState } from '@/stores/state';
 
 export const Header = () => {
-  const { poolAddress, onClose, poolType, pool, position, positionId, theme, chainId, poolPrice, dexId } =
-    useZapOutContext(s => s);
+  const {
+    poolAddress,
+    onClose,
+    poolType,
+    pool,
+    position,
+    positionId,
+    theme,
+    chainId,
+    poolPrice,
+    dexId,
+    onOpenPoolDetail,
+  } = useZapOutContext(s => s);
   const isUniV3 = univ3Types.includes(poolType as any);
 
   const { degenMode, toggleSetting, mode } = useZapOutUserState();
@@ -85,18 +96,23 @@ export const Header = () => {
           <Skeleton className="w-[300px] h-6 mt-1" />
         ) : (
           <div className="flex items-center gap-1 flex-1 flex-wrap">
-            <div className="relative flex items-end">
-              <TokenLogo src={pool.token0.logo} size={26} className="border-[2px] border-layer1" />
-              <TokenLogo src={pool.token1.logo} size={26} className="border-[2px] border-layer1 -ml-[6px]" />
-              <TokenLogo
-                src={NETWORKS_INFO[chainId].logo}
-                size={14}
-                className="border-[2px] border-layer1 max-sm:w-[18px] max-sm:h-[18px] max-sm:-ml-2 -ml-1"
-              />
-            </div>
-            <div className="text-xl flex items-center">
-              <TokenSymbol symbol={pool.token0.symbol} />/
-              <TokenSymbol symbol={pool.token1.symbol} />
+            <div
+              className={cn('flex items-center gap-1', onOpenPoolDetail && 'cursor-pointer')}
+              onClick={onOpenPoolDetail ? () => onOpenPoolDetail({ chainId, poolAddress, dexId }) : undefined}
+            >
+              <div className="relative flex items-end">
+                <TokenLogo src={pool.token0.logo} size={26} className="border-[2px] border-layer1" />
+                <TokenLogo src={pool.token1.logo} size={26} className="border-[2px] border-layer1 -ml-[6px]" />
+                <TokenLogo
+                  src={NETWORKS_INFO[chainId].logo}
+                  size={14}
+                  className="border-[2px] border-layer1 max-sm:w-[18px] max-sm:h-[18px] max-sm:-ml-2 -ml-1"
+                />
+              </div>
+              <div className="text-xl flex items-center">
+                <TokenSymbol symbol={pool.token0.symbol} />/
+                <TokenSymbol symbol={pool.token1.symbol} />
+              </div>
             </div>
             <div className="rounded-full text-xs bg-layer2 text-subText px-[14px] py-1">
               <Trans>Fee {pool.fee}%</Trans>

--- a/packages/zap-out-widgets/src/types/index.ts
+++ b/packages/zap-out-widgets/src/types/index.ts
@@ -61,4 +61,5 @@ export interface ZapOutProps {
   onExplorePools?: () => void;
   onSuccess?: (props: OnSuccessProps) => void;
   signTypedData?: (account: string, typedDataJson: string) => Promise<string>;
+  onOpenPoolDetail?: (pool: { chainId: number; poolAddress: string; dexId?: string }) => void;
 }


### PR DESCRIPTION
Add an optional onOpenPoolDetail callback prop to the Zap In, Zap Out, Zap Compound and Zap Migration widgets. When provided, clicking the token pair symbol (logos + TOKEN0/TOKEN1 text) opens the pool detail page and the cursor turns into a pointer on hover. When omitted, the symbol is not clickable and the cursor is unchanged.

The Earns hooks wire the callback to a shared navigateToPoolDetail helper that targets the same route used by the position detail header. For Zap Migration both the source and target pools route to their own pool.