### PR TITLE
fix(limit-order): align chain handling and validation

### DIFF
--- a/apps/kyberswap-interface/src/components/LimitOrder/CancelOrder/CancelOrderModal.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/CancelOrder/CancelOrderModal.tsx
@@ -17,6 +17,7 @@ import { HStack, Stack } from 'components/Stack'
 import { useActiveWeb3React } from 'hooks'
 import { NETWORKS_INFO } from 'hooks/useChainsConfig'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
+import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
 import { CloseIcon } from 'theme/components'
 import { formatDisplayNumber } from 'utils/numbers'
 
@@ -87,7 +88,8 @@ const CancelOrderModal = ({
   const [errorMessage, setErrorMessage] = useState('')
   const requestController = useRef(new AbortController())
 
-  const { networkInfo } = useActiveWeb3React()
+  const { chainId: walletChainId, networkInfo } = useActiveWeb3React()
+  const { changeNetwork } = useChangeNetwork()
   const { trackingHandler } = useTracking()
 
   const getGaslessSupport = useIsSupportSoftCancelOrder(chainId)
@@ -162,6 +164,7 @@ const CancelOrderModal = ({
 
   const handleHardCancel = useCallback(() => handleCancel(CancelOrderType.HARD_CANCEL), [handleCancel])
   const handleConfirm = useCallback(() => handleCancel(cancelType), [cancelType, handleCancel])
+  const handleSwitchNetwork = useCallback(() => changeNetwork(chainId), [changeNetwork, chainId])
   const handleCountdownEnd = useCallback(() => setCancelStatus(CancelStatus.CANCEL_DONE), [])
   const handleChangeCancelAllChain = useCallback(
     (chainId: ChainId) => {
@@ -230,11 +233,13 @@ const CancelOrderModal = ({
 
   const isCountDown = cancelStatus === CancelStatus.COUNTDOWN
   const isCancelDone = cancelStatus === CancelStatus.CANCEL_DONE
+  const shouldSwitchNetwork = walletChainId !== chainId
 
   const disabledBecauseNoOrders = isCancelAll && !selectedOrders.length
   const disabledGasLessCancel = !supportsGaslessCancel || attemptingTxn || disabledBecauseNoOrders
   const disabledHardCancel = attemptingTxn || disabledBecauseNoOrders
   const disabledConfirm = attemptingTxn || disabledBecauseNoOrders || (disabledGasLessCancel && disabledHardCancel)
+  const disabledSwitchNetwork = attemptingTxn || disabledBecauseNoOrders
 
   const cancelGaslessText = isCancelAll ? (
     gaslessCancelableOrders.length === selectedOrders.length || !supportsGaslessCancel ? (
@@ -253,6 +258,7 @@ const CancelOrderModal = ({
     : ''
 
   const errorLine = <div className="min-h-4 text-xs leading-4 text-red">{errorMessage}</div>
+  const switchNetworkText = <Trans>Switch to {NETWORKS_INFO[chainId]?.name}</Trans>
 
   return (
     <Modal isOpen={isOpen} onDismiss={onDismiss} maxWidth={480} borderRadius={16}>
@@ -315,9 +321,12 @@ const CancelOrderModal = ({
                   <Trans>Close</Trans>
                 </ButtonOutlined>
                 <Stack className="flex-1 gap-1">
-                  <ButtonPrimary disabled={disabledHardCancel} onClick={handleHardCancel}>
+                  <ButtonPrimary
+                    disabled={shouldSwitchNetwork ? disabledSwitchNetwork : disabledHardCancel}
+                    onClick={shouldSwitchNetwork ? handleSwitchNetwork : handleHardCancel}
+                  >
                     <Dots absolute loading={attemptingTxn}>
-                      <Trans>Hard Cancel</Trans>
+                      {shouldSwitchNetwork ? switchNetworkText : <Trans>Hard Cancel</Trans>}
                     </Dots>
                   </ButtonPrimary>
                 </Stack>
@@ -342,9 +351,18 @@ const CancelOrderModal = ({
               />
 
               {errorLine}
-              <ButtonPrimary disabled={disabledConfirm} onClick={handleConfirm}>
+              <ButtonPrimary
+                disabled={shouldSwitchNetwork ? disabledSwitchNetwork : disabledConfirm}
+                onClick={shouldSwitchNetwork ? handleSwitchNetwork : handleConfirm}
+              >
                 <Dots absolute loading={attemptingTxn}>
-                  {isCancelAll ? <Trans>Cancel All Orders</Trans> : <Trans>Cancel Order</Trans>}
+                  {shouldSwitchNetwork ? (
+                    switchNetworkText
+                  ) : isCancelAll ? (
+                    <Trans>Cancel All Orders</Trans>
+                  ) : (
+                    <Trans>Cancel Order</Trans>
+                  )}
                 </Dots>
               </ButtonPrimary>
             </Stack>

--- a/apps/kyberswap-interface/src/components/LimitOrder/CreateOrder/useWarningCreateOrder.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/CreateOrder/useWarningCreateOrder.tsx
@@ -58,6 +58,18 @@ export const useWarningCreateOrder = ({
   const inputBalance = useCurrencyBalance(currencyIn?.isNative ? undefined : currencyIn, chainId)
   const wrappedNativeBalance = useCurrencyBalance(currencyIn?.isNative ? makingCurrency : undefined, chainId)
 
+  const isSameTokenPair = useMemo(() => {
+    if (!currencyIn || !currencyOut) return false
+    if (currencyIn.equals(currencyOut)) return true
+
+    const inputToken = currencyIn.wrapped
+    const outputToken = currencyOut.wrapped
+    return (
+      inputToken.chainId === outputToken.chainId &&
+      inputToken.address.toLowerCase() === outputToken.address.toLowerCase()
+    )
+  }, [currencyIn, currencyOut])
+
   const { data: pairActiveOrderMakingAmount = '', refetch: getPairActiveMakingAmount } =
     useGetTotalActiveMakingAmountQuery(
       {
@@ -115,6 +127,16 @@ export const useWarningCreateOrder = ({
       warnings.push({ type: options?.type || 'warn', message })
     }
 
+    if (isSameTokenPair) {
+      shouldDisableAction = true
+      addWarning(
+        <div className="text-xs font-medium italic text-subText">
+          <Trans>Token in and token out must be different.</Trans>
+        </div>,
+        { type: 'warn' },
+      )
+    }
+
     if (hasPercent && rawPercent >= BETTER_PRICE_DIFF_THRESHOLD) {
       addWarning(
         <div className="text-xs font-medium italic text-subText">
@@ -160,6 +182,6 @@ export const useWarningCreateOrder = ({
       shouldDisableAction,
       warnings,
     }
-  }, [currencyIn, currencyOut, deltaRate.percent, deltaRate.rawPercent, showReservedOrderNotice])
+  }, [currencyIn, currencyOut, deltaRate.percent, deltaRate.rawPercent, isSameTokenPair, showReservedOrderNotice])
   return warning
 }

--- a/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/index.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/index.tsx
@@ -30,12 +30,13 @@ import Pagination from 'components/Pagination'
 import RefetchIndicator from 'components/RefetchIndicator'
 import SearchInput from 'components/SearchInput'
 import { RTK_QUERY_TAGS } from 'constants/index'
-import { MAINNET_NETWORKS, NETWORKS_INFO } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
+import useChainsConfig from 'hooks/useChainsConfig'
 import { useInvalidateTagLimitOrder } from 'hooks/useInvalidateTags'
 import usePageLocation from 'hooks/usePageLocation'
 import useTab from 'hooks/useTab'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
+import { sortChainOptionsByPriority } from 'pages/Earns/hooks/useSupportedDexesAndChains'
 import { cn } from 'utils/cn'
 import {
   subscribeNotificationOrderCancelled,
@@ -47,8 +48,7 @@ import { isSupportLimitOrder } from 'utils/index'
 type NotificationOrderCallback = Parameters<typeof subscribeNotificationOrderExpired>[2]
 
 const ALL_CHAINS_VALUE = 'all'
-
-const SUPPORTED_LIMIT_ORDER_CHAINS = MAINNET_NETWORKS.filter(isSupportLimitOrder)
+const EMPTY_LIMIT_ORDERS: LimitOrder[] = []
 
 const NoResultWrapper = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>) => (
   <div
@@ -103,6 +103,8 @@ const MyOrders = () => {
   const { trackingHandler } = useTracking()
   const { isEmbeddedSwap } = usePageLocation()
   const { chainId, networkName } = useLimitOrderContext()
+  const { supportedChains } = useChainsConfig()
+
   const [searchParams, setSearchParams] = useSearchParams()
   const invalidateTag = useInvalidateTagLimitOrder()
 
@@ -121,38 +123,48 @@ const MyOrders = () => {
   const [isCancelAll, setIsCancelAll] = useState(false)
 
   const keyword = searchParams.get('search') || ''
+
   const isTabActive = isActiveStatus(orderType)
   const activeTab = getActiveTabByOrderType(orderType)
   const orderTypeOptions = getOrderTypeOptions(orderType)
-
-  const isAllChainsSelected = selectedChainValue === ALL_CHAINS_VALUE
-  const selectedOrderChainIds = isAllChainsSelected
-    ? SUPPORTED_LIMIT_ORDER_CHAINS
-    : [Number(selectedChainValue) as ChainId]
-  const cancellingChainId = isAllChainsSelected ? chainId : selectedOrderChainIds[0]
-  const ordersApiSearchKeyword = getOrdersApiSearchKeyword(keyword, selectedOrderChainIds)
-
-  const { isOrderCancelling, setCancellingOrders } = useCancellingOrders({ chainId: cancellingChainId })
-
   const orderTypeDropdownOptions = useMemo<MenuOption[]>(
     () => orderTypeOptions.map(option => ({ label: option.label, value: option.value })),
     [orderTypeOptions],
   )
 
+  const supportedLimitOrderChainOptions = useMemo<MenuOption[]>(
+    () =>
+      supportedChains
+        .filter(chain => isSupportLimitOrder(chain.chainId))
+        .map(chain => ({
+          label: chain.name,
+          value: chain.chainId.toString(),
+          icon: chain.icon,
+        }))
+        .sort(sortChainOptionsByPriority),
+    [supportedChains],
+  )
   const chainOptions = useMemo<MenuOption[]>(
-    () => [
-      { label: t`All Chains`, value: ALL_CHAINS_VALUE },
-      ...SUPPORTED_LIMIT_ORDER_CHAINS.map(chainId => ({
-        label: NETWORKS_INFO[chainId].name,
-        value: chainId.toString(),
-        icon: NETWORKS_INFO[chainId].icon,
-      })),
-    ],
-    [],
+    () => [{ label: t`All Chains`, value: ALL_CHAINS_VALUE }, ...supportedLimitOrderChainOptions],
+    [supportedLimitOrderChainOptions],
+  )
+  const supportedLimitOrderChains = useMemo(
+    () => supportedLimitOrderChainOptions.map(option => Number(option.value) as ChainId),
+    [supportedLimitOrderChainOptions],
   )
 
+  const selectedChainId = Number(selectedChainValue) as ChainId
+  const isSelectedChainSupported = supportedLimitOrderChains.includes(selectedChainId)
+  const isAllChainsSelected = selectedChainValue === ALL_CHAINS_VALUE || !isSelectedChainSupported
+  const selectedOrderChainIds = isAllChainsSelected ? supportedLimitOrderChains : [selectedChainId]
+
+  const cancellingChainId = isAllChainsSelected ? chainId : selectedOrderChainIds[0]
+  const ordersApiSearchKeyword = getOrdersApiSearchKeyword(keyword, selectedOrderChainIds)
+
+  const { isOrderCancelling, setCancellingOrders } = useCancellingOrders({ chainId: cancellingChainId })
+
   const {
-    data: { orders = [], totalOrder = 0 } = {},
+    data: listOrdersData,
     isFetching,
     isError: isOrdersError,
     isSuccess: isOrdersLoaded,
@@ -168,13 +180,15 @@ const MyOrders = () => {
     { skip: !account, pollingInterval: 10_000, refetchOnFocus: true },
   )
 
+  const orders = listOrdersData?.orders ?? EMPTY_LIMIT_ORDERS
+  const totalOrder = listOrdersData?.totalOrder ?? 0
   const hasOrders = orders.length > 0
   const showPagination = hasOrders && totalOrder > PAGE_SIZE
   const showCancelAll = hasOrders && isTabActive
   const showNoOrders = !hasOrders && (isOrdersLoaded || isOrdersError || !account)
 
   const {
-    data: { orders: cancelAllOrders = [] } = {},
+    data: cancelAllOrdersData,
     isError: isCancelAllOrdersError,
     isFetching: isFetchingCancelAllOrders,
     isSuccess: isCancelAllOrdersLoaded,
@@ -188,6 +202,7 @@ const MyOrders = () => {
     { skip: !account || !showCancelAll },
   )
 
+  const cancelAllOrders = cancelAllOrdersData?.orders ?? EMPTY_LIMIT_ORDERS
   const isLoadingCancelAllOrders =
     showCancelAll && !isCancelAllOrdersError && (!isCancelAllOrdersLoaded || isFetchingCancelAllOrders)
 
@@ -320,9 +335,9 @@ const MyOrders = () => {
   }, [account, chainId, refreshListOrder, trackCancelledOrder, trackFilledOrder])
 
   useEffect(() => {
-    setSelectedChainValue(chainId.toString())
+    setSelectedChainValue(supportedLimitOrderChains.includes(chainId) ? chainId.toString() : ALL_CHAINS_VALUE)
     onReset()
-  }, [chainId, onReset])
+  }, [chainId, onReset, supportedLimitOrderChains])
 
   useEffect(() => {
     onReset()

--- a/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/index.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/index.tsx
@@ -1,6 +1,6 @@
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import { Trans, t } from '@lingui/macro'
-import { HTMLAttributes, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+import { HTMLAttributes, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Trash } from 'react-feather'
 import { useSearchParams } from 'react-router-dom'
 import { useGetListOrdersQuery } from 'services/limitOrder'
@@ -121,6 +121,7 @@ const MyOrders = () => {
   const [currentOrder, setCurrentOrder] = useState<LimitOrder>()
   const [isOpenCancel, setIsOpenCancel] = useState(false)
   const [isCancelAll, setIsCancelAll] = useState(false)
+  const chainFilterRef = useRef({ chainId, selectedChainValue })
 
   const keyword = searchParams.get('search') || ''
 
@@ -253,7 +254,9 @@ const MyOrders = () => {
   }
 
   const onSelectChain = (value: string | number) => {
-    setSelectedChainValue(value.toString())
+    const nextSelectedChainValue = value.toString()
+    chainFilterRef.current.selectedChainValue = nextSelectedChainValue
+    setSelectedChainValue(nextSelectedChainValue)
     onReset()
   }
 
@@ -335,7 +338,13 @@ const MyOrders = () => {
   }, [account, chainId, refreshListOrder, trackCancelledOrder, trackFilledOrder])
 
   useEffect(() => {
-    setSelectedChainValue(supportedLimitOrderChains.includes(chainId) ? chainId.toString() : ALL_CHAINS_VALUE)
+    if (chainFilterRef.current.chainId === chainId) return
+    chainFilterRef.current.chainId = chainId
+    if (chainFilterRef.current.selectedChainValue === ALL_CHAINS_VALUE) return
+
+    const nextSelectedChainValue = supportedLimitOrderChains.includes(chainId) ? chainId.toString() : ALL_CHAINS_VALUE
+    chainFilterRef.current.selectedChainValue = nextSelectedChainValue
+    setSelectedChainValue(nextSelectedChainValue)
     onReset()
   }, [chainId, onReset, supportedLimitOrderChains])
 

--- a/apps/kyberswap-interface/src/components/LimitOrder/TakeOrder/TakeOrderActionButtons.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/TakeOrder/TakeOrderActionButtons.tsx
@@ -37,7 +37,7 @@ const TakeOrderActionButtons = ({
           <Trans>Use Swap Instead</Trans>
         </ButtonOutlined>
         <ButtonPrimary onClick={toggleWalletModal} className="flex-1">
-          <Trans>Connect wallet</Trans>
+          <Trans>Connect Wallet</Trans>
         </ButtonPrimary>
       </ActionWrapper>
     )

--- a/apps/kyberswap-interface/src/hooks/useChainsConfig.ts
+++ b/apps/kyberswap-interface/src/hooks/useChainsConfig.ts
@@ -12,10 +12,12 @@ export enum ChainState {
   MAINTENANCE = 'maintained',
 }
 
-export type ChainStateMap = { [chain in ChainId]: ChainState }
+export type ChainStateMap = {
+  [chain in ChainId]: ChainState
+}
 
 const cacheInfo: { [chain: string]: NetworkInfo } = {}
-// todo danh, when chain setting from admin ready, update all place use this
+
 export const NETWORKS_INFO = new Proxy(NETWORKS_INFO_HARDCODE, {
   get(target, p) {
     const prop = p as any as ChainId
@@ -31,7 +33,6 @@ export default function useChainsConfig() {
 
   return useMemo(() => {
     const hasBeConfig = !!data
-    // const chains: NetworkInfo[] = (data || defaultData).map(chain => {
     const chains: NetworkInfo[] = defaultData.map(chain => {
       const chainId = +chain.chainId as ChainId
       const chainState = hasBeConfig ? globalConfig?.chainStates?.[chainId] : ChainState.ACTIVE
@@ -46,9 +47,9 @@ export default function useChainsConfig() {
     })
 
     return {
-      activeChains: chains.filter(e => [ChainState.ACTIVE, ChainState.NEW].includes(e.state)),
-      supportedChains: chains.filter(e =>
-        [ChainState.ACTIVE, ChainState.NEW, ChainState.MAINTENANCE].includes(e.state),
+      activeChains: chains.filter(chain => [ChainState.ACTIVE, ChainState.NEW].includes(chain.state)),
+      supportedChains: chains.filter(chain =>
+        [ChainState.ACTIVE, ChainState.NEW, ChainState.MAINTENANCE].includes(chain.state),
       ),
       allChains: chains,
     }

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useSupportedDexesAndChains.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useSupportedDexesAndChains.ts
@@ -21,6 +21,16 @@ const CHAIN_PRIORITY_ORDER = [
   EarnChain.BERA,
 ]
 
+export const sortChainOptionsByPriority = (a: MenuOption, b: MenuOption) => {
+  const aIndex = CHAIN_PRIORITY_ORDER.indexOf(Number(a.value) as EarnChain)
+  const bIndex = CHAIN_PRIORITY_ORDER.indexOf(Number(b.value) as EarnChain)
+
+  if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex
+  if (aIndex !== -1) return -1
+  if (bIndex !== -1) return 1
+  return a.label.localeCompare(b.label)
+}
+
 const DEX_PRIORITY_ORDER = [
   Exchange.DEX_UNISWAP_V4_FAIRFLOW,
   Exchange.DEX_UNISWAP_V4,
@@ -53,18 +63,7 @@ const useSupportedDexesAndChains = (
         icon: chain.icon,
       }))
       .filter(chain => supportedProtocols?.data?.chains?.[chain.value] && EARN_CHAINS[Number(chain.value) as EarnChain])
-      .sort((a, b) => {
-        const aIndex = CHAIN_PRIORITY_ORDER.indexOf(Number(a.value))
-        const bIndex = CHAIN_PRIORITY_ORDER.indexOf(Number(b.value))
-
-        // If both chains are in priority order, sort by their priority
-        if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex
-        // If only one chain is in priority order, prioritize it
-        if (aIndex !== -1) return -1
-        if (bIndex !== -1) return 1
-        // If neither chain is in priority order, sort alphabetically
-        return a.label.localeCompare(b.label)
-      })
+      .sort(sortChainOptionsByPriority)
 
     const allowAllChains = 'chainIds' in filters
     return allowAllChains ? [AllChainsOption].concat(parsedChains) : parsedChains


### PR DESCRIPTION
## Summary
- Build My Orders chain options from supported Limit Order chains and reuse the Earns priority ordering
- Keep the My Orders chain filter stable when switching networks from cancel flows
- Require switching to the selected order chain before canceling orders
- Block create-order actions when input and output tokens resolve to the same token