### PR TITLE
refactor(wallet): align connect modal components

### DIFF
--- a/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
@@ -213,18 +213,18 @@ const DraggableNetworkButton = ({
           onClick={() => !selected && !dragging && handleChainSelect()}
           onMouseUp={e => e.preventDefault()}
           className={cn(
-            'group flex h-[60px] w-full cursor-pointer select-none items-center justify-center gap-1.5',
+            'group flex h-[54px] w-full cursor-pointer select-none items-center justify-center gap-1.5',
             'overflow-hidden whitespace-nowrap rounded-2xl bg-background p-3 text-sm text-subText',
             'transition-[background-color] duration-200 ease-in-out',
-            'max-sm:h-[54px] max-sm:p-2 max-sm:text-xs',
-            selected && '!bg-buttonBlack [&>div]:text-text',
+            'max-sm:p-2 max-sm:text-xs',
+            selected && '!bg-buttonBlack',
             disabled && '!cursor-not-allowed text-subText/40',
             !selected && !disabled && 'hover:bg-tableHeader',
           )}
         >
           <img src={icon} alt="Switch Network" className="size-5 min-w-5 rounded" />
-          <Row className="grow gap-1.5">
-            <span className="relative text-left">
+          <Row className={cn('grow gap-1.5', selected && 'text-text')}>
+            <span className="relative text-left font-medium">
               {name}
               {deprecatedSoon && (
                 <MaintainLabel style={{ position: 'absolute', top: '20%', right: '-90%' }}>Deprecating</MaintainLabel>
@@ -254,7 +254,7 @@ const DraggableNetworkButton = ({
             )}
           </Row>
           {!isMobile && (
-            <div className="hidden cursor-grab opacity-0 group-hover:block group-hover:opacity-100">
+            <div className="hidden cursor-grab text-border opacity-0 group-hover:flex group-hover:opacity-100">
               <Icon id="drag-indicator" className="text-border" />
             </div>
           )}

--- a/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DraggableNetworkButton.tsx
@@ -213,7 +213,7 @@ const DraggableNetworkButton = ({
           onClick={() => !selected && !dragging && handleChainSelect()}
           onMouseUp={e => e.preventDefault()}
           className={cn(
-            'group flex h-[54px] w-full cursor-pointer select-none items-center justify-center gap-1.5',
+            'group flex h-[54px] w-full cursor-pointer select-none items-center justify-center gap-1.5 outline-none',
             'overflow-hidden whitespace-nowrap rounded-2xl bg-background p-3 text-sm text-subText',
             'transition-[background-color] duration-200 ease-in-out',
             'max-sm:p-2 max-sm:text-xs',

--- a/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DropzoneOverlay.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/components/DropzoneOverlay.tsx
@@ -8,7 +8,7 @@ export default function DropzoneOverlay({ show, text }: { show: boolean; text: s
           initial={{ opacity: 0 }}
           animate={{ opacity: 0.8 }}
           exit={{ opacity: 0 }}
-          className="absolute inset-[-6px] z-[2] flex items-center justify-center rounded-lg bg-buttonBlack text-base font-medium"
+          className="absolute inset-[-6px] z-[2] flex items-center justify-center rounded-lg bg-buttonBlack text-sm font-medium"
           transition={{ duration: 0.15 }}
         >
           {text}

--- a/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/NetworkModal/index.tsx
@@ -116,8 +116,7 @@ export default function NetworkModal({
 
   const orders = allOrders.filter(item => activeChainIds.map(i => i.toString()).includes(item))
 
-  const isDraggingAddToFavorite =
-    draggingItem !== undefined && !favoriteChains.includes(draggingItem) && order === undefined
+  const isDraggingAddToFavorite = draggingItem !== undefined && !favoriteChains.includes(draggingItem)
   const isDraggingRemoveFavorite = favoriteChains.includes(draggingItem) && order === undefined
 
   const saveFavoriteChains = (chains: string[], updatedChain: string) => {
@@ -190,15 +189,15 @@ export default function NetworkModal({
     return (
       <>
         <Row className="gap-3">
-          <span className="flex-shrink-0 text-[10px] leading-6 text-subText">{title}</span>
+          <span className="flex-shrink-0 text-xs text-subText">{title}</span>
           <hr className="w-full border-0 border-b border-solid border-border" />
         </Row>
         <div className="relative mb-3 flex-grow">
           <DropzoneOverlay show={isDraggingRemoveFavorite} text={t`Remove from favorite`} />
           {displayChains.length === 0 ? (
             <Row className="min-h-[60px] justify-center rounded-2xl border border-dashed border-text/20 px-3 py-4">
-              <span className="text-[10px] leading-[14px] text-subText">
-                <Trans>Drag here to unfavorite chain(s).</Trans>
+              <span className="text-xs font-medium text-subText">
+                <Trans>Drag here to unfavorite chain(s)</Trans>
               </span>
             </Row>
           ) : (
@@ -248,7 +247,7 @@ export default function NetworkModal({
 
         <Column className="mt-4 grow gap-2">
           <Row className="gap-3">
-            <span className="flex-shrink-0 text-[10px] leading-6 text-subText">
+            <span className="flex-shrink-0 text-xs text-subText">
               <Trans>Favorite Chain(s)</Trans>
             </span>
             <hr className="w-full border-0 border-b border-solid border-border" />
@@ -258,7 +257,7 @@ export default function NetworkModal({
             {favoriteChains.filter(item => activeChainIds.map(i => i.toString()).includes(item)).length === 0 &&
             !isDraggingAddToFavorite ? (
               <Row className="min-h-[60px] justify-center rounded-2xl border border-dashed border-text/20 px-3 py-4">
-                <span className="text-[10px] leading-[14px] text-subText">
+                <span className="text-xs font-medium text-subText">
                   <Trans>Drag your favourite chain(s) here</Trans>
                 </span>
               </Row>

--- a/apps/kyberswap-interface/src/components/Header/web3/WalletModal/components.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/WalletModal/components.tsx
@@ -1,17 +1,116 @@
-import { t } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
+import dayjs from 'dayjs'
 import React, { useRef } from 'react'
+import { ChevronLeft } from 'react-feather'
 import { Connector, useConnect, useSwitchChain } from 'wagmi'
 
 import { NotificationType } from 'components/Announcement/type'
+import { RowBetween } from 'components/Row'
 import { CONNECTION, CONNECTOR_ICON_OVERRIDE_MAP } from 'components/Web3Provider'
+import { TERM_FILES_PATH } from 'constants/index'
 import { NETWORKS_INFO, isSupportedChainId } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
 import { useCloseModal, useNotify } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/types'
 import { useIsAcceptedTerm } from 'state/user/hooks'
+import { CloseIcon, ExternalLink } from 'theme'
 import { cn } from 'utils/cn'
 
-export const IconWrapper = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+export const Shell = ({ children, className, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex w-full flex-col flex-nowrap p-0', className)} {...rest}>
+    {children}
+  </div>
+)
+
+export const Section = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={cn('relative flex flex-col gap-6 p-5', className)}>{children}</div>
+)
+
+export const Content = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={cn('rounded-b-[20px]', className)}>{children}</div>
+)
+
+export const Header = ({
+  title,
+  onBack,
+  onClose,
+}: {
+  title: React.ReactNode
+  onBack?: () => void
+  onClose: () => void
+}) => (
+  <RowBetween className="gap-2">
+    {onBack && (
+      <div onClick={onBack} className="flex cursor-pointer items-center gap-1 text-xl font-medium hover:brightness-75">
+        <ChevronLeft className="text-primary" />
+      </div>
+    )}
+    <div className="flex flex-1 items-center gap-1 text-xl font-medium">{title}</div>
+    <CloseIcon onClick={onClose} />
+  </RowBetween>
+)
+
+type TermsProps =
+  | {
+      checked: boolean
+      onChange: (checked: boolean) => void
+      className?: string
+    }
+  | {
+      children: React.ReactNode
+      onClick?: () => void
+      className?: string
+      style?: React.CSSProperties
+    }
+
+export const Terms = (props: TermsProps) => {
+  const isControlled = 'checked' in props
+
+  return (
+    <div
+      onClick={isControlled ? () => props.onChange(!props.checked) : props.onClick}
+      style={isControlled ? undefined : props.style}
+      className={cn(
+        'flex cursor-pointer items-center gap-3 rounded-2xl bg-buttonBlack/30 px-3 py-2 text-xs font-medium leading-4 accent-primary hover:bg-buttonBlack/50',
+        props.className,
+      )}
+    >
+      {isControlled ? (
+        <>
+          <input
+            type="checkbox"
+            checked={props.checked}
+            onChange={() => {}}
+            data-testid="accept-term"
+            className="size-3.5 min-w-3.5 cursor-pointer"
+          />
+          <span className="text-subText">
+            <Trans>Accept </Trans>{' '}
+            <ExternalLink href={TERM_FILES_PATH.KYBERSWAP_TERMS} onClick={e => e.stopPropagation()}>
+              <Trans>KyberSwap&lsquo;s Terms of Use</Trans>
+            </ExternalLink>{' '}
+            <Trans>and</Trans>{' '}
+            <ExternalLink href={TERM_FILES_PATH.PRIVACY_POLICY} onClick={e => e.stopPropagation()}>
+              <Trans>Privacy Policy</Trans>
+            </ExternalLink>
+            {'. '}
+            <span className="text-[10px]">
+              <Trans>Last updated: {dayjs(TERM_FILES_PATH.VERSION).format('DD MMM YYYY')}</Trans>
+            </span>
+          </span>
+        </>
+      ) : (
+        props.children
+      )}
+    </div>
+  )
+}
+
+export const Options = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={cn('grid grid-cols-2 items-center gap-4 max-sm:grid-cols-1', className)}>{children}</div>
+)
+
+export const Icon = ({ children, className }: { children: React.ReactNode; className?: string }) => (
   <div
     className={cn(
       'flex items-center justify-center bg-transparent max-md:items-end',
@@ -23,18 +122,14 @@ export const IconWrapper = ({ children, className }: { children: React.ReactNode
   </div>
 )
 
-export const HeaderText = ({ children, className }: { children: React.ReactNode; className?: string }) => (
-  <div className={cn('flex flex-row flex-nowrap font-medium text-subText', className)}>{children}</div>
-)
-
-type OptionCardClickableProps = React.HTMLAttributes<HTMLDivElement> & {
+type OptionButtonProps = React.HTMLAttributes<HTMLDivElement> & {
   connected: boolean
   installLink?: string
   isDisabled?: boolean
   overridden?: boolean
 }
 
-export const OptionCardClickable = ({
+export const OptionButton = ({
   connected,
   installLink,
   isDisabled,
@@ -42,7 +137,7 @@ export const OptionCardClickable = ({
   className,
   children,
   ...props
-}: OptionCardClickableProps) => {
+}: OptionButtonProps) => {
   const disabled = isDisabled || installLink || overridden
   return (
     <div
@@ -50,10 +145,10 @@ export const OptionCardClickable = ({
       data-disabled={disabled || undefined}
       data-connected={!isDisabled && connected ? true : undefined}
       className={cn(
-        'group flex h-9 w-full flex-row items-center gap-2 overflow-hidden whitespace-nowrap rounded-[18px] bg-tableHeader px-2.5 py-2 text-sm',
-        'cursor-pointer hover:no-underline hover:brightness-90',
-        'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:grayscale',
-        'data-[connected=true]:!bg-primary',
+        'flex h-9 w-full flex-row items-center gap-2 overflow-hidden whitespace-nowrap rounded-full bg-transparent px-2.5 py-2 text-sm font-medium text-subText',
+        'cursor-pointer hover:bg-buttonBlack-60 hover:text-text hover:no-underline',
+        'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:text-border data-[disabled=true]:grayscale',
+        'data-[connected=true]:!bg-primary data-[connected=true]:!text-darkText',
         className,
       )}
     >
@@ -62,11 +157,7 @@ export const OptionCardClickable = ({
   )
 }
 
-export const OptionCardLeft = ({ children, className }: { children: React.ReactNode; className?: string }) => (
-  <div className={cn('flex h-full flex-col flex-nowrap justify-center', className)}>{children}</div>
-)
-
-const Option = ({ connector }: { connector: Connector }) => {
+export const WalletOption = React.memo(({ connector }: { connector: Connector }) => {
   const [isAcceptedTerm] = useIsAcceptedTerm()
 
   const { chainId } = useActiveWeb3React()
@@ -138,7 +229,7 @@ const Option = ({ connector }: { connector: Connector }) => {
   const isCurrentOptionPending = isSomeOptionPending && variables.connector === connector
 
   return (
-    <OptionCardClickable
+    <OptionButton
       role="button"
       id={`connect-${name}`}
       onClick={() => {
@@ -157,16 +248,10 @@ const Option = ({ connector }: { connector: Connector }) => {
       connected={isCurrentOptionPending}
       isDisabled={!isAcceptedTerm}
     >
-      <IconWrapper>
+      <Icon>
         <img src={icon} alt={'Icon'} />
-      </IconWrapper>
-      <OptionCardLeft>
-        <HeaderText className="group-hover:!text-text group-data-[connected=true]:!text-darkText group-data-[disabled=true]:!text-border">
-          {name}
-        </HeaderText>
-      </OptionCardLeft>
-    </OptionCardClickable>
+      </Icon>
+      <span>{name}</span>
+    </OptionButton>
   )
-}
-
-export default React.memo(Option)
+})

--- a/apps/kyberswap-interface/src/components/Header/web3/WalletModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/Header/web3/WalletModal/index.tsx
@@ -1,19 +1,22 @@
 import { Trans } from '@lingui/macro'
-import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { isAndroid, isIOS } from 'react-device-detect'
-import { ChevronLeft } from 'react-feather'
 import { useConnect } from 'wagmi'
 
-import { ReactComponent as Close } from 'assets/images/x.svg'
 import METAMASK_ICON from 'assets/wallets-connect/metamask.svg'
-import Option from 'components/Header/web3/WalletModal/Option'
+import {
+  Content,
+  Header,
+  Options,
+  Section,
+  Shell,
+  Terms,
+  WalletOption,
+} from 'components/Header/web3/WalletModal/components'
 import { useOrderedConnections } from 'components/Header/web3/WalletModal/useConnections'
 import Modal from 'components/Modal'
-import { RowBetween } from 'components/Row'
 import WalletPopup from 'components/WalletPopup'
 import { setMetaMaskMobileLink, useMetaMaskMobileLink } from 'components/Web3Provider/metamaskMobileLink'
-import { TERM_FILES_PATH } from 'constants/index'
 import { useActiveWeb3React } from 'hooks'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { ApplicationModal } from 'state/application/actions'
@@ -25,8 +28,6 @@ import {
   useWalletModalToggle,
 } from 'state/application/hooks'
 import { useIsAcceptedTerm } from 'state/user/hooks'
-import { ExternalLink } from 'theme'
-import { cn } from 'utils/cn'
 
 // Store page shown alongside the mobile "Open MetaMask" deep link, for users without the app.
 const METAMASK_STORE_URL = isAndroid
@@ -35,71 +36,16 @@ const METAMASK_STORE_URL = isAndroid
   ? 'https://apps.apple.com/app/metamask/id1438144202'
   : 'https://metamask.io/download/'
 
-export const CloseIcon = ({
-  children,
-  onClick,
-  className,
-}: {
-  children: React.ReactNode
-  onClick?: () => void
-  className?: string
-}) => (
-  <div onClick={onClick} className={cn('h-6 cursor-pointer self-end text-text hover:opacity-60', className)}>
-    {children}
-  </div>
-)
-
-export const ContentWrapper = ({ children, className }: { children: React.ReactNode; className?: string }) => (
-  <div className={cn('mt-4 gap-4 rounded-b-[20px]', className)}>{children}</div>
-)
-
-export const TermAndCondition = ({
-  children,
-  onClick,
-  className,
-  style,
-}: {
-  children: React.ReactNode
-  onClick?: () => void
-  className?: string
-  style?: React.CSSProperties
-}) => (
-  <div
-    onClick={onClick}
-    style={style}
-    className={cn(
-      'flex cursor-pointer items-center rounded-2xl bg-buttonBlack/30 p-2 text-xs font-medium leading-4 accent-primary hover:bg-buttonBlack/50',
-      className,
-    )}
-  >
-    {children}
-  </div>
-)
-
-export const UpperSection = ({ children, className }: { children: React.ReactNode; className?: string }) => (
-  <div className={cn('relative p-6', className)}>{children}</div>
-)
-
-export const OptionGrid = ({ children, className }: { children: React.ReactNode; className?: string }) => (
-  <div className={cn('grid grid-cols-2 items-center gap-4 max-sm:grid-cols-1', className)}>{children}</div>
-)
-
-const HoverText = ({
-  children,
-  onClick,
-  className,
-}: {
-  children: React.ReactNode
-  onClick?: () => void
-  className?: string
-}) => (
-  <div
-    onClick={onClick}
-    className={cn('flex cursor-pointer items-center gap-1 text-xl hover:cursor-pointer', className)}
-  >
-    {children}
-  </div>
-)
+export {
+  Content,
+  Header,
+  Icon,
+  OptionButton,
+  Options,
+  Section,
+  Shell,
+  Terms,
+} from 'components/Header/web3/WalletModal/components'
 
 export default function WalletModal() {
   const { isWrongNetwork, account } = useActiveWeb3React()
@@ -146,35 +92,34 @@ export default function WalletModal() {
   const [isPinnedPopupWallet, setPinnedPopupWallet] = useState(false)
 
   function getModalContent() {
+    const isConnectingBackVisible = isSomeOptionPending || isError
+
+    const handleAcceptTermChange = (checked: boolean) => {
+      if (checked && !isAcceptedTerm) {
+        trackingHandler(TRACKING_EVENT_TYPE.WALLET_CONNECT_ACCEPT_TERM_CLICK)
+      }
+      setIsAcceptedTerm(checked)
+    }
+
     return (
-      <UpperSection>
-        <RowBetween className="mb-[26px] gap-5">
-          {(isSomeOptionPending || isError) && (
-            <HoverText onClick={resetConnect} className="mr-4 flex-1">
-              <ChevronLeft className="text-primary" />
-            </HoverText>
-          )}
-          <HoverText>
-            {!isSomeOptionPending ? <Trans>Connect your Wallet</Trans> : <Trans>Connecting Wallet</Trans>}
-          </HoverText>
-          <CloseIcon
-            onClick={() => {
-              resetConnect()
-              toggleWalletModal()
-            }}
-          >
-            <Close />
-          </CloseIcon>
-        </RowBetween>
+      <Section>
+        <Header
+          title={!isSomeOptionPending ? <Trans>Connect your Wallet</Trans> : <Trans>Connecting Wallet</Trans>}
+          onBack={isConnectingBackVisible ? resetConnect : undefined}
+          onClose={() => {
+            resetConnect()
+            toggleWalletModal()
+          }}
+        />
         {metaMaskLink ? (
-          <ContentWrapper className="flex flex-col items-center gap-4 pb-1 pt-2 text-center">
+          <Content className="flex flex-col items-center gap-4 pb-1 pt-2 text-center">
             <img src={METAMASK_ICON} alt="MetaMask" className="size-12 rounded-lg" />
             <span className="text-sm text-subText">
               <Trans>Tap the button below to open the MetaMask app and approve the connection.</Trans>
             </span>
             <a
               href={metaMaskLink}
-              className="w-full rounded-full bg-primary px-6 py-3 text-center text-base font-medium text-darkText hover:brightness-90"
+              className="w-full rounded-full bg-primary py-2 text-center text-base font-medium !text-darkText hover:brightness-110"
             >
               <Trans>Open MetaMask</Trans>
             </a>
@@ -182,55 +127,24 @@ export default function WalletModal() {
               href={METAMASK_STORE_URL}
               target="_blank"
               rel="noreferrer"
-              className="text-xs text-subText underline hover:text-text"
+              className="text-sm font-medium text-subText underline"
             >
               <Trans>No MetaMask app yet? Install it</Trans>
             </a>
-          </ContentWrapper>
+          </Content>
         ) : (
-          <>
-            {isIdle && (
-              <TermAndCondition
-                onClick={() => {
-                  if (!isAcceptedTerm) {
-                    trackingHandler(TRACKING_EVENT_TYPE.WALLET_CONNECT_ACCEPT_TERM_CLICK)
-                  }
-                  setIsAcceptedTerm(!isAcceptedTerm)
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={isAcceptedTerm}
-                  onChange={() => {}}
-                  data-testid="accept-term"
-                  className="mr-3 size-3.5 min-w-3.5 cursor-pointer"
-                />
-                <span className="text-subText">
-                  <Trans>Accept </Trans>{' '}
-                  <ExternalLink href={TERM_FILES_PATH.KYBERSWAP_TERMS} onClick={e => e.stopPropagation()}>
-                    <Trans>KyberSwap&lsquo;s Terms of Use</Trans>
-                  </ExternalLink>{' '}
-                  <Trans>and</Trans>{' '}
-                  <ExternalLink href={TERM_FILES_PATH.PRIVACY_POLICY} onClick={e => e.stopPropagation()}>
-                    <Trans>Privacy Policy</Trans>
-                  </ExternalLink>
-                  {'. '}
-                  <span className="text-[10px]">
-                    <Trans>Last updated: {dayjs(TERM_FILES_PATH.VERSION).format('DD MMM YYYY')}</Trans>
-                  </span>
-                </span>
-              </TermAndCondition>
-            )}
-            <ContentWrapper>
-              <OptionGrid>
+          <div className="flex flex-col gap-4">
+            {isIdle && <Terms checked={isAcceptedTerm} onChange={handleAcceptTermChange} />}
+            <Content>
+              <Options>
                 {connectors.map(c => (
-                  <Option connector={c} key={c.uid} />
+                  <WalletOption connector={c} key={c.uid} />
                 ))}
-              </OptionGrid>
-            </ContentWrapper>
-          </>
+              </Options>
+            </Content>
+          </div>
         )}
-      </UpperSection>
+      </Section>
     )
   }
 
@@ -257,7 +171,7 @@ export default function WalletModal() {
       bypassFocusLock={true}
       zindex={99999}
     >
-      <div className="m-0 flex w-full flex-col flex-nowrap p-0">{getModalContent()}</div>
+      <Shell>{getModalContent()}</Shell>
     </Modal>
   )
 }

--- a/apps/kyberswap-interface/src/pages/Campaign/components/SelectChainModal.tsx
+++ b/apps/kyberswap-interface/src/pages/Campaign/components/SelectChainModal.tsx
@@ -1,9 +1,7 @@
 import { Trans } from '@lingui/macro'
 
-import { ReactComponent as Close } from 'assets/images/x.svg'
-import { CloseIcon } from 'components/Header/web3/WalletModal'
+import { Content, Header, Icon, OptionButton, Options, Section, Shell } from 'components/Header/web3/WalletModal'
 import Modal from 'components/Modal'
-import { RowBetween } from 'components/Row'
 
 export const SelectChainModal = ({
   showSelect,
@@ -16,46 +14,46 @@ export const SelectChainModal = ({
   setShowSelect: (show: boolean) => void
   logo: Record<string, string>
 }) => {
+  const closeModal = () => setShowSelect(false)
+  const chainOptions = Object.entries(logo)
+
   return (
     <Modal
       isOpen={showSelect}
-      onDismiss={() => setShowSelect(false)}
+      onDismiss={closeModal}
       maxHeight={90}
       maxWidth={600}
       bypassScrollLock={true}
       bypassFocusLock={true}
       zindex={99999}
-      width="240px"
+      width="min(430px, calc(100vw - 32px))"
     >
-      <div className="flex w-full flex-col p-6">
-        <RowBetween className="mb-6 gap-5">
-          <span className="text-xl font-medium">
-            <Trans>Select chain</Trans>
-          </span>
-          <CloseIcon
-            onClick={() => {
-              setShowSelect(false)
-            }}
-          >
-            <Close />
-          </CloseIcon>
-        </RowBetween>
+      <Shell>
+        <Section>
+          <Header title={<Trans>Select chain</Trans>} onClose={closeModal} />
 
-        {Object.keys(logo).map(walletType => (
-          <div
-            key={walletType}
-            role="button"
-            onClick={() => {
-              setShowSelect(false)
-              connect[walletType]()
-            }}
-            className="flex cursor-pointer items-center gap-2 rounded-[10px] p-3.5 font-medium hover:bg-buttonBlack"
-          >
-            <img src={logo[walletType]} width={20} height={20} alt="" style={{ borderRadius: '50%' }} />
-            <span>{walletType}</span>
-          </div>
-        ))}
-      </div>
+          <Content>
+            <Options>
+              {chainOptions.map(([walletType, icon]) => (
+                <OptionButton
+                  key={walletType}
+                  role="button"
+                  connected={false}
+                  onClick={() => {
+                    closeModal()
+                    connect[walletType]()
+                  }}
+                >
+                  <Icon>
+                    <img src={icon} alt={walletType} />
+                  </Icon>
+                  <span>{walletType}</span>
+                </OptionButton>
+              ))}
+            </Options>
+          </Content>
+        </Section>
+      </Shell>
     </Modal>
   )
 }

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/BitcoinConnectModal.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/BitcoinConnectModal.tsx
@@ -1,52 +1,15 @@
-import { Trans, t } from '@lingui/macro'
-import dayjs from 'dayjs'
-import { useEffect, useState } from 'react'
+import { t } from '@lingui/macro'
+import { useCallback, useEffect, useState } from 'react'
 
-import { ReactComponent as Close } from 'assets/images/x.svg'
 import { NotificationType } from 'components/Announcement/type'
-import {
-  CloseIcon,
-  ContentWrapper,
-  OptionGrid,
-  TermAndCondition,
-  UpperSection,
-} from 'components/Header/web3/WalletModal'
+import { Content, Header, Icon, OptionButton, Options, Section, Shell, Terms } from 'components/Header/web3/WalletModal'
 import Loader from 'components/Loader'
 import Modal from 'components/Modal'
-import { RowBetween } from 'components/Row'
 import { useBitcoinWallet } from 'components/Web3Provider/BitcoinProvider'
 import { DerivationPaths } from 'components/Web3Provider/BitcoinProvider/providers/ledger'
-import { TERM_FILES_PATH } from 'constants/index'
 import { useNotify } from 'state/application/hooks'
 import { useIsAcceptedTerm } from 'state/user/hooks'
-import { ExternalLink } from 'theme'
 import { cn } from 'utils/cn'
-
-const Option = ({
-  disabled,
-  selected,
-  children,
-  onClick,
-}: {
-  disabled?: boolean
-  selected?: boolean
-  children: React.ReactNode
-  onClick?: () => void
-}) => (
-  <div
-    role="button"
-    onClick={disabled ? undefined : onClick}
-    className={cn(
-      'flex h-9 w-full items-center justify-between gap-2 rounded-full bg-tableHeader px-2.5 py-2',
-      disabled || selected ? 'cursor-not-allowed' : 'cursor-pointer',
-      !disabled && 'hover:bg-[#171717] hover:!text-text hover:no-underline',
-      selected && 'bg-[#171717]',
-      disabled && 'text-border grayscale',
-    )}
-  >
-    {children}
-  </div>
-)
 
 export const BitcoinConnectModal = ({ isOpen, onDismiss }: { isOpen: boolean; onDismiss: () => void }) => {
   const [isAcceptedTerm, setIsAcceptedTerm] = useIsAcceptedTerm()
@@ -56,12 +19,24 @@ export const BitcoinConnectModal = ({ isOpen, onDismiss }: { isOpen: boolean; on
 
   const { walletInfo, availableWallets, connectingWallet, setConnectingWallet } = useBitcoinWallet()
 
+  const handleDismiss = useCallback(() => {
+    setConnectingWallet(null)
+    onDismiss()
+  }, [onDismiss, setConnectingWallet])
+
+  const handleHeaderClose = useCallback(() => {
+    if (showLedgerType) {
+      setShowLedgerType(false)
+      return
+    }
+    handleDismiss()
+  }, [handleDismiss, showLedgerType])
+
   useEffect(() => {
     if (walletInfo.isConnected) {
-      setConnectingWallet(null)
-      onDismiss()
+      handleDismiss()
     }
-  }, [walletInfo.isConnected, onDismiss, setConnectingWallet])
+  }, [handleDismiss, walletInfo.isConnected])
 
   if (walletInfo.isConnected) return null
 
@@ -70,10 +45,7 @@ export const BitcoinConnectModal = ({ isOpen, onDismiss }: { isOpen: boolean; on
   return (
     <Modal
       isOpen={isOpen}
-      onDismiss={() => {
-        setConnectingWallet(null)
-        onDismiss()
-      }}
+      onDismiss={handleDismiss}
       minHeight={false}
       maxHeight={90}
       maxWidth={600}
@@ -81,69 +53,25 @@ export const BitcoinConnectModal = ({ isOpen, onDismiss }: { isOpen: boolean; on
       bypassFocusLock={true}
       zindex={99999}
     >
-      <div className="m-0 flex w-full flex-col flex-nowrap p-0">
-        <UpperSection>
-          <RowBetween className="mb-[26px] gap-5">
-            <span className="text-xl font-medium">
-              {showLedgerType ? t`Select Derivation Path` : t`Connect your Bitcoin Wallet`}
-            </span>
-            <CloseIcon
-              onClick={() => {
-                if (showLedgerType) {
-                  setShowLedgerType(false)
-                  return
-                }
-                setConnectingWallet(null)
-                onDismiss()
-              }}
-            >
-              <Close />
-            </CloseIcon>
-          </RowBetween>
+      <Shell>
+        <Section>
+          <Header
+            title={showLedgerType ? t`Select Derivation Path` : t`Connect your Bitcoin Wallet`}
+            onClose={handleHeaderClose}
+          />
 
-          {!showLedgerType && (
-            <TermAndCondition
-              onClick={() => {
-                setIsAcceptedTerm(!isAcceptedTerm)
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={isAcceptedTerm}
-                onChange={() => {}}
-                data-testid="accept-term"
-                style={{ marginRight: '12px', height: '14px', width: '14px', minWidth: '14px', cursor: 'pointer' }}
-              />
-              <span className="text-subText">
-                <Trans>
-                  Accept{' '}
-                  <ExternalLink href={TERM_FILES_PATH.KYBERSWAP_TERMS} onClick={e => e.stopPropagation()}>
-                    KyberSwap&lsquo;s Terms of Use
-                  </ExternalLink>{' '}
-                  and{' '}
-                  <ExternalLink href={TERM_FILES_PATH.PRIVACY_POLICY} onClick={e => e.stopPropagation()}>
-                    Privacy Policy
-                  </ExternalLink>
-                  {'. '}
-                  <span className="text-[10px]">
-                    Last updated: {dayjs(TERM_FILES_PATH.VERSION).format('DD MMM YYYY')}
-                  </span>
-                </Trans>
-              </span>
-            </TermAndCondition>
-          )}
-
-          <ContentWrapper>
-            {showLedgerType ? (
-              <>
-                {Object.keys(DerivationPaths).map(item => {
+          {showLedgerType ? (
+            <Content>
+              <div className="flex flex-col gap-4">
+                {Object.entries(DerivationPaths).map(([name, path]) => {
                   return (
-                    <div
-                      key={item}
+                    <OptionButton
+                      key={name}
                       role="button"
-                      className="flex cursor-pointer items-center gap-1 py-3"
+                      connected={false}
+                      className="gap-2"
                       onClick={() => {
-                        ledgerWallet?.connect(DerivationPaths[item]).catch(error => {
+                        ledgerWallet?.connect(path).catch(error => {
                           console.log('Error connecting Ledger wallet:', error)
                           notify(
                             {
@@ -157,54 +85,58 @@ export const BitcoinConnectModal = ({ isOpen, onDismiss }: { isOpen: boolean; on
                         setShowLedgerType(false)
                       }}
                     >
-                      <img
-                        src="https://storage.googleapis.com/bitfi-static-35291d79/images/tokens/btc.svg"
-                        width={20}
-                        height={20}
-                      />
-                      <span className="ml-1.5 text-base font-medium">{item}</span>
-                      <span className="text-sm text-subText">{DerivationPaths[item]}</span>
-                    </div>
+                      <Icon>
+                        <img src="https://storage.googleapis.com/bitfi-static-35291d79/images/tokens/btc.svg" alt="" />
+                      </Icon>
+                      <span>{name}</span>
+                      <span className="truncate text-sm font-normal text-subText">{path}</span>
+                    </OptionButton>
                   )
                 })}
-              </>
-            ) : (
-              <OptionGrid>
-                {availableWallets.map(wallet => {
-                  return (
-                    <Option
-                      disabled={!isAcceptedTerm || (connectingWallet !== null && connectingWallet !== wallet.type)}
-                      selected={connectingWallet === wallet.type}
-                      key={wallet.type}
-                      onClick={() => {
-                        if (connectingWallet) return
-                        if (wallet.name === 'Ledger') {
-                          setShowLedgerType(true)
-                        } else wallet.connect()
-                      }}
-                    >
-                      <div className="flex w-full items-center gap-2">
-                        <img
-                          src={wallet.logo}
-                          alt=""
-                          width={20}
-                          height={20}
-                          style={{
-                            borderRadius: '50%',
-                          }}
-                        />
-                        <span className="flex flex-row flex-nowrap font-medium text-subText">{wallet.name}</span>
-                        {connectingWallet === wallet.type && <Loader className="text-white" />}
-                      </div>
-                      <span className="min-w-max text-xs text-subText">{wallet.isInstalled() && t`Detected`}</span>
-                    </Option>
-                  )
-                })}
-              </OptionGrid>
-            )}
-          </ContentWrapper>
-        </UpperSection>
-      </div>
+              </div>
+            </Content>
+          ) : (
+            <div className="flex flex-col gap-4">
+              <Terms checked={isAcceptedTerm} onChange={setIsAcceptedTerm} />
+              <Content>
+                <Options>
+                  {availableWallets.map(wallet => {
+                    const isConnecting = connectingWallet === wallet.type
+                    const isDisabled = !isAcceptedTerm || (connectingWallet !== null && !isConnecting)
+                    const handleConnect = () => {
+                      if (wallet.name === 'Ledger') {
+                        setShowLedgerType(true)
+                        return
+                      }
+                      wallet.connect()
+                    }
+
+                    return (
+                      <OptionButton
+                        key={wallet.type}
+                        role="button"
+                        onClick={isDisabled || isConnecting ? undefined : handleConnect}
+                        connected={isConnecting}
+                        isDisabled={isDisabled}
+                        className={cn('justify-between', isConnecting && 'cursor-not-allowed hover:brightness-100')}
+                      >
+                        <div className="flex w-full items-center gap-2">
+                          <Icon>
+                            <img src={wallet.logo} alt={wallet.name} />
+                          </Icon>
+                          <span>{wallet.name}</span>
+                          {isConnecting && <Loader className="text-white" />}
+                        </div>
+                        <span className="min-w-max text-xs font-normal">{wallet.isInstalled() && t`Detected`}</span>
+                      </OptionButton>
+                    )
+                  })}
+                </Options>
+              </Content>
+            </div>
+          )}
+        </Section>
+      </Shell>
     </Modal>
   )
 }

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SolanaConnectModal.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SolanaConnectModal.tsx
@@ -1,24 +1,18 @@
 import { t } from '@lingui/macro'
-import { Adapter, WalletReadyState } from '@solana/wallet-adapter-base'
+import { WalletReadyState } from '@solana/wallet-adapter-base'
 import { useWallet } from '@solana/wallet-adapter-react'
 import { useStandardWalletAdapters } from '@solana/wallet-standard-wallet-adapter-react'
-import dayjs from 'dayjs'
 import { useCallback, useMemo } from 'react'
 
-import { ReactComponent as Close } from 'assets/images/x.svg'
-import { ContentWrapper, OptionGrid } from 'components/Header/web3/WalletModal'
-import { HeaderText, IconWrapper, OptionCardClickable, OptionCardLeft } from 'components/Header/web3/WalletModal/Option'
+import { Content, Header, Icon, OptionButton, Options, Section, Shell, Terms } from 'components/Header/web3/WalletModal'
 import Modal from 'components/Modal'
-import { RowBetween } from 'components/Row'
-import { TERM_FILES_PATH } from 'constants/index'
-import { CloseIcon, TermAndCondition, UpperSection, Wrapper } from 'pages/CrossChainSwap/components/TermAndPolicy'
 import { useSolanaConnectModal } from 'pages/CrossChainSwap/provider/SolanaConnectModalProvider'
 import { useIsAcceptedTerm } from 'state/user/hooks'
-import { ExternalLink } from 'theme'
 
 const SolanaConnectModal = () => {
   const { isOpen, setIsOpen } = useSolanaConnectModal()
   const [isAcceptedTerm, setIsAcceptedTerm] = useIsAcceptedTerm()
+  const { select } = useWallet()
 
   const adaptersWithStandardAdapters = useStandardWalletAdapters([])
 
@@ -43,79 +37,46 @@ const SolanaConnectModal = () => {
       bypassFocusLock
       zindex={99999}
     >
-      <Wrapper>
-        <UpperSection>
-          <RowBetween className="mb-[26px] gap-5">
-            <span>{t`Connect your Wallet`}</span>
-            <CloseIcon onClick={handleClose}>
-              <Close />
-            </CloseIcon>
-          </RowBetween>
-          <TermAndCondition onClick={() => setIsAcceptedTerm(!isAcceptedTerm)}>
-            <input
-              type="checkbox"
-              checked={isAcceptedTerm}
-              onChange={() => {}}
-              data-testid="accept-term"
-              style={{ marginRight: '12px', height: '14px', width: '14px', minWidth: '14px', cursor: 'pointer' }}
-            />
-            <span className="text-subText">
-              <span>{t`Accept`}</span>{' '}
-              <ExternalLink href={TERM_FILES_PATH.KYBERSWAP_TERMS} onClick={e => e.stopPropagation()}>
-                <span>{t`KyberSwap's Terms of Use`}</span>
-              </ExternalLink>{' '}
-              <span>{t`and`}</span>{' '}
-              <ExternalLink href={TERM_FILES_PATH.PRIVACY_POLICY} onClick={e => e.stopPropagation()}>
-                <span>{t`Privacy Policy`}</span>
-              </ExternalLink>
-              {'. '}
-              <span className="text-[10px]">
-                {t`Last updated:`} {dayjs(TERM_FILES_PATH.VERSION).format('DD MMM YYYY')}
-              </span>
-            </span>
-          </TermAndCondition>
-          <ContentWrapper>
-            <OptionGrid>
-              {listedWallets.map(w => (
-                <Option key={w.name} wallet={w} onCloseModal={handleClose} />
-              ))}
-            </OptionGrid>
-          </ContentWrapper>
-        </UpperSection>
-      </Wrapper>
+      <Shell>
+        <Section>
+          <Header title={t`Connect your Wallet`} onClose={handleClose} />
+          <div className="flex flex-col gap-4">
+            <Terms checked={isAcceptedTerm} onChange={setIsAcceptedTerm} />
+            <Content>
+              {listedWallets.length ? (
+                <Options>
+                  {listedWallets.map(({ name, icon }) => (
+                    <OptionButton
+                      key={name}
+                      role="button"
+                      id={`solana-connect-${name}`}
+                      onClick={() => {
+                        if (isAcceptedTerm) {
+                          select(name)
+                          handleClose()
+                        }
+                      }}
+                      connected={false}
+                      isDisabled={!isAcceptedTerm}
+                    >
+                      <Icon>
+                        <img src={icon} alt={'Icon'} />
+                      </Icon>
+                      <span>{name}</span>
+                    </OptionButton>
+                  ))}
+                </Options>
+              ) : (
+                <div className="rounded-2xl bg-buttonBlack/30 px-3 py-4 text-center text-sm font-medium text-subText">
+                  {t`No Solana wallet detected`}
+                </div>
+              )}
+            </Content>
+          </div>
+        </Section>
+      </Shell>
     </Modal>
   )
-}
-
-const Option = ({ wallet, onCloseModal }: { wallet: Adapter; onCloseModal: () => void }) => {
-  const [isAcceptedTerm] = useIsAcceptedTerm()
-  const { select } = useWallet()
-
-  const { name, icon } = wallet
-
-  const content = (
-    <OptionCardClickable
-      role="button"
-      id={`solana-connect-${name}`}
-      onClick={() => {
-        if (isAcceptedTerm) {
-          select(name)
-          onCloseModal()
-        }
-      }}
-      connected={false}
-      isDisabled={!isAcceptedTerm}
-    >
-      <IconWrapper>
-        <img src={icon} alt={'Icon'} />
-      </IconWrapper>
-      <OptionCardLeft>
-        <HeaderText>{name}</HeaderText>
-      </OptionCardLeft>
-    </OptionCardClickable>
-  )
-
-  return content
 }
 
 export default SolanaConnectModal

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TermAndPolicy.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TermAndPolicy.tsx
@@ -1,44 +1,9 @@
 import { t } from '@lingui/macro'
-import dayjs from 'dayjs'
 
-import { ReactComponent as Close } from 'assets/images/x.svg'
 import { ButtonPrimary } from 'components/Button'
+import { Header, Section, Shell, Terms } from 'components/Header/web3/WalletModal'
 import Modal from 'components/Modal'
-import { RowBetween } from 'components/Row'
-import { TERM_FILES_PATH } from 'constants/index'
 import { useIsAcceptedTerm } from 'state/user/hooks'
-import { ExternalLink } from 'theme'
-import { cn } from 'utils/cn'
-
-export const Wrapper = ({ children, className, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('m-0 flex w-full flex-col flex-nowrap p-0', className)} {...rest}>
-    {children}
-  </div>
-)
-
-export const UpperSection = ({ children, className, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('relative p-6', className)} {...rest}>
-    {children}
-  </div>
-)
-
-export const CloseIcon = ({ children, className, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('h-6 cursor-pointer self-end text-text hover:opacity-60', className)} {...rest}>
-    {children}
-  </div>
-)
-
-export const TermAndCondition = ({ children, className, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      'flex cursor-pointer items-center rounded-2xl bg-buttonBlack-40 p-2 text-xs font-medium leading-4 accent-primary hover:bg-buttonBlack-60',
-      className,
-    )}
-    {...rest}
-  >
-    {children}
-  </div>
-)
 
 export default function TermAndPolicy({
   isOpen,
@@ -57,51 +22,24 @@ export default function TermAndPolicy({
       onDismiss={onClose}
       minHeight={false}
       maxHeight={90}
-      maxWidth={430}
+      maxWidth={600}
       bypassScrollLock
       bypassFocusLock
       zindex={99999}
     >
-      <Wrapper>
-        <UpperSection>
-          <RowBetween className="mb-[26px] gap-5">
-            <span>{t`Connect your Wallet`}</span>
-            <CloseIcon onClick={onClose}>
-              <Close />
-            </CloseIcon>
-          </RowBetween>
-          <TermAndCondition onClick={() => setIsAcceptedTerm(!isAcceptedTerm)}>
-            <input
-              type="checkbox"
-              checked={isAcceptedTerm}
-              onChange={() => {
-                // controlled — toggled via parent onClick
-              }}
-              data-testid="accept-term"
-              style={{ marginRight: '12px', height: '14px', width: '14px', minWidth: '14px', cursor: 'pointer' }}
-            />
-            <span className="text-subText">
-              <span>{t`Accept`}</span>{' '}
-              <ExternalLink href={TERM_FILES_PATH.KYBERSWAP_TERMS} onClick={e => e.stopPropagation()}>
-                <span>{t`KyberSwap's Terms of Use`}</span>
-              </ExternalLink>{' '}
-              <span>{t`and`}</span>{' '}
-              <ExternalLink href={TERM_FILES_PATH.PRIVACY_POLICY} onClick={e => e.stopPropagation()}>
-                <span>{t`Privacy Policy`}</span>
-              </ExternalLink>
-              {'. '}
-              <span className="text-[10px]">
-                {t`Last updated:`} {dayjs(TERM_FILES_PATH.VERSION).format('DD MMM YYYY')}
-              </span>
-            </span>
-          </TermAndCondition>
-          <div className="mt-6 flex justify-center">
-            <ButtonPrimary width={'120px'} disabled={!isAcceptedTerm} onClick={onConfirm}>
-              {t`Continue`}
-            </ButtonPrimary>
+      <Shell>
+        <Section>
+          <Header title={t`Connect your Wallet`} onClose={onClose} />
+          <div className="flex flex-col gap-4">
+            <Terms checked={isAcceptedTerm} onChange={setIsAcceptedTerm} />
+            <div className="flex justify-center">
+              <ButtonPrimary width="120px" className="py-2" disabled={!isAcceptedTerm} onClick={onConfirm}>
+                {t`Continue`}
+              </ButtonPrimary>
+            </div>
           </div>
-        </UpperSection>
-      </Wrapper>
+        </Section>
+      </Shell>
     </Modal>
   )
 }

--- a/apps/kyberswap-interface/src/pages/ElasticSnapshot/components/InstantClaimModal.tsx
+++ b/apps/kyberswap-interface/src/pages/ElasticSnapshot/components/InstantClaimModal.tsx
@@ -10,7 +10,7 @@ import { ButtonEmpty, ButtonOutlined, ButtonPrimary } from 'components/Button'
 import CurrencyLogo from 'components/CurrencyLogo'
 import Divider from 'components/Divider'
 import Dots from 'components/Dots'
-import { TermAndCondition } from 'components/Header/web3/WalletModal'
+import { Terms } from 'components/Header/web3/WalletModal'
 import InfoHelper from 'components/InfoHelper'
 import Modal from 'components/Modal'
 import { wagmiConfig } from 'components/Web3Provider'
@@ -303,7 +303,7 @@ export default function InstantClaimModal({ onDismiss, phase }: { onDismiss: () 
               need to Sign a message to confirm that you have read and accepted before claiming your assets.
             </div>
 
-            <TermAndCondition onClick={() => setIsAcceptTerm(prev => !prev)} className="mt-6 !bg-transparent !p-0">
+            <Terms onClick={() => setIsAcceptTerm(prev => !prev)} className="mt-6 !bg-transparent !p-0">
               <input
                 type="checkbox"
                 checked={isAcceptTerm}
@@ -313,7 +313,7 @@ export default function InstantClaimModal({ onDismiss, phase }: { onDismiss: () 
               <div>
                 Accept <ExternalLink href={ipfsLink}>KyberSwap’s Terms and Conditions</ExternalLink>
               </div>
-            </TermAndCondition>
+            </Terms>
             <div className="mt-6 flex gap-4">
               <ButtonOutlined
                 onClick={() => {

--- a/apps/kyberswap-interface/src/pages/ElasticSnapshot/components/VestingClaimModal.tsx
+++ b/apps/kyberswap-interface/src/pages/ElasticSnapshot/components/VestingClaimModal.tsx
@@ -7,7 +7,7 @@ import { useMedia } from 'react-use'
 import { NotificationType } from 'components/Announcement/type'
 import { ButtonEmpty, ButtonOutlined, ButtonPrimary } from 'components/Button'
 import Dots from 'components/Dots'
-import { TermAndCondition } from 'components/Header/web3/WalletModal'
+import { Terms } from 'components/Header/web3/WalletModal'
 import Modal from 'components/Modal'
 import { useActiveWeb3React, useWeb3React } from 'hooks'
 import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
@@ -182,7 +182,7 @@ export default function VestingClaimModal({
           to Sign a message to confirm that you have read and accepted before claiming your assets.
         </span>
 
-        <TermAndCondition onClick={() => setIsAcceptTerm(prev => !prev)} className="mt-6 !bg-transparent !p-0">
+        <Terms onClick={() => setIsAcceptTerm(prev => !prev)} className="mt-6 !bg-transparent !p-0">
           <input
             type="checkbox"
             checked={isAcceptTerm}
@@ -192,7 +192,7 @@ export default function VestingClaimModal({
           <span>
             Accept <ExternalLink href={tcLink}>KyberSwap’s Terms and Conditions</ExternalLink>
           </span>
-        </TermAndCondition>
+        </Terms>
         <div className="mt-6 flex gap-4">
           <ButtonOutlined
             onClick={() => {


### PR DESCRIPTION
## Summary
- Extract shared wallet modal shell, header, terms, and option components.
- Reuse the shared connect modal components across EVM, Bitcoin, Solana, campaign chain selection, and cross-chain terms flows.
- Update claim modals to use the shared terms wrapper.