### PR TITLE
chore(layout): polish app shell layout

### DIFF
--- a/apps/kyberswap-interface/index.html
+++ b/apps/kyberswap-interface/index.html
@@ -141,12 +141,21 @@
 
       .preloadhtml-header {
         display: flex;
+        align-items: center;
         gap: 12px;
         padding: 1rem;
         z-index: 2;
       }
 
       .preloadhtml-logo {
+        display: flex;
+        min-height: 48px;
+        align-items: center;
+
+        @media screen and (max-width: 768px) {
+          min-height: 36px;
+        }
+
         .kyber-logo {
           width: 140px;
           margin-top: -2px;
@@ -159,24 +168,29 @@
 
       .preloadhtml-header-link {
         display: flex;
+        flex-flow: row nowrap;
         gap: 4px;
         align-items: center;
+        justify-content: center;
+
+        @media screen and (max-width: 1200px) {
+          justify-content: flex-end;
+        }
 
         @media screen and (max-width: 992px) {
-          gap: 0px;
-          justify-content: flex-end;
           width: 100%;
-          height: 36px;
-          margin-top: 1px;
         }
       }
 
       .preloadhtml-header-link-item {
         font-size: 16px;
         font-weight: 500;
+        line-height: normal;
         display: flex;
         align-items: center;
         gap: 2px;
+        width: fit-content;
+        user-select: none;
       }
 
       .preloadhtml-header-link-item {
@@ -188,12 +202,27 @@
       }
 
       .preloadhtml-header-link-label {
-        display: flex;
+        display: inline-flex;
+        width: fit-content;
+        cursor: pointer;
         padding: 8px 12px;
 
         &:has(+ .preloadhtml-dropdown-icon) {
           padding: 8px 0px 8px 6px;
         }
+
+        @media screen and (max-width: 768px) {
+          &:not(:has(+ .preloadhtml-dropdown-icon)) {
+            padding-right: 6px;
+            padding-left: 6px;
+          }
+        }
+      }
+
+      .preloadhtml-earn-label {
+        display: flex;
+        align-items: center;
+        gap: 4px;
       }
 
       .preloadhtml-new-label {
@@ -202,8 +231,26 @@
         color: #ff537b;
       }
 
-      .mobile-hidden {
+      .hide-max-500 {
+        @media screen and (max-width: 500px) {
+          display: none;
+        }
+      }
+
+      .hide-max-576 {
+        @media screen and (max-width: 576px) {
+          display: none;
+        }
+      }
+
+      .hide-max-768 {
         @media screen and (max-width: 768px) {
+          display: none;
+        }
+      }
+
+      .hide-max-992 {
+        @media screen and (max-width: 992px) {
           display: none;
         }
       }
@@ -233,28 +280,32 @@
             <img class="preloadhtml-dropdown-icon" width="24px" src="/icons/down.svg" alt="downSvg" />
           </div>
           <div class="preloadhtml-header-link-item">
-            <img width="20px" src="/icons/kem.svg" alt="kemSvg" style="margin-left: 6px; margin-right: -4px" />
-            <div class="preloadhtml-header-link-label">Earn</div>
+            <div class="preloadhtml-header-link-label">
+              <span class="preloadhtml-earn-label">
+                <img width="20px" height="20px" src="/icons/kem.svg" alt="kemSvg" />
+                Earn
+              </span>
+            </div>
             <img class="preloadhtml-dropdown-icon" width="24px" src="/icons/down.svg" alt="downSvg" />
           </div>
-          <div class="preloadhtml-header-link-item mobile-hidden">
+          <div class="preloadhtml-header-link-item hide-max-576">
             <div class="preloadhtml-header-link-label">Market</div>
           </div>
-          <div class="preloadhtml-header-link-item mobile-hidden">
+          <div class="preloadhtml-header-link-item hide-max-500">
             <div class="preloadhtml-header-link-label">
               Campaigns
               <!-- <span class="preloadhtml-new-label">New</span> -->
             </div>
             <img class="preloadhtml-dropdown-icon" width="24px" src="/icons/down.svg" alt="downSvg" />
           </div>
-          <div class="preloadhtml-header-link-item mobile-hidden">
+          <div class="preloadhtml-header-link-item hide-max-992">
             <div class="preloadhtml-header-link-label">KyberDAO</div>
             <img class="preloadhtml-dropdown-icon" width="24px" src="/icons/down.svg" alt="downSvg" />
           </div>
-          <div class="preloadhtml-header-link-item mobile-hidden">
+          <div class="preloadhtml-header-link-item hide-max-992">
             <div class="preloadhtml-header-link-label">Analytics</div>
           </div>
-          <div class="preloadhtml-header-link-item mobile-hidden">
+          <div class="preloadhtml-header-link-item hide-max-768">
             <div class="preloadhtml-header-link-label">About</div>
             <img class="preloadhtml-dropdown-icon" width="24px" src="/icons/down.svg" alt="downSvg" />
           </div>

--- a/apps/kyberswap-interface/src/components/Footer/Footer.tsx
+++ b/apps/kyberswap-interface/src/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { Trans, t } from '@lingui/macro'
-import { useMedia } from 'react-use'
+import type { ComponentProps } from 'react'
 
 import ChainSecurity from 'assets/svg/chainsecurity.svg'
 import Hexens from 'assets/svg/hexens.svg'
@@ -11,85 +11,102 @@ import PoweredByIconDark from 'components/Icons/PoweredByIconDark'
 import TwitterIcon from 'components/Icons/TwitterIcon'
 import InfoHelper from 'components/InfoHelper'
 import { KYBER_NETWORK_DISCORD_URL, KYBER_NETWORK_TELEGRAM_URL, KYBER_NETWORK_TWITTER_URL } from 'constants/index'
-import { ExternalLink, ExternalLinkNoLineHeight } from 'theme'
+import { ExternalLink } from 'theme'
+import { cn } from 'utils/cn'
+
+const FooterLink = ({ className, ...props }: ComponentProps<typeof ExternalLink>) => (
+  <ExternalLink
+    className={cn(
+      '!text-subText no-underline transition hover:!text-subText hover:!no-underline hover:brightness-125 focus:!text-subText focus:!no-underline active:!text-subText active:!no-underline',
+      className,
+    )}
+    {...props}
+  />
+)
 
 export const FooterSocialLink = () => {
   return (
     <div className="flex items-center justify-center gap-6">
-      <ExternalLinkNoLineHeight href={KYBER_NETWORK_TELEGRAM_URL}>
+      <FooterLink href={KYBER_NETWORK_TELEGRAM_URL} className="leading-none">
         <Telegram size={16} className="text-subText" />
-      </ExternalLinkNoLineHeight>
-      <ExternalLinkNoLineHeight href={KYBER_NETWORK_TWITTER_URL}>
+      </FooterLink>
+      <FooterLink href={KYBER_NETWORK_TWITTER_URL} className="leading-none">
         <TwitterIcon className="text-subText" />
-      </ExternalLinkNoLineHeight>
-      <ExternalLinkNoLineHeight href={KYBER_NETWORK_DISCORD_URL}>
+      </FooterLink>
+      <FooterLink href={KYBER_NETWORK_DISCORD_URL} className="leading-none">
         <Discord width={16} height={12} className="text-subText" />
-      </ExternalLinkNoLineHeight>
+      </FooterLink>
     </div>
   )
 }
 
 function Footer() {
-  const above768 = useMedia('(min-width: 768px)')
-
   return (
-    <div className="w-full bg-buttonGray/20 max-lg:mb-16">
-      <div className="m-auto flex w-full flex-col-reverse items-center justify-between p-4 sm:flex-row [@media(min-width:1000px)]:px-8 [@media(min-width:1366px)]:px-[215px] [@media(min-width:1500px)]:px-[252px]">
-        <div className="flex gap-4 text-xs text-subText/20 max-sm:mt-4 max-sm:gap-6">
-          <div className="flex items-center text-subText max-sm:flex-col max-sm:gap-3">
-            <span className="mr-1.5">
+    <div className="w-full shrink-0 bg-buttonGray/20">
+      <div className="mx-auto flex w-full max-w-[1480px] flex-col-reverse items-center justify-between gap-4 p-4 sm:flex-row sm:px-6">
+        <div className="flex items-start gap-4 text-xs text-subText max-sm:gap-6 sm:items-center">
+          <div className="flex items-center gap-2 max-sm:flex-col max-sm:gap-3">
+            <span>
               <Trans>Powered By</Trans>
             </span>
-            <ExternalLink href="https://kyber.network" className="flex">
-              <PoweredByIconDark width={48} />
-            </ExternalLink>
+            <FooterLink href="https://kyber.network" className="flex">
+              <PoweredByIconDark height={36} />
+            </FooterLink>
           </div>
-          <div className="w-px bg-border max-sm:hidden" />
+          <div className="h-5 w-px bg-border max-sm:hidden" />
 
-          <div className="flex items-center text-subText max-sm:flex-col max-sm:gap-3">
-            <span className="mr-1.5 flex">
+          <div className="flex items-center gap-2 max-sm:flex-col max-sm:gap-3">
+            <span className="flex items-center gap-1">
               <Trans>
                 Audited{' '}
-                {above768 ? (
+                <span className="hidden sm:inline-flex">
                   <InfoHelper
                     size={14}
                     text={t`Covers smart-contracts`}
                     placement="top"
                     width="fit-content"
-                    style={{ marginRight: '4px' }}
+                    margin={false}
+                    className="hover:!opacity-100 hover:brightness-125 focus:!opacity-100"
                   />
-                ) : null}{' '}
+                </span>{' '}
                 By
               </Trans>
-              {!above768 && (
-                <InfoHelper size={14} text={t`Covers smart-contracts`} placement="top" width="fit-content" />
-              )}
+              <span className="sm:hidden">
+                <InfoHelper
+                  size={14}
+                  text={t`Covers smart-contracts`}
+                  placement="top"
+                  width="fit-content"
+                  margin={false}
+                  className="hover:!opacity-100 hover:brightness-125 focus:!opacity-100"
+                />
+              </span>
             </span>
             <img src={ChainSecurity} alt="" width="98px" />
-            {above768 && <span className="mx-1.5">&</span>}
-            <ExternalLink
+            <span className="max-sm:hidden">&</span>
+            <FooterLink
               href="https://omniscia.io/reports/kyber-network-uniswap-v4-hooks-68163cf266222800187026b8/"
-              className="flex items-center gap-1 no-underline"
+              className="flex items-center gap-1"
             >
               <img src={Omniscia} alt="" width={20} />
               <span className="text-subText">Omniscia</span>
-            </ExternalLink>
-            {above768 && <span className="mx-1.5">&</span>}
-            <ExternalLink
+            </FooterLink>
+            <span className="max-sm:hidden">&</span>
+            <FooterLink
               href="https://github.com/spearbit/portfolio/blob/master/pdfs/Kyber-Hook-Uniswap-Foundation-Spearbit-Security-Review-October-2025.pdf"
-              className="flex items-center gap-1 no-underline"
+              className="flex items-center gap-1"
             >
               <img src={Spearbit} alt="" className="h-5 w-auto" />
               <span className="text-subText">Spearbit</span>
-            </ExternalLink>
-            {above768 && <span className="mx-1.5">&</span>}
-            <ExternalLink
+            </FooterLink>
+            <span className="max-sm:hidden">&</span>
+            <FooterLink
               href="https://github.com/Hexens/Smart-Contract-Review-Public-Reports/blob/main/kyberswap-dec-25(Final).pdf"
-              className="flex items-center gap-1 no-underline"
+              className="flex items-center gap-1"
             >
               <img src={Hexens} alt="" className="h-5 w-auto" />
               <span className="text-subText">Hexens</span>
-            </ExternalLink>
+            </FooterLink>
           </div>
         </div>
         <FooterSocialLink />

--- a/apps/kyberswap-interface/src/components/Header/index.tsx
+++ b/apps/kyberswap-interface/src/components/Header/index.tsx
@@ -29,7 +29,9 @@ const LogoImage = ({ isChristmas, src, alt }: { isChristmas?: boolean; src: stri
 )
 
 const LogoIcon = ({ children }: { children: React.ReactNode }) => (
-  <div className="transition-transform duration-300 hover:rotate-[-5deg] max-xs:hover:rotate-0">{children}</div>
+  <div className="flex min-h-12 items-center transition-transform duration-300 hover:rotate-[-5deg] max-sm:min-h-9 max-xs:hover:rotate-0">
+    {children}
+  </div>
 )
 
 export default function Header() {
@@ -58,12 +60,10 @@ export default function Header() {
     <div
       style={{ zIndex: Z_INDEXS.HEADER }}
       className={cn(
-        'relative top-0 grid w-full items-center justify-between border-b border-black/10',
+        'relative top-0 grid w-full items-center justify-between',
         'grid-cols-[1fr_120px] flex-row p-4',
         'max-lg:grid-cols-[1fr]',
-        'max-xs:px-4 max-xs:py-2',
         hide && '!h-0 !overflow-hidden !p-0',
-        hide ? 'max-xs:!h-0' : 'max-xs:h-[60px]',
       )}
     >
       <div className="flex w-fit flex-row flex-nowrap items-center gap-3 justify-self-start max-md:w-full">
@@ -115,8 +115,7 @@ export default function Header() {
           'flex flex-row items-center gap-2 justify-self-end',
           'max-lg:fixed max-lg:bottom-0 max-lg:left-0 max-lg:z-[98] max-lg:h-[72px] max-lg:w-full',
           'max-lg:justify-between max-lg:justify-self-center max-lg:bg-buttonBlack max-lg:p-4',
-          'max-sm:h-[60px]',
-          'max-[500px]:px-2 max-[500px]:py-4',
+          'max-sm:h-[60px] max-sm:p-2',
         )}
       >
         {isEmbeddedSwap ? (

--- a/apps/kyberswap-interface/src/components/RouteFallback/index.tsx
+++ b/apps/kyberswap-interface/src/components/RouteFallback/index.tsx
@@ -41,13 +41,13 @@ const Cards = ({ count, height }: { count: number; height: number }) => (
 
 // Two-column swap page (max-w-1440, gap-12): the left column holds the tabs, subtitle and swap widget; the
 // right column holds the trending/farming pool cards, the price chart and the route bar. Below lg the right
-// column hides and the widget stays w-[425px] centered (full-width only on mobile) — mirroring the real
-// SwapFormWrapper (`w-[425px] max-sm:w-full`) + Container (`max-lg:items-center`). Fields use plain default
+// column hides and the widget stays capped at 425px centered — mirroring the real
+// SwapFormWrapper (`w-full max-w-[425px]`) + Container (`max-lg:items-center`). Fields use plain default
 // Skeletons on the page (no bg-background card wrapper) so the whole page's tone matches.
 const SwapPageSkeleton = () => (
   <div className="mx-auto w-full max-w-[1440px] px-6 pt-6 max-sm:px-4">
     <div className="flex gap-12 max-lg:flex-col max-lg:items-center max-lg:gap-6">
-      <div className="flex w-[425px] shrink-0 flex-col gap-4 max-sm:w-full">
+      <div className="flex w-full max-w-[425px] shrink-0 flex-col gap-4">
         {/* Tabs (Swap | Limit Order | Cross-Chain) on the left; info + settings icons aligned to the right. */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -106,12 +106,12 @@ const SwapPageSkeleton = () => (
 // PartnerSwap's InfoComponents render nothing until the price chart or trade-routes panel is toggled on,
 // which never happens on first paint. The form runs in omniView, so the card leads with the "Choose a chain"
 // network selector. Mirrors PartnerSwap's PageWrapper/Container (`justify-center`) + SwapFormWrapper
-// (`w-[425px] max-sm:w-full`); the column self-centers because the RouteFallback slot sits in an items-start
+// (`w-full max-w-[425px]`); the column self-centers because the RouteFallback slot sits in an items-start
 // AppWrapper.
 const PartnerSwapSkeleton = () => (
   <div className="mx-auto w-full max-w-[1464px] px-9 pt-6 max-sm:px-4 max-sm:py-5">
     <div className="flex justify-center">
-      <div className="flex w-[425px] shrink-0 flex-col gap-4 max-sm:w-full">
+      <div className="flex w-full max-w-[425px] shrink-0 flex-col gap-4">
         {/* Header: tabs (Swap | Limit Order | Cross-Chain) on the left, info + settings icons on the right,
             with the one-line subtitle below — grouped gap-2 to match the real Header's Stack. */}
         <div className="flex flex-col gap-2">
@@ -344,14 +344,9 @@ const pickSkeleton = (rawPathname: string) => {
 const RouteFallback = () => {
   const { pathname } = useLocation()
 
-  // The real pages render inside App's BodyWrapper (w-full, items-center). The Suspense fallback replaces
-  // those children, so it sits directly under AppWrapper (items-start) and would otherwise left-align.
-  // Mirror BodyWrapper here so every skeleton centers + reserves the same min-height as the loaded page.
-  return (
-    <div className="relative z-[1] flex min-h-[calc(100vh-148px)] w-full flex-1 flex-col items-center">
-      {pickSkeleton(pathname)}
-    </div>
-  )
+  // The real pages render inside App's BodyWrapper (w-full, flex-1, items-center). The Suspense fallback replaces
+  // those children, so it sits directly under AppWrapper (items-start) and would otherwise left-align/fail to fill.
+  return <div className="relative z-[1] flex w-full flex-1 flex-col items-center">{pickSkeleton(pathname)}</div>
 }
 
 export default RouteFallback

--- a/apps/kyberswap-interface/src/components/SupportButton.tsx
+++ b/apps/kyberswap-interface/src/components/SupportButton.tsx
@@ -89,14 +89,14 @@ export default function SupportButton() {
   if (isEmbeddedSwap) return null
 
   return (
-    <motion.div ref={supportButtonRef} className="fixed bottom-4 right-4 z-[1] max-lg:bottom-[75px]">
+    <motion.div ref={supportButtonRef} className="fixed bottom-4 right-4 z-[1] max-lg:bottom-[88px]">
       <button
         type="button"
         aria-expanded={isOpen}
         aria-label="Support"
         onClick={() => setIsOpen(open => !open)}
         className={cn(
-          'flex h-9 cursor-pointer items-center justify-center rounded-full border-0 bg-primary text-sm font-medium text-textReverse',
+          'flex h-9 cursor-pointer items-center justify-center rounded-full border-0 bg-primary text-sm font-medium text-textReverse hover:brightness-110',
           upToSmall ? 'w-9 p-0' : 'w-max px-3 py-0',
         )}
       >

--- a/apps/kyberswap-interface/src/components/swapv2/styleds.tsx
+++ b/apps/kyberswap-interface/src/components/swapv2/styleds.tsx
@@ -79,7 +79,7 @@ export function SwapCallbackError({ error, style = {} }: { error: string; style?
 export const SwapFormWrapper = ({ children, className, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'z-[1] flex w-[425px] flex-shrink-0 flex-col items-center justify-center gap-4 max-sm:w-full lg:sticky lg:top-4',
+      'z-[1] flex w-full max-w-[425px] flex-shrink-0 flex-col items-center justify-center gap-4 lg:sticky lg:top-4',
       className,
     )}
     {...rest}

--- a/apps/kyberswap-interface/src/pages/About/styleds.tsx
+++ b/apps/kyberswap-interface/src/pages/About/styleds.tsx
@@ -140,11 +140,7 @@ export const Footer = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement> 
   ({ className, background: _bg, ...rest }, ref) => (
     <div
       ref={ref}
-      className={cn(
-        'w-full bg-background [filter:drop-shadow(0px_-4px_16px_rgba(0,0,0,0.04))]',
-        'max-lg:mb-16',
-        className,
-      )}
+      className={cn('w-full shrink-0 bg-background [filter:drop-shadow(0px_-4px_16px_rgba(0,0,0,0.04))]', className)}
       {...rest}
     />
   ),

--- a/apps/kyberswap-interface/src/pages/App.tsx
+++ b/apps/kyberswap-interface/src/pages/App.tsx
@@ -2,7 +2,6 @@ import '@kyber/token-selector/styles.css'
 import '@kyber/ui/styles.css'
 import { Suspense, lazy, useEffect } from 'react'
 import { Navigate, Route, Routes, useLocation, useParams, useSearchParams } from 'react-router-dom'
-import { useNetwork, usePrevious } from 'react-use'
 
 import Popups from 'components/Announcement/Popups'
 import TopBanner from 'components/Announcement/Popups/TopBanner'
@@ -72,15 +71,15 @@ const PoolDetail = lazy(() => import('pages/Earns/PoolDetail'))
 const Recap2025Redirect = lazy(() => import('pages/Recap2025Redirect'))
 
 const AppWrapper = ({ children }: { children: React.ReactNode }) => (
-  <div className="flex flex-col items-start">{children}</div>
+  <div className="flex min-h-dvh w-full flex-col items-start max-lg:pb-[72px] max-sm:pb-[60px]">{children}</div>
 )
 
 const HeaderWrapper = ({ children }: { children: React.ReactNode }) => (
-  <div className="z-[3] flex w-full flex-row flex-nowrap justify-between">{children}</div>
+  <div className="z-[3] flex w-full shrink-0 flex-row flex-nowrap justify-between">{children}</div>
 )
 
 const BodyWrapper = ({ children }: { children: React.ReactNode }) => (
-  <div className="relative z-[1] flex min-h-[calc(100vh-148px)] w-full flex-1 flex-col items-center">{children}</div>
+  <div className="relative z-[1] flex w-full flex-1 flex-col items-center">{children}</div>
 )
 
 const preloadImages = () => {
@@ -196,31 +195,21 @@ const RoutesWithNetworkPrefix = () => {
 }
 
 export default function App() {
-  const { account, chainId } = useActiveWeb3React()
+  const { chainId } = useActiveWeb3React()
   const { pathname } = useLocation()
   const { isEmbeddedSwap } = usePageLocation()
-  useAutoLogin()
-  const { online } = useNetwork()
-  const prevOnline = usePrevious(online)
-  useSessionExpiredGlobal()
+  const dispatch = useAppDispatch()
+  const safeAppAcceptedTermOfUse = useAppSelector(state => state.user.safeAppAcceptedTermOfUse)
 
-  useEffect(() => {
-    if (prevOnline === false && online && account) {
-      // refresh page when network back to normal to prevent some issues: ex: stale data, ...
-      window.location.reload()
-    }
-  }, [online, prevOnline, account])
+  useAutoLogin()
+  useSessionExpiredGlobal()
+  useGlobalTrackingEvents()
 
   useEffect(() => {
     preloadImages()
   }, [])
 
-  useGlobalTrackingEvents()
   const showFooter = !pathname.includes(APP_PATHS.ABOUT) && !isEmbeddedSwap
-  // const [holidayMode] = useHolidayMode()
-
-  const safeAppAcceptedTermOfUse = useAppSelector(state => state.user.safeAppAcceptedTermOfUse)
-  const dispatch = useAppDispatch()
 
   return (
     <ErrorBoundary>
@@ -360,7 +349,6 @@ export default function App() {
             </Routes>
           </BodyWrapper>
           {showFooter && <Footer />}
-          {!showFooter && <div className="mb-16" />}
         </Suspense>
       </AppWrapper>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- Adjust app shell wrappers so page content and footer fill the viewport around the fixed mobile controls
- Align header/logo preload, footer responsiveness, and footer clickable hover states with the live layout
- Cap the swap form wrapper width with the form body and mirror that width in route fallbacks