### PR TITLE
fix(modal): prevent dialog portal leak that froze the chain modal after select

### DIFF
--- a/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/index.tsx
@@ -86,10 +86,17 @@ export default function NetworkModal({
   const networkModalOpen = useModalOpen(ApplicationModal.NETWORK)
   const toggleNetworkModalGlobal = useNetworkModalToggle()
   const [searchText, setSearchText] = useState('')
+  const modalIsOpen = isOpen !== undefined ? isOpen : networkModalOpen
   const toggleNetworkModal = () => {
     setSearchText('')
     ;(customToggleModal || toggleNetworkModalGlobal)()
   }
+
+  // Reset the search whenever the modal closes — selecting a chain closes via customToggleModal,
+  // which bypasses the search reset above, so the next open would otherwise show the stale query.
+  useEffect(() => {
+    if (!modalIsOpen) setSearchText('')
+  }, [modalIsOpen])
 
   const favoriteDropRef = useRef<HTMLDivElement>(null)
   const { allChains, supportedChains } = useChainsConfig()
@@ -215,7 +222,7 @@ export default function NetworkModal({
   }, [userInfo, setFavoriteChains])
   return (
     <Modal
-      isOpen={isOpen !== undefined ? isOpen : networkModalOpen}
+      isOpen={modalIsOpen}
       onDismiss={toggleNetworkModal}
       zindex={Z_INDEXS.MODAL}
       minHeight="550px"

--- a/apps/kyberswap-interface/src/components/Modal/index.tsx
+++ b/apps/kyberswap-interface/src/components/Modal/index.tsx
@@ -1,14 +1,15 @@
 import { DialogContent, DialogOverlay } from '@reach/dialog'
 import '@reach/dialog/styles.css'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import React, { CSSProperties, useCallback } from 'react'
 import { isMobile } from 'react-device-detect'
 
 import { cn } from 'utils/cn'
 
-// motion.create wraps @reach/dialog only for the mobile swipe-drag below. The entrance fade is CSS
-// (.ks-dialog-overlay), since animating the wrapped overlay via framer-motion is unreliable under React 19.
-const AnimatedDialogOverlay = motion.create(DialogOverlay)
+// motion.create wraps @reach/dialog content only for the mobile swipe-drag below. The entrance fade is
+// CSS (.ks-dialog-overlay). The overlay is rendered/unmounted with a plain conditional (no AnimatePresence):
+// AnimatePresence leaves the @reach/dialog portal orphaned in the DOM when the modal closes during a
+// concurrent re-render under React 19, freezing the dialog (clicks dead). Plain unmount is reliable.
 const AnimatedDialogContent = motion.create(DialogContent)
 
 export interface ModalProps {
@@ -96,37 +97,35 @@ export default function Modal({
     ...(hasExplicitBorderRadius && { borderRadius: borderRadius as string }),
   }
 
+  if (!isOpen) return null
+
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <AnimatedDialogOverlay
-          onDismiss={onDismiss}
-          dangerouslyBypassScrollLock={bypassScrollLock}
-          dangerouslyBypassFocusLock={bypassFocusLock}
-          className="ks-dialog-overlay"
-          style={overlayStyle}
-          data-no-transition={transition ? 'false' : 'true'}
-        >
-          <AnimatedDialogContent
-            drag={isMobile && enableSwipeGesture && 'y'}
-            dragConstraints={{ top: 0, bottom: 0 }}
-            dragElastic={{ top: 0, bottom: 0.5 }}
-            onDrag={handleDrag as any}
-            aria-label="dialog content"
-            className={cn('ks-dialog-content', className)}
-            style={contentStyle}
-            data-has-explicit-width={hasExplicitWidth ? 'true' : 'false'}
-            data-has-explicit-radius={hasExplicitBorderRadius ? 'true' : 'false'}
-            data-mobile={isMobile ? 'true' : 'false'}
-            data-mobile-full-width={mobileFullWidth ? 'true' : 'false'}
-          >
-            {/* prevents the automatic focusing of inputs on mobile by the reach dialog */}
-            {!enableInitialFocusInput && isMobile ? <div tabIndex={1} /> : null}
-            {children}
-          </AnimatedDialogContent>
-        </AnimatedDialogOverlay>
-      )}
-    </AnimatePresence>
+    <DialogOverlay
+      onDismiss={onDismiss}
+      dangerouslyBypassScrollLock={bypassScrollLock}
+      dangerouslyBypassFocusLock={bypassFocusLock}
+      className="ks-dialog-overlay"
+      style={overlayStyle}
+      data-no-transition={transition ? 'false' : 'true'}
+    >
+      <AnimatedDialogContent
+        drag={isMobile && enableSwipeGesture && 'y'}
+        dragConstraints={{ top: 0, bottom: 0 }}
+        dragElastic={{ top: 0, bottom: 0.5 }}
+        onDrag={handleDrag as any}
+        aria-label="dialog content"
+        className={cn('ks-dialog-content', className)}
+        style={contentStyle}
+        data-has-explicit-width={hasExplicitWidth ? 'true' : 'false'}
+        data-has-explicit-radius={hasExplicitBorderRadius ? 'true' : 'false'}
+        data-mobile={isMobile ? 'true' : 'false'}
+        data-mobile-full-width={mobileFullWidth ? 'true' : 'false'}
+      >
+        {/* prevents the automatic focusing of inputs on mobile by the reach dialog */}
+        {!enableInitialFocusInput && isMobile ? <div tabIndex={1} /> : null}
+        {children}
+      </AnimatedDialogContent>
+    </DialogOverlay>
   )
 }
 

--- a/apps/kyberswap-interface/src/pages/Bridge/SelectNetwork.tsx
+++ b/apps/kyberswap-interface/src/pages/Bridge/SelectNetwork.tsx
@@ -26,7 +26,7 @@ const SelectNetwork = forwardRef<
 
   const [isOpen, setIsOpen] = useState(false)
   const toggleNetworkModal = () => {
-    setIsOpen(!isOpen)
+    setIsOpen(prev => !prev)
   }
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Selecting a chain in the cross-chain network modal closed it (isOpen=false) while setSearchParams ran in the same tick. Under React 19, AnimatePresence failed to remove the @reach/dialog portal during that concurrent re-render, leaving the overlay orphaned and frozen so the search clear and close buttons stopped responding.

- Modal: render the overlay with a plain conditional instead of AnimatePresence (entrance fade is CSS, no exit animation exists); keep motion on the content for the mobile swipe gesture.
- NetworkModal: reset the search whenever the modal closes so reopening is clean.
- SelectNetwork: toggle isOpen with a functional updater.