### PR TITLE
hotfix(cross-chain): omit zero usd quote params

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
@@ -685,8 +685,8 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
         integrator: 'kyberswap',
         stream: 'true',
         slippage: params.slippage.toString(),
-        fromTokenUsd: params.tokenInUsd?.toString() || '0',
-        toTokenUsd: params.tokenOutUsd?.toString() || '0',
+        ...(params.tokenInUsd > 0 ? { fromTokenUsd: params.tokenInUsd.toString() } : {}),
+        ...(params.tokenOutUsd > 0 ? { toTokenUsd: params.tokenOutUsd.toString() } : {}),
       })
 
       // Add includedSources and excludedSources parameters


### PR DESCRIPTION
## Summary
- Omit token USD query params from cross-chain streaming quotes when their values are not positive
- Keep positive token USD values serialized in the quote request