### PR TITLE
chore(auth): remove oauth auto bootstrap

### DIFF
--- a/apps/kyberswap-interface/src/hooks/useLogin.tsx
+++ b/apps/kyberswap-interface/src/hooks/useLogin.tsx
@@ -313,29 +313,30 @@ const useLogin = (autoLogin = false) => {
   }
 }
 
+/**
+ * @deprecated OAuth/BFF profile auto bootstrap is no longer active. Keep explicit sign-in flows on `useLogin`.
+ */
 export const useAutoLogin = () => {
   const { signedMethod, signedAccount } = useSignedAccountInfo()
   const qs = useParsedQueryString()
   const { account } = useActiveWeb3React()
   const [isKeepCurrentProfile] = useIsKeepCurrentProfile()
-  const { signIn, checkSessionSignIn, signInAnonymous } = useLogin(true)
+  const { signIn, checkSessionSignIn } = useLogin(true)
+  const setLoading = useSetPendingAuthentication()
 
-  // auto try sign in when the first visit app, call once
+  // Complete the initial auth bootstrap without probing deprecated OAuth/BFF
+  // sessions on regular app loads.
   const isInit = useRef(false)
   useEffect(() => {
     if (isInit.current) return
     isInit.current = true
     if (qs.code) {
       // redirect from server
-      checkSessionSignIn(undefined)
+      checkSessionSignIn(undefined, false)
       return
     }
-    if (signedMethod === LoginMethod.ANONYMOUS) {
-      signInAnonymous(signedAccount)
-      return
-    }
-    checkSessionSignIn(signedAccount || undefined)
-  }, [checkSessionSignIn, signedAccount, signedMethod, signInAnonymous, qs.code])
+    setLoading(false)
+  }, [checkSessionSignIn, setLoading, qs.code])
 
   // auto sign in after connect wallet
   const [{ value: needSignInAfterConnectWallet, account: accountSignAfterConnectedWallet }, setAutoSignIn] =

--- a/apps/kyberswap-interface/src/pages/App.tsx
+++ b/apps/kyberswap-interface/src/pages/App.tsx
@@ -20,7 +20,6 @@ import SupportButton from 'components/SupportButton'
 import { APP_PATHS, CHAINS_SUPPORT_CROSS_CHAIN, TERM_FILES_PATH } from 'constants/index'
 import { CLASSIC_NOT_SUPPORTED, ELASTIC_NOT_SUPPORTED, NETWORKS_INFO, SUPPORTED_NETWORKS } from 'constants/networks'
 import { useActiveWeb3React } from 'hooks'
-import { useAutoLogin } from 'hooks/useLogin'
 import usePageLocation from 'hooks/usePageLocation'
 import useSessionExpiredGlobal from 'hooks/useSessionExpire'
 import { useGlobalTrackingEvents } from 'hooks/useTracking'
@@ -201,7 +200,6 @@ export default function App() {
   const dispatch = useAppDispatch()
   const safeAppAcceptedTermOfUse = useAppSelector(state => state.user.safeAppAcceptedTermOfUse)
 
-  useAutoLogin()
   useSessionExpiredGlobal()
   useGlobalTrackingEvents()
 

--- a/apps/kyberswap-interface/src/state/authen/reducer.ts
+++ b/apps/kyberswap-interface/src/state/authen/reducer.ts
@@ -27,7 +27,7 @@ const DEFAULT_AUTHEN_STATE: AuthenState = {
   anonymousUserInfo: undefined,
   signedUserInfo: undefined,
   isLogin: false,
-  pendingAuthentication: true,
+  pendingAuthentication: false,
   authenticationSuccess: false,
   isConnectingWallet: false,
   showConfirmProfile: false,


### PR DESCRIPTION
## Summary
- Remove the root app call to the deprecated OAuth auto-login bootstrap.
- Keep explicit sign-in flows on useLogin and mark useAutoLogin deprecated.
- Default auth pending state to false now that root auto bootstrap no longer clears it.