### PR TITLE
fix(earn): stop decimal.js-light precision leak crashing recharts (#3246)

### DIFF
--- a/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/utils.ts
+++ b/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/utils.ts
@@ -65,11 +65,15 @@ export const formatOrders = (
       const takerCurrencyAmount = CurrencyAmount.fromRawAmount(newTakerCurrency, order.takingAmount)
       const availableMakerCurrencyAmount = CurrencyAmount.fromRawAmount(newMakerCurrency, order.availableMakingAmount)
 
+      // Cap the significant digits well below decimal.js-light's LN10 limit (~110): Fraction.toSignificant
+      // mutates the shared global Decimal.precision, and recharts reuses the same singleton for axis ticks —
+      // leaving precision high there makes every chart throw `LN10 precision limit exceeded`. 30 digits keep
+      // full double precision for the rate, which is only parseFloat'd and re-formatted to 6 figures downstream.
       const rate = (
         !reverse
           ? takerCurrencyAmount.divide(makerCurrencyAmount).multiply(makerCurrencyAmount.decimalScale)
           : makerCurrencyAmount.divide(takerCurrencyAmount).multiply(takerCurrencyAmount.decimalScale)
-      ).toSignificant(100)
+      ).toSignificant(30)
 
       const filledMakingAmount = CurrencyAmount.fromRawAmount(newMakerCurrency, order.filledMakingAmount)
       const filledPercent = (parseFloat(filledMakingAmount.toExact()) / parseFloat(makerCurrencyAmount.toExact())) * 100

--- a/apps/kyberswap-interface/src/components/SwapForm/OutputCurrencyPanel.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/OutputCurrencyPanel.tsx
@@ -6,7 +6,7 @@ import { useMedia } from 'react-use'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import Skeleton from 'components/Skeleton'
 import { TextHelper } from 'components/Text'
-import { CHAINS_SUPPORT_FEE_CONFIGS, RESERVE_USD_DECIMALS } from 'constants/index'
+import { CHAINS_SUPPORT_FEE_CONFIGS } from 'constants/index'
 import { useActiveWeb3React } from 'hooks'
 import { WrapType } from 'hooks/useWrapCallback'
 import { MEDIA_WIDTHS } from 'theme'
@@ -49,7 +49,7 @@ const OutputCurrencyPanel: React.FC<Props> = ({
       return parsedAmountIn?.toExact() || ''
     }
     if (!parsedAmountOut) return ''
-    return parsedAmountOut.toSignificant(RESERVE_USD_DECIMALS)
+    return parsedAmountOut.toExact()
   }
 
   const getEstimatedUsd = () => {

--- a/apps/kyberswap-interface/src/components/SwapForm/SwapModal/SwapBrief.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/SwapModal/SwapBrief.tsx
@@ -8,7 +8,7 @@ import Skeleton from 'components/Skeleton'
 import { Stack } from 'components/Stack'
 import { useSwapFormContext } from 'components/SwapForm/SwapFormContext'
 import UpdatedBadge, { Props as UpdatedBadgeProps } from 'components/SwapForm/SwapModal/SwapDetails/UpdatedBadge'
-import { CHAINS_SUPPORT_FEE_CONFIGS, RESERVE_USD_DECIMALS } from 'constants/index'
+import { CHAINS_SUPPORT_FEE_CONFIGS } from 'constants/index'
 import { useActiveWeb3React } from 'hooks'
 import { formatDisplayNumber } from 'utils/numbers'
 
@@ -44,11 +44,7 @@ export default function SwapBrief({
       return <span className="min-w-0 flex-1 truncate text-2xl font-medium">--</span>
     }
 
-    return (
-      <span className="min-w-0 flex-1 truncate text-2xl font-medium">
-        {outputAmountFromBuild.toSignificant(RESERVE_USD_DECIMALS)}
-      </span>
-    )
+    return <span className="min-w-0 flex-1 truncate text-2xl font-medium">{outputAmountFromBuild.toExact()}</span>
   }
 
   const renderAmountOutUsd = () => {

--- a/apps/kyberswap-interface/src/components/SwapForm/SwapModal/SwapDetails/UpdatedBadge.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/SwapModal/SwapDetails/UpdatedBadge.tsx
@@ -2,7 +2,6 @@ import { Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
 
 import InfoHelper from 'components/InfoHelper'
-import { RESERVE_USD_DECIMALS } from 'constants/index'
 import { cn } from 'utils/cn'
 
 export type Level = 'better' | 'worse' | 'worst' | undefined
@@ -19,7 +18,7 @@ const LEVEL_CLASS: Record<NonNullable<Level>, string> = {
 }
 
 export default function UpdatedBadge({ $level, outputAmount }: Props) {
-  const output = `${outputAmount.toSignificant(RESERVE_USD_DECIMALS)} ${outputAmount.currency.symbol}`
+  const output = `${outputAmount.toExact()} ${outputAmount.currency.symbol}`
 
   if (!$level) {
     return null

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/SparklineChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/SparklineChart.tsx
@@ -91,11 +91,7 @@ const SparklineChart = ({
           dateLabel: today.subtract(totalPoints - 1 - index, 'day').format('MMM D'),
           value: shouldInvert && value > 0 ? 1 / value : value,
         }))
-        // Drop non-finite values (NaN, ±Infinity) before recharts touches them.
-        // Recharts uses decimal.js internally to compute YAxis tick spacing and
-        // throws `[DecimalError] LN10 precision limit exceeded` when it tries to
-        // take `log()` of an infinite/NaN value — taking the whole /earn page
-        // down via the error boundary.
+        // Keep only finite values so recharts never sees NaN/±Infinity in the series.
         .filter(point => Number.isFinite(point.value))
     )
   }, [normalizedSparkline, shouldInvert])

--- a/apps/kyberswap-interface/src/services/route/utils.ts
+++ b/apps/kyberswap-interface/src/services/route/utils.ts
@@ -32,7 +32,7 @@ const calculateFee = (
   return {
     currency: currencyAmountToTakeFee.currency,
     currencyAmount: feeCurrencyAmount,
-    formattedAmount: formattedNum(feeCurrencyAmount.toSignificant(RESERVE_USD_DECIMALS), false),
+    formattedAmount: formattedNum(feeCurrencyAmount.toExact(), false),
     formattedAmountUsd: feeAmountUsd && feeAmountUsd !== '0' ? formattedNum(feeAmountUsd, true, 4) : '',
   }
 }

--- a/apps/kyberswap-interface/src/utils/fee.ts
+++ b/apps/kyberswap-interface/src/utils/fee.ts
@@ -43,7 +43,7 @@ export const calculateFeeFromBuildData = (
   const feeUsd = buildData.feeUsd
 
   return {
-    feeAmount: formatDisplayNumber(feeCurrencyAmount.toSignificant(RESERVE_USD_DECIMALS), { significantDigits: 10 }),
+    feeAmount: formatDisplayNumber(feeCurrencyAmount.toExact(), { significantDigits: 10 }),
     feeAmountUsd:
       feeUsd && feeUsd !== '0' ? formatDisplayNumber(feeUsd, { style: 'currency', significantDigits: 10 }) : '',
     currencyAmount: feeCurrencyAmount,


### PR DESCRIPTION
## Problem

Fixes #3246 — `/earn/pools` (and any recharts chart) intermittently crashes with:

```
Error: [DecimalError] LN10 precision limit exceeded
    at Object.pI [as getDigitCount] (generateCategoricalChart-*.js)
```

## Root cause

`@kyberswap/ks-sdk-core`'s `Fraction.toSignificant(n)` calls `Decimal.set({ precision: n + 1 })` on the **shared `decimal.js-light` singleton** and never restores it. `recharts` (via `recharts-scale`) reuses that **same singleton** to compute Y-axis tick spacing (`getDigitCount → Decimal.log(10)`).

Once the leaked global precision passes ~99, `decimal.js-light`'s bundled `LN10` constant (115 significant digits) is too short and `getLn10` throws `LN10 precision limit exceeded`. The error boundary then takes down the whole `/earn` page.

Reproduced end-to-end with the repo's own libraries: any `toSignificant(≥98)` (we had several `toSignificant(100)` / `toSignificant(RESERVE_USD_DECIMALS)` sites) leaves precision at 101, and the next chart to render crashes. It's intermittent because it's order-dependent global state — most `toSignificant` calls use small counts that reset precision back down.

## Fix

Route the "full precision" formatters off `toSignificant(100)`:

- **CurrencyAmount amount displays** → `toExact()` (Big.js-backed, no `decimal.js-light` leak). Provably the same string as `toSignificant(100)` — on-chain amounts are `uint256` (≤ 78 significant digits < 100), so `toSignificant(100)` never rounded them.
- **OrderBook `rate`** (a *fractional* `CurrencyAmount`) → `toSignificant(30)`. Here `toExact()` would floor the ratio to whole taker-wei (tiny rates → `"0"`) and `toFixed(100)` violates `CurrencyAmount`'s `decimals` invariant, so neither is valid. `toSignificant(30)` keeps full double precision for the `parseFloat` / 6-figure display downstream while capping global precision at 31 — comfortably below recharts' ~99 limit.
- Corrected the misleading `SparklineChart` comment (filtering non-finite values is *not* what prevents the crash; recharts already guards non-finite domains).

Because the leak is fixed at the source, **all** recharts charts in the app are protected at once — not just the Earn sparkline.

## Verification

- End-to-end repro with the real `ks-sdk-core` + `recharts-scale`: after the swap/limit/fee flows run with the new code, global precision stays ≤ 31 and charts render fine; the old `toSignificant(100)` still reproduces the crash.
- Compared `toExact()` vs `toSignificant(100)` across 12 realistic + edge `CurrencyAmount`s (0/6/8/18/27 decimals, 1 wei, uint256-max): 0 string differences. Fee `bps` branch (fractional) is display-identical at 10 significant figures.
- Compared OrderBook `toSignificant(30)` vs `toSignificant(100)` across realistic token-pair rates: identical `parseFloat` and 6-figure output in every case.
- `pnpm exec eslint` clean; `tsc --noEmit` 0 errors.

## No behavior change

Displayed numbers (swap output, fee amounts, limit-order rate) are unchanged — only the internal precision path differs.