### PR TITLE
chore(limit-order): track page viewed

### DIFF
--- a/apps/kyberswap-interface/src/components/LimitOrder/Form/LimitOrderForm.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/Form/LimitOrderForm.tsx
@@ -1,6 +1,6 @@
 import { Currency } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
-import { ReactNode, memo, useState } from 'react'
+import { ReactNode, memo, useEffect, useRef, useState } from 'react'
 
 import { ButtonLight, ButtonPrimary, ButtonWarning } from 'components/Button'
 import DateTimePicker from 'components/DateTimePicker'
@@ -22,6 +22,7 @@ import { useActiveWeb3React } from 'hooks'
 import { NETWORKS_INFO } from 'hooks/useChainsConfig'
 import usePageLocation from 'hooks/usePageLocation'
 import { restrictedTokenMessage, useIsTokenRestricted } from 'hooks/useRestrictedTokens'
+import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
 import ErrorWarning from 'pages/Bridge/ErrorWarning'
 import { useWalletModalToggle } from 'state/application/hooks'
@@ -67,8 +68,17 @@ const LimitOrderForm = ({ currencyIn: currencyInProp, currencyOut: currencyOutPr
   const { changeNetwork } = useChangeNetwork()
   const { account } = useActiveWeb3React()
   const { isEmbeddedSwap } = usePageLocation()
+  const { trackingHandler, isTrackingReady } = useTracking()
 
   const [showReview, setShowReview] = useState(false)
+  const trackedPageViewed = useRef(false)
+
+  useEffect(() => {
+    if (!isTrackingReady || trackedPageViewed.current) return
+
+    trackedPageViewed.current = true
+    trackingHandler(TRACKING_EVENT_TYPE.LO_PAGE_VIEWED)
+  }, [isTrackingReady, trackingHandler])
 
   const { currencyIn, currencyOut } = useLimitOrderCurrencies({
     currencyIn: currencyInProp,

--- a/apps/kyberswap-interface/src/hooks/useTracking.ts
+++ b/apps/kyberswap-interface/src/hooks/useTracking.ts
@@ -160,6 +160,7 @@ export enum TRACKING_EVENT_TYPE {
   ANNOUNCEMENT_CLICK_CLEAR_ALL_INBOXES,
 
   // Limit Order
+  LO_PAGE_VIEWED,
   LO_CLICK_PLACE_ORDER,
   LO_PLACE_ORDER_SUCCESS,
   LO_ENTER_DETAIL,
@@ -1172,6 +1173,10 @@ export default function useTracking(currencies?: { [field in Field]?: Currency }
           formoTrack('Gas refund - KNC Utility source click', { source })
           break
         }
+        case TRACKING_EVENT_TYPE.LO_PAGE_VIEWED: {
+          formoTrack('Limit Order Page Viewed')
+          break
+        }
         case TRACKING_EVENT_TYPE.LO_CLICK_PLACE_ORDER: {
           formoTrack('Limit Order - Place Order Click', payload)
           break
@@ -1838,7 +1843,7 @@ export default function useTracking(currencies?: { [field in Field]?: Currency }
     [currencies, account, mixpanel.hasOwnProperty('get_distinct_id'), formoTrack],
     /* eslint-enable */
   )
-  return { trackingHandler }
+  return { trackingHandler, isTrackingReady: !!analytics }
 }
 
 export const useGlobalTrackingEvents = () => {


### PR DESCRIPTION
## Summary
- Add the Limit Order page-view tracking event to the shared tracking handler
- Fire the event from the Limit Order form once tracking is ready