### PR TITLE
fix(swap): allow leaving settings immediately after Swap Anyway

### DIFF
--- a/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/DegenModeSetting.tsx
+++ b/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/DegenModeSetting.tsx
@@ -1,6 +1,5 @@
 import { Trans } from '@lingui/macro'
 import { Dispatch, FC, SetStateAction } from 'react'
-import { useSearchParams } from 'react-router-dom'
 
 import AdvanceModeModal from 'components/TransactionSettings/AdvanceModeModal'
 import { SettingsLabel, SettingsRow, SettingsToggle } from 'components/swapv2/SwapSettingsPanel/components'
@@ -10,8 +9,9 @@ import { useDegenModeManager } from 'state/user/hooks'
 type Props = {
   showConfirmation: boolean
   setShowConfirmation: Dispatch<SetStateAction<boolean>>
+  highlight?: boolean
 }
-const DegenModeSetting: FC<Props> = ({ showConfirmation, setShowConfirmation }) => {
+const DegenModeSetting: FC<Props> = ({ showConfirmation, setShowConfirmation, highlight = false }) => {
   const { trackingHandler } = useTracking()
 
   const [isDegenMode, toggleDegenMode] = useDegenModeManager()
@@ -30,15 +30,9 @@ const DegenModeSetting: FC<Props> = ({ showConfirmation, setShowConfirmation }) 
     setShowConfirmation(true)
   }
 
-  const [searchParams] = useSearchParams()
-  const enableDegenMode = searchParams.get('enableDegenMode') === 'true'
-
   return (
     <>
-      <SettingsRow
-        data-highlight={enableDegenMode}
-        className="-m-1 rounded-lg p-1 data-[highlight=true]:animate-highlight"
-      >
+      <SettingsRow data-highlight={highlight} className="-m-1 rounded-lg p-1 data-[highlight=true]:animate-highlight">
         <SettingsLabel
           tooltip={
             <Trans>

--- a/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/index.tsx
+++ b/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/index.tsx
@@ -34,6 +34,7 @@ type Props = {
   onClickCrossChainSources: () => void
   isSwapPage?: boolean
   isCrossChainPage?: boolean
+  highlightDegenMode?: boolean
   displaySettings?: {
     isShowPricingChart?: boolean
     isShowTradeRoutes?: boolean
@@ -62,6 +63,7 @@ const DisplaySettingRow = ({
 const SettingsPanel: React.FC<Props> = ({
   isSwapPage,
   isCrossChainPage,
+  highlightDegenMode,
   onBack,
   onClickLiquiditySources,
   onClickCrossChainSources,
@@ -106,7 +108,11 @@ const SettingsPanel: React.FC<Props> = ({
           <SettingsSection title={<Trans>Advanced Settings</Trans>}>
             <SlippageSetting />
             {isSwapPage && <TransactionTimeLimitSetting />}
-            <DegenModeSetting showConfirmation={showConfirmation} setShowConfirmation={setShowConfirmation} />
+            <DegenModeSetting
+              showConfirmation={showConfirmation}
+              setShowConfirmation={setShowConfirmation}
+              highlight={highlightDegenMode}
+            />
             {isSwapPage && <LiquiditySourcesSetting onClick={onClickLiquiditySources} />}
             {isCrossChainPage && <CrossChainSourceSetting onClick={onClickCrossChainSources} />}
           </SettingsSection>

--- a/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/useRequiredDegenMode.ts
+++ b/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/useRequiredDegenMode.ts
@@ -1,37 +1,53 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 const ENABLE_DEGEN_MODE_PARAM = 'enableDegenMode'
 const HIGHLIGHT_DURATION = 4_000
 const DEFAULT_SETTINGS_TAB = 'settings'
 
+/**
+ * When the user lands with `?enableDegenMode=true` (e.g. via the "Swap Anyway" button),
+ * open the settings tab once and flash the Degen Mode row.
+ *
+ * The URL param is cleared immediately after opening so it only forces the tab a single time —
+ * otherwise the effect would keep snapping the tab back to settings while the param lived,
+ * blocking the back button. The flash is driven by internal state instead, decoupled from the param.
+ *
+ * Returns whether the Degen Mode row should currently be highlighted.
+ */
 export default function useRequiredDegenMode<Tab>({
-  activeTab,
   settingsTab = DEFAULT_SETTINGS_TAB as Tab,
   setActiveTab,
 }: {
-  activeTab: Tab
   settingsTab?: Tab
   setActiveTab: (tab: Tab) => void
 }) {
   const [searchParams, setSearchParams] = useSearchParams()
   const shouldOpenSettings = searchParams.get(ENABLE_DEGEN_MODE_PARAM) === 'true'
+  const [highlightDegenMode, setHighlightDegenMode] = useState(false)
 
   useEffect(() => {
     if (!shouldOpenSettings) return
 
-    if (activeTab !== settingsTab) {
-      setActiveTab(settingsTab)
-    }
+    setActiveTab(settingsTab)
+    setHighlightDegenMode(true)
 
-    const timeout = setTimeout(() => {
-      setSearchParams(prev => {
+    setSearchParams(
+      prev => {
         const nextSearchParams = new URLSearchParams(prev)
         nextSearchParams.delete(ENABLE_DEGEN_MODE_PARAM)
         return nextSearchParams
-      })
-    }, HIGHLIGHT_DURATION)
+      },
+      { replace: true },
+    )
+  }, [shouldOpenSettings, setActiveTab, setSearchParams, settingsTab])
 
+  useEffect(() => {
+    if (!highlightDegenMode) return
+
+    const timeout = setTimeout(() => setHighlightDegenMode(false), HIGHLIGHT_DURATION)
     return () => clearTimeout(timeout)
-  }, [activeTab, searchParams, setActiveTab, setSearchParams, settingsTab, shouldOpenSettings])
+  }, [highlightDegenMode])
+
+  return highlightDegenMode
 }

--- a/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/useRequiredDegenMode.ts
+++ b/apps/kyberswap-interface/src/components/swapv2/SwapSettingsPanel/useRequiredDegenMode.ts
@@ -5,16 +5,6 @@ const ENABLE_DEGEN_MODE_PARAM = 'enableDegenMode'
 const HIGHLIGHT_DURATION = 4_000
 const DEFAULT_SETTINGS_TAB = 'settings'
 
-/**
- * When the user lands with `?enableDegenMode=true` (e.g. via the "Swap Anyway" button),
- * open the settings tab once and flash the Degen Mode row.
- *
- * The URL param is cleared immediately after opening so it only forces the tab a single time —
- * otherwise the effect would keep snapping the tab back to settings while the param lived,
- * blocking the back button. The flash is driven by internal state instead, decoupled from the param.
- *
- * Returns whether the Degen Mode row should currently be highlighted.
- */
 export default function useRequiredDegenMode<Tab>({
   settingsTab = DEFAULT_SETTINGS_TAB as Tab,
   setActiveTab,

--- a/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
+++ b/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
@@ -235,7 +235,7 @@ export default function PartnerSwap({ mode = 'partner' }: Props) {
   const isLimitPage = activeMainTab === TAB.LIMIT
   const isCrossChainPage = activeMainTab === TAB.CROSS_CHAIN
 
-  useRequiredDegenMode({ activeTab, setActiveTab })
+  const highlightDegenMode = useRequiredDegenMode({ setActiveTab })
 
   const onBackToSwapTab = () => setActiveTab(activeMainTab)
 
@@ -320,6 +320,7 @@ export default function PartnerSwap({ mode = 'partner' }: Props) {
                   }}
                   isCrossChainPage={isCrossChainPage}
                   isSwapPage={isSwapPage}
+                  highlightDegenMode={highlightDegenMode}
                   onBack={onBackToSwapTab}
                   onClickLiquiditySources={() => setActiveTab(TAB.LIQUIDITY_SOURCES)}
                   onClickCrossChainSources={() => setActiveTab(TAB.CROSS_CHAIN_SOURCES)}

--- a/apps/kyberswap-interface/src/pages/SwapV3/index.tsx
+++ b/apps/kyberswap-interface/src/pages/SwapV3/index.tsx
@@ -91,7 +91,7 @@ export default function Swap() {
   const [activeTab, setActiveTab] = useState<TAB>(getDefaultTab())
   const [selectedQuote, setSelectedQuote] = useState<Quote | null>(null)
 
-  useRequiredDegenMode({ activeTab, setActiveTab })
+  const highlightDegenMode = useRequiredDegenMode({ setActiveTab })
 
   useEffect(() => {
     setActiveTab(getDefaultTab())
@@ -146,6 +146,7 @@ export default function Swap() {
               <SettingsPanel
                 isCrossChainPage={isCrossChainPage}
                 isSwapPage={isSwapPage}
+                highlightDegenMode={highlightDegenMode}
                 onBack={onBackToSwapTab}
                 onClickLiquiditySources={() => setActiveTab(TAB.LIQUIDITY_SOURCES)}
                 onClickCrossChainSources={() => setActiveTab(TAB.CROSS_CHAIN_SOURCES)}


### PR DESCRIPTION
The enableDegenMode URL param drove both opening the settings tab and the 4s Degen Mode highlight, so the effect kept forcing the tab back to settings (and resetting the timer) for 4s, blocking the back button.

Clear the param right after opening so the tab is forced only once, and drive the highlight from internal state instead.