### PR TITLE
fix: add Unichain public RPC endpoints

### DIFF
--- a/packages/rpc-client/src/endpoints.ts
+++ b/packages/rpc-client/src/endpoints.ts
@@ -9,6 +9,7 @@ const RONIN = 2020;
 const MONAD = 143;
 const ETHERLINK = 42793;
 const MEGAETH = 4326;
+const UNICHAIN = 130;
 
 export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
   [ChainId.Ethereum]: [
@@ -182,6 +183,13 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
     'https://mainnet.megaeth.com/rpc',
     'https://megaeth.gateway.tenderly.co',
     'https://4326.rpc.thirdweb.com',
+  ],
+  [UNICHAIN]: [
+    'https://unichain.drpc.org',
+    'https://unichain-rpc.publicnode.com',
+    'https://unichain.api.onfinality.io/public',
+    'https://unichain.gateway.tenderly.co',
+    'https://mainnet.unichain.org',
   ],
 };
 


### PR DESCRIPTION
## Summary

Adds public RPC endpoints for **Unichain** (chain ID `130`) to `packages/rpc-client/src/endpoints.ts`. Unichain is a supported network in the app but was missing from `PUBLIC_RPC_ENDPOINTS`, so it fell back to Kyber RPC only (with a console warning).

Audited every chain in the app's supported-network list against this file — Unichain was the only one missing.

## Endpoints added

- `unichain.drpc.org`
- `unichain-rpc.publicnode.com`
- `unichain.api.onfinality.io/public`
- `unichain.gateway.tenderly.co`
- `mainnet.unichain.org`

## Test plan

- `pnpm type-check` passes for `@kyber/rpc-client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)