### PR TITLE
fix(swap): fill route token metadata

### DIFF
--- a/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
+++ b/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
@@ -20,7 +20,7 @@ import { MAX_FEE_IN_BIPS } from 'constants/index'
 import { SUPPORTED_NETWORKS } from 'constants/networks'
 import { DEFAULT_OUTPUT_TOKEN_BY_CHAIN, NativeCurrencies, PRICE_CHART_QUOTE_TOKEN_BY_CHAIN } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
-import { useAllTokens, useCurrencyV2 } from 'hooks/useTokens'
+import { useCurrencyV2 } from 'hooks/useTokens'
 import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
 import { BodyWrapper } from 'pages/AppBody'
 import CrossChainSwap from 'pages/CrossChainSwap'
@@ -37,7 +37,7 @@ import { useDegenModeManager, useUserSlippageTolerance, useUserTransactionTTL } 
 import { useCurrencyBalances } from 'state/wallet/hooks'
 import { ChargeFeeBy, DetailedRouteSummary } from 'types/route'
 import { isAddress } from 'utils'
-import { getTradeComposition } from 'utils/aggregationRouting'
+import { useTradeComposition } from 'utils/aggregationRouting'
 import { cn } from 'utils/cn'
 
 export const InfoComponents = ({ children }: { children: ReactNode[] }) => {
@@ -95,7 +95,6 @@ export default function PartnerSwap({ mode = 'partner' }: Props) {
   const { tipsId = '' } = useParams()
 
   const isUserSwap = mode === 'user'
-  const defaultTokens = useAllTokens()
 
   const { data: tipConfig } = useGetTipLinkQuery(tipsId, { skip: !isUserSwap || !tipsId })
   const appliedTipRef = useRef('')
@@ -206,10 +205,11 @@ export default function PartnerSwap({ mode = 'partner' }: Props) {
   const togglePricingChart = useCallback(() => setIsShowPricingChart(prev => !prev), [])
   const toggleTradeRoutes = useCallback(() => setIsShowTradeRoutes(prev => !prev), [])
 
-  const tradeRouteComposition = useMemo(
-    () => getTradeComposition(swapChainId, routeSummary?.parsedAmountIn, undefined, routeSummary?.route, defaultTokens),
-    [defaultTokens, routeSummary, swapChainId],
-  )
+  const tradeRouteComposition = useTradeComposition({
+    chainId: swapChainId,
+    inputAmount: routeSummary?.parsedAmountIn,
+    swaps: routeSummary?.route,
+  })
 
   const isSmartSettlementActive = useMemo(
     () => routeSummary?.route?.some(route => route.some(swap => swap.extra?._ce)),

--- a/apps/kyberswap-interface/src/pages/SwapV3/index.tsx
+++ b/apps/kyberswap-interface/src/pages/SwapV3/index.tsx
@@ -19,7 +19,6 @@ import { PRICE_CHART_QUOTE_TOKEN_BY_CHAIN } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import { NETWORKS_INFO } from 'hooks/useChainsConfig'
 import useParsedQueryString from 'hooks/useParsedQueryString'
-import { useAllTokens } from 'hooks/useTokens'
 import CrossChainSwap from 'pages/CrossChainSwap'
 import { CrossChainSwapSources } from 'pages/CrossChainSwap/components/CrossChainSwapSources'
 import QuoteSteps from 'pages/CrossChainSwap/components/QuoteSteps'
@@ -33,7 +32,7 @@ import { AppBodyWrapped, BannerWrapper, SwitchLocaleLinkWrapper } from 'pages/Sw
 import useCurrenciesByPage from 'pages/SwapV3/useCurrenciesByPage'
 import { useShowPricingChart, useShowTradeRoutes } from 'state/user/hooks'
 import { DetailedRouteSummary } from 'types/route'
-import { getTradeComposition } from 'utils/aggregationRouting'
+import { useTradeComposition } from 'utils/aggregationRouting'
 
 const InfoComponents = ({ children }: { children: ReactNode[] }) => {
   return children.filter(Boolean).length ? <InfoComponentsWrapper>{children}</InfoComponentsWrapper> : null
@@ -56,7 +55,6 @@ export default function Swap() {
   const { chainId } = useActiveWeb3React()
   const isShowPricingChart = useShowPricingChart()
   const isShowTradeRoutes = useShowTradeRoutes()
-  const defaultTokens = useAllTokens()
   const { currencies, currencyIn, currencyOut } = useCurrenciesByPage()
   const qs = useParsedQueryString<{ highlightBox: string }>()
   const [routeSummary, setRouteSummary] = useState<DetailedRouteSummary>()
@@ -110,9 +108,11 @@ export default function Swap() {
     }
   }, [tabFromUrl, searchParams, setSearchParams])
 
-  const tradeRouteComposition = useMemo(() => {
-    return getTradeComposition(chainId, routeSummary?.parsedAmountIn, undefined, routeSummary?.route, defaultTokens)
-  }, [chainId, defaultTokens, routeSummary])
+  const tradeRouteComposition = useTradeComposition({
+    chainId,
+    inputAmount: routeSummary?.parsedAmountIn,
+    swaps: routeSummary?.route,
+  })
 
   const isSmartSettlementActive = useMemo(
     () => routeSummary?.route?.some(route => route.some(swap => swap.extra?._ce)),

--- a/apps/kyberswap-interface/src/utils/aggregationRouting.ts
+++ b/apps/kyberswap-interface/src/utils/aggregationRouting.ts
@@ -1,9 +1,12 @@
 import { ZERO } from '@kyberswap/ks-sdk-classic'
 import { ChainId, Currency, CurrencyAmount, Percent, Rounding, Token, WETH } from '@kyberswap/ks-sdk-core'
 import JSBI from 'jsbi'
+import { useMemo } from 'react'
+import { useGetTokenByAddressesQuery } from 'services/ksSetting'
 
 import { ETHER_ADDRESS } from 'constants/index'
 import { NativeCurrencies } from 'constants/tokens'
+import { useAllTokens } from 'hooks/useTokens'
 import { isAddressString } from 'utils'
 
 export interface SwapPool {
@@ -45,6 +48,73 @@ export interface SwapRouteV3 {
   swapAmount: string
   amountOut: string
   exchange: string
+}
+
+type InvolvingTokens = { [address: string]: Token | undefined }
+
+type UseTradeCompositionArgs = {
+  chainId: ChainId
+  inputAmount: CurrencyAmount<Currency> | undefined
+  swaps: Swap[][] | undefined
+}
+
+export function useTradeComposition({
+  chainId,
+  inputAmount,
+  swaps,
+}: UseTradeCompositionArgs): SwapRouteV2[] | SwapRouteV3[] | undefined {
+  const allTokens = useAllTokens(false, chainId)
+
+  const routeTokenAddresses = useMemo(() => {
+    const addresses = new Map<string, string>()
+
+    swaps?.forEach(route => {
+      route.forEach(swap => {
+        const tokenAddresses = [swap.tokenIn, swap.tokenOut]
+
+        tokenAddresses.forEach(tokenAddress => {
+          const address = isAddressString(tokenAddress)
+          if (address && address.toLowerCase() !== ETHER_ADDRESS.toLowerCase()) {
+            addresses.set(address.toLowerCase(), address)
+          }
+        })
+      })
+    })
+
+    return Array.from(addresses.values())
+  }, [swaps])
+
+  const missingRouteTokenAddresses = useMemo(() => {
+    return routeTokenAddresses.filter(address => {
+      const formattedAddress = isAddressString(address)
+      return formattedAddress && !allTokens?.[formattedAddress] && !allTokens?.[formattedAddress.toLowerCase()]
+    })
+  }, [allTokens, routeTokenAddresses])
+
+  const { currentData: fetchedTokens = [] } = useGetTokenByAddressesQuery(
+    { chainId, addresses: missingRouteTokenAddresses },
+    { skip: !missingRouteTokenAddresses.length },
+  )
+
+  const involvingTokens = useMemo<InvolvingTokens>(() => {
+    const tokens: InvolvingTokens = {}
+
+    fetchedTokens.forEach(currency => {
+      const token = currency?.wrapped
+      const address = token && isAddressString(token.address)
+      if (!address) return
+
+      tokens[address] = token
+      tokens[address.toLowerCase()] = token
+    })
+
+    return tokens
+  }, [fetchedTokens])
+
+  return useMemo(
+    () => buildTradeComposition(chainId, inputAmount, involvingTokens, swaps, allTokens),
+    [allTokens, chainId, inputAmount, involvingTokens, swaps],
+  )
 }
 
 function formatRoutesV2(routes: SwapRoute[]): SwapRouteV2[] {
@@ -125,10 +195,10 @@ function formatRoutesV2(routes: SwapRoute[]): SwapRouteV2[] {
   }
 }
 
-export function getTradeComposition(
+function buildTradeComposition(
   chainId: ChainId,
   inputAmount: CurrencyAmount<Currency> | undefined,
-  involvingTokens: { [address: string]: Token | undefined } | undefined,
+  involvingTokens: InvolvingTokens | undefined,
   swaps: Swap[][] | undefined,
   allTokens: { [address: string]: Token } | undefined,
 ): SwapRouteV2[] | SwapRouteV3[] | undefined {


### PR DESCRIPTION
## Summary
- Move swap route composition into a hook that loads the active chain token list internally
- Fetch missing route token metadata before building trade route compositions
- Use the shared route composition hook in SwapV3 and PartnerSwap