### PR TITLE
fix(limit-order): refine order table mobile layout

### DIFF
--- a/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/TableHeader.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/TableHeader.tsx
@@ -21,12 +21,12 @@ export const RowWrapper = ({ children, className, layout = RowWrapperLayout.HIST
   return (
     <div
       className={cn(
-        'grid items-center gap-x-4 gap-y-1 text-sm',
+        'grid items-center gap-x-4 gap-y-1 text-sm max-sm:gap-x-2 max-sm:px-3',
         isActiveLayout
           ? 'grid-cols-[44px_minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,1.4fr)_minmax(0,0.8fr)_60px]'
           : 'grid-cols-[44px_minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,0.8fr)_60px]',
-        'max-sm:grid-cols-[48px_minmax(0,1fr)_minmax(0,0.8fr)]',
-        isActiveLayout && 'max-sm:grid-cols-[48px_minmax(0,1fr)_minmax(0,0.8fr)_28px]',
+        'max-sm:grid-cols-[28px_minmax(0,1fr)_minmax(0,0.8fr)]',
+        isActiveLayout && 'max-sm:grid-cols-[28px_minmax(0,1fr)_minmax(0,0.8fr)_28px]',
         className,
       )}
     >
@@ -40,7 +40,7 @@ const TableHeader = ({ isActiveTab }: { isActiveTab?: boolean }) => (
     layout={isActiveTab ? RowWrapperLayout.ACTIVE : RowWrapperLayout.HISTORY}
     className="cursor-default bg-background px-4 py-3 text-xs font-medium uppercase tracking-[0.04em] text-subText"
   >
-    <span className="max-sm:row-span-2 max-sm:self-center">
+    <span className="max-sm:invisible max-sm:row-span-2 max-sm:self-center">
       <Trans>Chain</Trans>
     </span>
     <span className="justify-self-center text-center max-sm:justify-self-start max-sm:text-left">

--- a/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/components.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/MyOrders/components.tsx
@@ -58,7 +58,18 @@ export const TabSelector = ({ activeTab, setActiveTab }: TabSelectorProps) => (
           type="button"
         >
           <span className="text-base font-medium leading-[normal]" style={{ color: 'inherit' }}>
-            {tab === LimitOrderStatus.ACTIVE ? <Trans>Active Orders</Trans> : <Trans>Order History</Trans>}
+            {tab === LimitOrderStatus.ACTIVE ? (
+              <Trans>Active Orders</Trans>
+            ) : (
+              <>
+                <span className="max-sm:hidden">
+                  <Trans>Order History</Trans>
+                </span>
+                <span className="sm:hidden">
+                  <Trans>History</Trans>
+                </span>
+              </>
+            )}
           </span>
         </button>
       )

--- a/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/OrderRow.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/OrderRow.tsx
@@ -1,13 +1,11 @@
 import { Currency } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
 
-import CopyHelper from 'components/Copy'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { RowWrapper } from 'components/LimitOrder/OrderBook/TableHeader'
-import { ClippedText } from 'components/LimitOrder/components'
 import { LimitOrderFromTokenPairFormatted } from 'components/LimitOrder/types'
 import { formatRatePercentText } from 'components/LimitOrder/utils'
-import { NETWORKS_INFO } from 'hooks/useChainsConfig'
+import { HStack, Stack } from 'components/Stack'
 import { useLimitState } from 'state/limit/hooks'
 import { cn } from 'utils/cn'
 
@@ -17,32 +15,6 @@ const formatAmountWithSymbol = (amount: string, symbol?: string, amountPrefix?: 
 enum AmountSign {
   Plus = '+',
   Minus = '-',
-}
-
-type RateCellProps = {
-  order: LimitOrderFromTokenPairFormatted
-  className?: string
-  showInvertedRate?: boolean
-}
-
-const RateCell = ({ order, className, showInvertedRate }: RateCellProps) => {
-  const formattedRate = showInvertedRate ? order.formattedInvertedRate : order.formattedRate
-  const formattedMarketDiffPercent = showInvertedRate
-    ? order.formattedInvertedMarketDiffPercent
-    : order.formattedMarketDiffPercent
-
-  return (
-    <div className="flex w-full min-w-0 flex-col items-end gap-1 text-right">
-      <ClippedText className={cn('text-sm font-medium', className)} title={formattedRate}>
-        {formattedRate}
-      </ClippedText>
-      {formattedMarketDiffPercent && (
-        <div className="whitespace-nowrap text-xs text-subText">
-          {formatRatePercentText(formattedMarketDiffPercent)}
-        </div>
-      )}
-    </div>
-  )
 }
 
 type AmountTextProps = {
@@ -57,17 +29,17 @@ const AmountText = ({ amount, currency, amountPrefix, symbol }: AmountTextProps)
 
   return (
     <div
-      className="flex w-full min-w-0 items-center justify-end gap-1 text-right text-sm font-medium text-text"
+      className="flex w-full min-w-0 items-center justify-start gap-1 text-sm font-medium text-text"
       title={amount ? formatAmountWithSymbol(amount, displaySymbol, amountPrefix) : undefined}
     >
       {amount ? (
         <>
           {currency && (
-            <span className="hidden shrink-0 max-sm:flex">
+            <span className="flex shrink-0">
               <CurrencyLogo currency={currency} size="16px" />
             </span>
           )}
-          <span className="min-w-0 overflow-hidden whitespace-nowrap text-left">
+          <span className="min-w-0 overflow-hidden whitespace-nowrap">
             {amountPrefix}
             {amount}
           </span>
@@ -83,59 +55,92 @@ const AmountText = ({ amount, currency, amountPrefix, symbol }: AmountTextProps)
 type SizeCellProps = {
   amount: string
   currency?: Currency
+  amountPrefix: AmountSign
   filledPercentText: string
   filledProgressPercent: number
 }
 
-const SizeCell = ({ amount, currency, filledPercentText, filledProgressPercent }: SizeCellProps) => {
+const SizeCell = ({ amount, currency, amountPrefix, filledPercentText, filledProgressPercent }: SizeCellProps) => {
   const symbol = currency?.wrapped.symbol
 
   return (
-    <div
-      className={cn(
-        'grid w-full min-w-0 items-start gap-x-2 gap-y-1 text-left',
-        currency ? 'grid-cols-[16px_minmax(0,1fr)]' : 'grid-cols-[minmax(0,1fr)]',
-      )}
-    >
+    <HStack className="w-full min-w-0 items-start gap-1">
       {currency && (
-        <span className="row-span-2 flex size-4 self-center">
+        <HStack className="h-5 shrink-0 items-center">
           <CurrencyLogo currency={currency.wrapped} size="16px" />
-        </span>
+        </HStack>
       )}
-      <div
-        className="flex min-w-0 items-center justify-start gap-1 text-left text-sm font-medium text-text"
-        title={formatAmountWithSymbol(amount, symbol, AmountSign.Minus)}
-      >
-        <span className="min-w-0 overflow-hidden whitespace-nowrap text-left">
-          {AmountSign.Minus}
-          {amount}
-        </span>
-        {symbol && <span className="shrink-0 whitespace-nowrap">{symbol}</span>}
-      </div>
-      <div className="flex min-w-0 items-center justify-start gap-1 text-xs text-subText">
-        <span className="min-w-12 whitespace-nowrap text-left">
-          <Trans>Fill</Trans> {filledPercentText}%
-        </span>
-        <span className="h-1 w-12 shrink-0 overflow-hidden rounded-full bg-subText-40">
-          <span
-            className="block h-full rounded-full bg-primary"
-            style={{ width: `${Math.min(filledProgressPercent, 100)}%` }}
-          />
-        </span>
-      </div>
-    </div>
+      <Stack className="min-w-0 gap-1 max-sm:gap-y-0">
+        <HStack
+          className="min-w-0 items-center gap-1 text-sm font-medium text-text"
+          title={formatAmountWithSymbol(amount, symbol, amountPrefix)}
+        >
+          <span className="min-w-0 overflow-hidden whitespace-nowrap">
+            {amountPrefix}
+            {amount}
+          </span>
+          {symbol && <span className="shrink-0 whitespace-nowrap">{symbol}</span>}
+        </HStack>
+        <HStack className="min-w-0 items-center gap-1 text-xs text-subText max-sm:hidden">
+          <span className="min-w-12 whitespace-nowrap">
+            <Trans>Fill</Trans> {filledPercentText}%
+          </span>
+          <span className="h-1 w-12 shrink-0 overflow-hidden rounded-full bg-subText-40">
+            <span
+              className="block h-full rounded-full bg-primary"
+              style={{ width: `${Math.min(filledProgressPercent, 100)}%` }}
+            />
+          </span>
+        </HStack>
+      </Stack>
+    </HStack>
   )
 }
 
 const AvailableCell = ({ amount, symbol }: { amount?: string; symbol?: string }) => (
-  <div className="min-w-0 max-sm:col-start-3 max-sm:row-start-2">
+  <div className="w-full min-w-0 max-sm:col-start-2 max-sm:row-start-1">
     <AmountText amount={amount} symbol={symbol} />
   </div>
 )
 
-const TotalCell = ({ amount, currency }: { amount?: string; currency?: Currency }) => (
-  <div className="min-w-0 max-sm:col-start-2 max-sm:row-start-2 [&>div]:max-sm:justify-start [&>div]:max-sm:text-left">
-    <AmountText amount={amount} currency={currency} amountPrefix={AmountSign.Plus} />
+type RateCellProps = {
+  order: LimitOrderFromTokenPairFormatted
+  className?: string
+  showInvertedRate?: boolean
+}
+
+const RateCell = ({ order, className, showInvertedRate }: RateCellProps) => {
+  const formattedRate = showInvertedRate ? order.formattedInvertedRate : order.formattedRate
+  const formattedMarketDiffPercent = showInvertedRate
+    ? order.formattedInvertedMarketDiffPercent
+    : order.formattedMarketDiffPercent
+
+  return (
+    <div className="flex w-full min-w-0 flex-col items-start gap-1 max-sm:flex-row max-sm:items-center">
+      <span
+        className={cn('block min-w-0 max-w-full overflow-hidden whitespace-nowrap text-sm font-medium', className)}
+        title={formattedRate}
+      >
+        {formattedRate}
+      </span>
+      {formattedMarketDiffPercent && (
+        <div className="whitespace-nowrap text-xs text-subText">
+          {formatRatePercentText(formattedMarketDiffPercent)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+type TotalCellProps = {
+  amount?: string
+  currency?: Currency
+  amountPrefix: AmountSign
+}
+
+const TotalCell = ({ amount, currency, amountPrefix }: TotalCellProps) => (
+  <div className="w-full min-w-0 max-sm:col-start-1 max-sm:row-start-2">
+    <AmountText amount={amount} currency={currency} amountPrefix={amountPrefix} />
   </div>
 )
 
@@ -149,34 +154,31 @@ type OrderRowProps = {
 const OrderRow = ({ reverse = false, order, onTake, showInvertedRate }: OrderRowProps) => {
   const { currencyIn: makerCurrency, currencyOut: takerCurrency } = useLimitState()
 
-  const chain = NETWORKS_INFO[order.chainId]
   const filledPercent = Math.max(0, Math.min(Number(order.filledPercent) || 0, 100))
-  const sizeAmount = order.formattedMakerAmount
-  const availableAmount = order.formattedAvailableMakerAmount
-  const totalAmount = order.formattedTakerAmount
-  const sizeCurrency = !reverse ? makerCurrency : takerCurrency
-  const totalCurrency = !reverse ? takerCurrency : makerCurrency
+  const sizeAmount = reverse ? order.formattedTakerAmount : order.formattedMakerAmount
+  const availableAmount = reverse ? order.formattedAvailableTakerAmount : order.formattedAvailableMakerAmount
+  const totalAmount = reverse ? order.formattedMakerAmount : order.formattedTakerAmount
+  const sizeAmountPrefix = reverse ? AmountSign.Plus : AmountSign.Minus
+  const totalAmountPrefix = reverse ? AmountSign.Minus : AmountSign.Plus
 
   return (
-    <RowWrapper className="min-h-14 px-4 py-2 max-sm:min-h-[84px] max-sm:grid-rows-[40px_24px]">
-      <span className="flex items-center justify-center max-sm:row-start-1">
-        <img className="size-5" src={chain?.icon} alt="Network" />
-      </span>
+    <RowWrapper className="px-4 py-2 max-sm:gap-y-0">
       <SizeCell
         amount={sizeAmount}
-        currency={sizeCurrency}
+        currency={makerCurrency}
+        amountPrefix={sizeAmountPrefix}
         filledPercentText={filledPercent.toString()}
         filledProgressPercent={filledPercent}
       />
-      <AvailableCell amount={availableAmount} symbol={sizeCurrency?.wrapped.symbol} />
-      <div className="min-w-0 max-sm:col-start-3 max-sm:row-start-1">
+      <AvailableCell amount={availableAmount} symbol={makerCurrency?.wrapped.symbol} />
+      <div className="w-full min-w-0 max-sm:col-start-2 max-sm:row-start-2">
         <RateCell order={order} className={reverse ? 'text-primary' : 'text-red'} showInvertedRate={showInvertedRate} />
       </div>
-      <TotalCell amount={totalAmount} currency={totalCurrency} />
-      <span className="justify-self-end max-sm:hidden">
-        <CopyHelper toCopy={String(order.id)} margin="0" size={16} className="justify-self-end text-subText" />
-      </span>
-      <div className="justify-self-end max-sm:col-start-1 max-sm:row-start-2 max-sm:justify-self-center">
+      <TotalCell amount={totalAmount} currency={takerCurrency} amountPrefix={totalAmountPrefix} />
+      <Stack className="gap-1 max-sm:col-start-3 max-sm:row-span-2 max-sm:row-start-1">
+        <span className="hidden whitespace-nowrap text-xs text-subText max-sm:block">
+          <Trans>Fill</Trans> {filledPercent.toString()}%
+        </span>
         {order.hasAvailable && (
           <button
             type="button"
@@ -186,7 +188,7 @@ const OrderRow = ({ reverse = false, order, onTake, showInvertedRate }: OrderRow
             <Trans>Take</Trans>
           </button>
         )}
-      </div>
+      </Stack>
     </RowWrapper>
   )
 }

--- a/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/TableHeader.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/TableHeader.tsx
@@ -7,7 +7,7 @@ import { cn } from 'utils/cn'
 export const RowWrapper = ({ children, className, ...rest }: HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'grid grid-cols-[44px_minmax(0,1.2fr)_minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1.4fr)_48px_88px] items-center gap-x-4 gap-y-1 text-sm max-sm:grid-cols-[48px_minmax(0,1fr)_minmax(0,0.8fr)]',
+      'grid grid-cols-[minmax(0,1.2fr)_minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1.4fr)_64px] gap-x-4 gap-y-1 text-sm max-sm:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)_56px]',
       className,
     )}
     {...rest}
@@ -18,27 +18,21 @@ export const RowWrapper = ({ children, className, ...rest }: HTMLAttributes<HTML
 
 const TableHeader = () => {
   return (
-    <RowWrapper className="cursor-default bg-background px-4 py-3 text-xs font-medium uppercase tracking-[0.04em] text-subText">
-      <span className="max-sm:row-span-2 max-sm:self-center">
-        <Trans>Chain</Trans>
-      </span>
-      <span className="justify-self-center text-center max-sm:justify-self-start max-sm:text-left">
+    <RowWrapper className="cursor-default bg-background px-4 py-3 text-xs font-medium uppercase text-subText">
+      <span className="w-full max-sm:col-start-1 max-sm:row-start-1">
         <Trans>Size</Trans>
       </span>
-      <span className="flex gap-1 justify-self-end text-right max-sm:col-start-3 max-sm:row-start-2">
+      <span className="flex w-full gap-1 max-sm:col-start-2 max-sm:row-start-1">
         <Trans>Available</Trans>
         <InfoHelper margin={false} size={14} text={<Trans>Amount available to be filled.</Trans>} />
       </span>
-      <span className="justify-self-end text-right max-sm:col-start-3 max-sm:row-start-1">
+      <span className="w-full max-sm:col-start-2 max-sm:row-start-2">
         <Trans>Rate</Trans>
       </span>
-      <span className="justify-self-end text-right max-sm:col-start-2 max-sm:row-start-2 max-sm:justify-self-start max-sm:text-left">
+      <span className="w-full max-sm:col-start-1 max-sm:row-start-2">
         <Trans>Total</Trans>
       </span>
-      <span className="justify-self-end text-right max-sm:hidden">
-        <Trans>ID</Trans>
-      </span>
-      <span className="justify-self-end text-right max-sm:hidden">
+      <span className="max-sm:hidden">
         <Trans>Action</Trans>
       </span>
     </RowWrapper>

--- a/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/index.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/index.tsx
@@ -37,9 +37,12 @@ const NoDataPanel = () => (
 )
 
 const SectionLabel = ({ color, label, symbol }: { color: string; label: React.ReactNode; symbol?: string }) => (
-  <div className="border-b border-border/20 px-4 py-3 text-sm font-medium tracking-[0.08em]" style={{ color }}>
-    {label} <span className="text-text">{symbol}</span>
-  </div>
+  <>
+    <div className="px-4 py-3 text-sm font-medium tracking-[0.08em]" style={{ color }}>
+      {label} <span className="text-text">{symbol}</span>
+    </div>
+    <hr style={{ borderColor: color, opacity: 0.2 }} />
+  </>
 )
 
 const OrderSide = ({ children, reverse }: { children: React.ReactNode; reverse?: boolean }) => {
@@ -47,7 +50,7 @@ const OrderSide = ({ children, reverse }: { children: React.ReactNode; reverse?:
 }
 
 const OrderBook = () => {
-  const { chainId, networkInfo } = useActiveWeb3React()
+  const { chainId } = useActiveWeb3React()
   const { setPriceInputRequest } = useLimitOrderContext()
   const { currencyIn: makerCurrency, currencyOut: takerCurrency } = useLimitState()
   const { isStableCoin } = useStableCoins(chainId)
@@ -191,19 +194,16 @@ const OrderBook = () => {
       </OrderSide>
 
       <RowWrapper className="bg-background px-4 py-3 text-xl font-medium leading-6">
-        <span className="flex items-center justify-center">
-          <img className="size-5" src={networkInfo?.icon} alt="Network" />
-        </span>
-        <button
-          type="button"
-          className="col-start-4 justify-self-end border-none bg-transparent p-0 text-right text-inherit hover:brightness-75 max-sm:col-start-2"
-          onClick={handleSetMarketRate}
-          disabled={!marketRate || !invertRate}
-          aria-label="Set market rate"
-        >
-          {displayedMarketRate ? formatDisplayNumber(displayedMarketRate, { significantDigits: 6 }) : '--'}
-        </button>
-        <span className="col-start-5 justify-self-start max-sm:col-start-3">
+        <div className="col-span-2 col-start-3 flex min-w-0 items-center gap-4 max-sm:col-span-2 max-sm:col-start-2">
+          <button
+            type="button"
+            className="border-none bg-transparent p-0 text-left text-inherit hover:brightness-75"
+            onClick={handleSetMarketRate}
+            disabled={!marketRate || !invertRate}
+            aria-label="Set market rate"
+          >
+            {displayedMarketRate ? formatDisplayNumber(displayedMarketRate, { significantDigits: 6 }) : '--'}
+          </button>
           <button
             type="button"
             className="flex items-center gap-1 border-none bg-transparent p-0 text-sm transition hover:brightness-75"
@@ -213,8 +213,8 @@ const OrderBook = () => {
             <span>{displayedRatePair}</span>
             <Repeat size={14} />
           </button>
-        </span>
-        <div className="col-start-7 justify-self-end max-sm:hidden">
+        </div>
+        <div className="col-start-5 justify-self-center max-sm:hidden">
           <RefreshLoading clickable refetchLoading={refetchLoading} onRefresh={onRefreshOrders} />
         </div>
       </RowWrapper>


### PR DESCRIPTION
## Summary
- Adjust OrderBook columns and row cells for desktop and mobile layouts
- Update OrderBook amount display, action column, and market price controls
- Tighten My Orders mobile spacing, chain/action columns, and history tab label