### PR TITLE
fix(wallet): use metamask:// scheme for mobile connect deep link

### DIFF
--- a/apps/kyberswap-interface/src/components/Header/web3/WalletModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/WalletModal/index.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro'
 import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
+import { isAndroid, isIOS } from 'react-device-detect'
 import { ChevronLeft } from 'react-feather'
 import { useConnect } from 'wagmi'
 
@@ -26,6 +27,13 @@ import {
 import { useIsAcceptedTerm } from 'state/user/hooks'
 import { ExternalLink } from 'theme'
 import { cn } from 'utils/cn'
+
+// Store page shown alongside the mobile "Open MetaMask" deep link, for users without the app.
+const METAMASK_STORE_URL = isAndroid
+  ? 'https://play.google.com/store/apps/details?id=io.metamask'
+  : isIOS
+  ? 'https://apps.apple.com/app/metamask/id1438144202'
+  : 'https://metamask.io/download/'
 
 export const CloseIcon = ({
   children,
@@ -169,6 +177,14 @@ export default function WalletModal() {
               className="w-full rounded-full bg-primary px-6 py-3 text-center text-base font-medium text-darkText hover:brightness-90"
             >
               <Trans>Open MetaMask</Trans>
+            </a>
+            <a
+              href={METAMASK_STORE_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-subText underline hover:text-text"
+            >
+              <Trans>No MetaMask app yet? Install it</Trans>
             </a>
           </ContentWrapper>
         ) : (

--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -463,17 +463,18 @@ export const wagmiConfig = createConfig({
         iconUrl: `${KYBERSWAP_URL}/favicon.svg`,
       },
       // The SDK calls this on a native mobile browser with the `metamask://connect/mwp?...`
-      // deep link, asynchronously after the relay handshake. We deliberately do NOT open it
-      // here: iOS won't resolve a Universal Link to the installed app when it's triggered from
-      // JS without a live user gesture (it lands on metamask.app.link → App Store, even when
-      // installed), and the `metamask://` scheme errors when the app isn't installed.
+      // deep link, asynchronously after the relay handshake. We surface it to the wallet modal
+      // rather than opening it here, so the user launches MetaMask with a real tap — a genuine
+      // gesture is the reliable way to open the app, and tapping a custom-scheme link keeps this
+      // page (and its open relay connection) alive so the pairing can complete on return.
       //
-      // Instead we surface the link to the wallet modal, which renders a real anchor the user
-      // taps. A genuine tap lets iOS open the installed MetaMask via the Universal Link, and
-      // fall back to the store when it isn't installed — handling both cases cleanly.
+      // Keep the `metamask://` custom scheme as-is: it carries the connection payload straight
+      // into the app, so MetaMask lands on the approval screen. Do NOT rewrite it to the
+      // `metamask.app.link` Universal Link — that domain is a Branch link that drops the query
+      // params, so the app opens to its home screen with no pairing request.
       mobile: {
         preferredOpenLink: deeplink => {
-          setMetaMaskMobileLink(deeplink.replace(/^metamask:\/\//, 'https://metamask.app.link/'))
+          setMetaMaskMobileLink(deeplink)
         },
       },
     }),


### PR DESCRIPTION
## Summary
- Pass the `metamask://connect/mwp` deep link to the wallet modal unchanged instead of rewriting it to the `metamask.app.link` Universal Link. The custom scheme carries the connection payload straight into MetaMask so it opens on the pairing/approval screen; the `metamask.app.link` (Branch) link drops the query params on the handoff, so the app opened to its home screen with no connection request.
- Add a platform-specific "Install MetaMask" store link (iOS App Store / Google Play / metamask.io) in the mobile "Open MetaMask" view, for users who don't have the app.
