### PR TITLE
fix(limit): guard orderbook query params

### DIFF
--- a/apps/kyberswap-interface/src/components/LanguageSelector/index.tsx
+++ b/apps/kyberswap-interface/src/components/LanguageSelector/index.tsx
@@ -1,5 +1,4 @@
-import { isMobile } from 'react-device-detect'
-import { ArrowLeft, Check } from 'react-feather'
+import { Check } from 'react-feather'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { HStack, Stack } from 'components/Stack'
@@ -12,15 +11,13 @@ const LOCALES = Object.keys(LOCALE_INFO) as SupportedLocale[]
 type LanguageSelectorProps = {
   onDismiss?: () => void
   onLanguageChange?: (previousLanguage: string, newLanguage: string) => void
-  variant?: 'standalone' | 'menu'
 }
 
-const LanguageSelector = ({ onDismiss, onLanguageChange, variant = 'standalone' }: LanguageSelectorProps) => {
+const LanguageSelector = ({ onDismiss, onLanguageChange }: LanguageSelectorProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const userLocale = useUserLocale()
   const selectedLocale = userLocale || DEFAULT_LOCALE
-  const isMenu = variant === 'menu'
 
   const handleSelectLanguage = (locale: SupportedLocale) => {
     if (locale !== selectedLocale) {
@@ -38,19 +35,8 @@ const LanguageSelector = ({ onDismiss, onLanguageChange, variant = 'standalone' 
   }
 
   return (
-    <Stack className={cn(isMenu ? 'pl-4' : 'items-start justify-center gap-6')}>
-      {!isMenu && onDismiss && (
-        <button type="button" onClick={onDismiss} className="cursor-pointer border-0 bg-transparent p-0 text-text">
-          <ArrowLeft />
-        </button>
-      )}
-      <div
-        className={cn(
-          'grid w-full',
-          !isMenu && 'gap-x-12 gap-y-6',
-          isMobile && !isMenu ? 'grid-cols-[1fr_1fr]' : 'grid-cols-[1fr]',
-        )}
-      >
+    <Stack className="pl-4">
+      <div className="grid w-full grid-cols-[1fr]">
         {LOCALES.map(locale => {
           const localeInfo = LOCALE_INFO[locale]
           const isSelected = locale === selectedLocale
@@ -62,9 +48,7 @@ const LanguageSelector = ({ onDismiss, onLanguageChange, variant = 'standalone' 
               onClick={() => handleSelectLanguage(locale)}
               className={cn(
                 'group flex w-full cursor-pointer items-center justify-between gap-2 border-0 bg-transparent text-left outline-none transition-colors',
-                isMenu
-                  ? 'px-0 py-2.5 text-sm text-subText hover:text-text focus:text-text'
-                  : 'p-0 text-sm text-subText',
+                'px-0 py-2.5 text-sm text-subText hover:text-text focus:text-text',
                 isSelected && '!text-primary',
               )}
             >

--- a/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/index.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/index.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro'
+import { skipToken } from '@reduxjs/toolkit/query'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Repeat } from 'react-feather'
 import { useGetOrdersByTokenPairQuery } from 'services/limitOrder'
@@ -75,27 +76,24 @@ const OrderBook = () => {
     refetch: refetchMarketRate,
   } = useBaseTradeInfoLimitOrder(makerCurrency, takerCurrency, chainId)
 
+  const makerAsset = makerCurrency?.wrapped.address
+  const takerAsset = takerCurrency?.wrapped.address
+
   const {
     data: { orders = [] } = {},
     isFetching: isFetchingOrders,
     isSuccess: isOrdersLoaded,
     refetch: refetchOrders,
-  } = useGetOrdersByTokenPairQuery({
-    chainId,
-    makerAsset: makerCurrency?.wrapped?.address,
-    takerAsset: takerCurrency?.wrapped?.address,
-  })
+  } = useGetOrdersByTokenPairQuery(makerAsset && takerAsset ? { chainId, makerAsset, takerAsset } : skipToken)
 
   const {
     data: { orders: reversedOrders = [] } = {},
     isFetching: isFetchingReversedOrder,
     isSuccess: isReversedOrdersLoaded,
     refetch: refetchReversedOrders,
-  } = useGetOrdersByTokenPairQuery({
-    chainId,
-    makerAsset: takerCurrency?.wrapped?.address,
-    takerAsset: makerCurrency?.wrapped?.address,
-  })
+  } = useGetOrdersByTokenPairQuery(
+    makerAsset && takerAsset ? { chainId, makerAsset: takerAsset, takerAsset: makerAsset } : skipToken,
+  )
 
   const refetchLoading = loadingMarketRate || isFetchingOrders || isFetchingReversedOrder
 

--- a/apps/kyberswap-interface/src/components/Menu/NavDropDown.tsx
+++ b/apps/kyberswap-interface/src/components/Menu/NavDropDown.tsx
@@ -37,7 +37,7 @@ const NavDropDown = ({ title, icon, options = [] }: NavDropDownProps) => {
           {title}
         </HStack>
         <DropdownSVG
-          className={cn('!size-6 shrink-0 transition-all duration-200 ease-in-out', isShowOptions && 'rotate-180')}
+          className={cn('-mx-1 size-6 shrink-0 transition-all duration-200 ease-in-out', isShowOptions && 'rotate-180')}
         />
       </MenuItemContent>
       <div

--- a/apps/kyberswap-interface/src/components/Menu/components/PreferencesSection.tsx
+++ b/apps/kyberswap-interface/src/components/Menu/components/PreferencesSection.tsx
@@ -106,7 +106,10 @@ export const PreferencesSection = ({ toggle }: PreferencesSectionProps) => {
             <span>{selectedLocale.split('-')[0].toUpperCase()}</span>
           </HStack>
           <DropdownSVG
-            className={cn('-mx-1 size-4 transition-transform duration-300', isLanguageOpen && 'rotate-180')}
+            className={cn(
+              '-mx-1 size-6 text-subText transition-transform duration-300',
+              isLanguageOpen && 'rotate-180',
+            )}
           />
         </HStack>
       </NavLinkBetween>
@@ -118,7 +121,6 @@ export const PreferencesSection = ({ toggle }: PreferencesSectionProps) => {
       >
         <div className="min-h-0 overflow-hidden">
           <LanguageSelector
-            variant="menu"
             onDismiss={() => setIsLanguageOpen(false)}
             onLanguageChange={(prevLang, newLang) => {
               trackingHandler(TRACKING_EVENT_TYPE.LANGUAGE_CHANGED, {

--- a/apps/kyberswap-interface/src/services/limitOrder.ts
+++ b/apps/kyberswap-interface/src/services/limitOrder.ts
@@ -184,8 +184,8 @@ const limitOrderApi = createApi({
       { orders: LimitOrderFromTokenPair[] },
       {
         chainId: ChainId
-        makerAsset?: string
-        takerAsset?: string
+        makerAsset: string
+        takerAsset: string
       }
     >({
       query: params => ({


### PR DESCRIPTION
## Summary
- Skip OrderBook order queries until both maker and taker token addresses are available
- Require makerAsset and takerAsset in the orderbook query service type