### PR TITLE
fix(swap): prevent infinite loop in trade route graph for cyclic routes

### DIFF
--- a/apps/kyberswap-interface/src/components/TradeRouting/TradeRouteV3.tsx
+++ b/apps/kyberswap-interface/src/components/TradeRouting/TradeRouteV3.tsx
@@ -129,6 +129,12 @@ const TradeRouteV3: React.FC<SwapRouteV3Props> = ({ tradeComposition, tokenIn })
   const maximumPathLengths: { [key: string]: number } = {}
   maximumPathLengths[tokenIn.address] = 0
   const queue = [tokenIn.address]
+  // The aggregator can return routes whose token graph contains a cycle (e.g. a same-token swap
+  // such as ETH→WETH routed WETH→X→WETH). A simple path across `nodes.length` distinct tokens spans
+  // at most `nodes.length - 1` edges, so relaxation must stop there: without this bound the
+  // "longer path" check below keeps re-enqueuing cycle nodes with an ever-increasing length and the
+  // loop never terminates, hard-freezing the whole tab.
+  const maxPathLength = nodes.length
   while (queue.length) {
     const currentNode = queue.shift() as string // Use shift() for BFS
     const currentLength = maximumPathLengths[currentNode] || 0
@@ -138,8 +144,11 @@ const TradeRouteV3: React.FC<SwapRouteV3Props> = ({ tradeComposition, tokenIn })
       const targetAddress = neighbor.target.address
       const newLength = currentLength + 1
 
-      // If we found a longer path to this node
-      if (maximumPathLengths[targetAddress] === undefined || newLength > maximumPathLengths[targetAddress]) {
+      // Relax to a longer path, but never beyond a simple path's length (cycle guard)
+      if (
+        newLength <= maxPathLength &&
+        (maximumPathLengths[targetAddress] === undefined || newLength > maximumPathLengths[targetAddress])
+      ) {
         maximumPathLengths[targetAddress] = newLength
         queue.push(targetAddress) // Add back to the queue to find potentially longer paths from it
       }

--- a/apps/kyberswap-interface/src/hooks/useWrapCallback.ts
+++ b/apps/kyberswap-interface/src/hooks/useWrapCallback.ts
@@ -52,7 +52,10 @@ export default function useWrapCallback(
   const notify = useNotify()
 
   return useMemo(() => {
-    if (!wethAddress || !inputCurrency || !outputCurrency || !account) return NOT_APPLICABLE
+    // Detect wrap/unwrap independently of wallet connection so the UI shows the 1:1 wrap
+    // immediately and skips the aggregator route path even before an account connects; only
+    // `execute` (which sends the transaction) requires an account.
+    if (!wethAddress || !inputCurrency || !outputCurrency) return NOT_APPLICABLE
 
     const sufficientBalance = inputAmount && balance && !balance.lessThan(inputAmount)
 
@@ -62,7 +65,7 @@ export default function useWrapCallback(
       return {
         wrapType: WrapType.WRAP,
         execute:
-          sufficientBalance && inputAmount
+          account && sufficientBalance && inputAmount
             ? async () => {
                 try {
                   const txReceipt = await sendEVMTransaction({
@@ -121,7 +124,7 @@ export default function useWrapCallback(
       return {
         wrapType: WrapType.UNWRAP,
         execute:
-          sufficientBalance && inputAmount
+          account && sufficientBalance && inputAmount
             ? async () => {
                 try {
                   const txReceipt = await sendEVMTransaction({


### PR DESCRIPTION
## Summary

Fixes a **hard full-screen freeze** in the swap box: on Optimism, selecting the pair **ETH → WETH** hangs the whole tab (no rate, nothing clickable). The renderer is locked by a **synchronous infinite loop**, not a slow API.

This PR contains two commits:
1. **Root fix** — cycle guard in the trade-route graph (stops the freeze for *any* cyclic route).
2. **Complementary hardening** — detect ETH↔WETH wrap without a connected wallet (keeps this pair off the aggregator route path entirely).

---

## 1. Root cause — infinite loop in `TradeRouteV3`

`TradeRouteV3` assigns each token a "level" for the left-to-right route layout by computing the longest path from the input token with a re-enqueuing BFS (Bellman–Ford-style relaxation). That only terminates for a **DAG**.

For **ETH → WETH** the input and output resolve to the **same token** (WETH), so the aggregator returns a route whose token graph contains a **cycle** — a `WETH → WETH` self-loop (`wrapped-native`), or `WETH → X → WETH`. Around a cycle, `newLength = currentLength + 1` strictly increases every pass, so the "found a longer path" check is always true, the node is re-enqueued forever, `queue.length` never reaches `0`, and the synchronous render never returns → the entire renderer freezes (no React "Maximum update depth" error, because it is a plain `while` loop, not a re-render storm).

### Why it looked Optimism-specific

The freeze mechanism exists on **every** chain, but it only runs when the **Route** panel is mounted (expanded). The panel's default state is:

```ts
defaultCollapsed = hasSupportedTokenPriceChart && isShowPricingChart // isShowPricingChart defaults to true
```

`PRICE_CHART_QUOTE_TOKEN_BY_CHAIN` only lists **Ethereum, BSC, Base, Arbitrum, Monad**. On those chains the price chart shows and the Route panel is **collapsed by default**, so `TradeRouteV3` never mounts on load. On **Optimism** (and every other chain not in that map) there is no supported price chart, so the Route panel is **expanded by default** and the loop runs **on page load** → freeze.

> On Base/Arbitrum the same pair freezes too if you manually expand the **Route** panel — the difference is purely the default collapsed/expanded state.

### Fix

Bound the relaxation to a simple path's maximum length. A simple path over `nodes.length` distinct tokens spans at most `nodes.length - 1` edges, so stop relaxing/re-enqueuing once `newLength` exceeds `nodes.length`. This is the standard Bellman–Ford iteration bound: it preserves the correct layout for valid (acyclic) routes and simply assigns finite levels to cyclic ones instead of looping forever.

```diff
+ const maxPathLength = nodes.length
  while (queue.length) {
    ...
    for (const neighbor of neighbors) {
      const newLength = currentLength + 1
-     if (maximumPathLengths[targetAddress] === undefined || newLength > maximumPathLengths[targetAddress]) {
+     if (
+       newLength <= maxPathLength &&
+       (maximumPathLengths[targetAddress] === undefined || newLength > maximumPathLengths[targetAddress])
+     ) {
        maximumPathLengths[targetAddress] = newLength
        queue.push(targetAddress)
      }
    }
  }
```

This fixes **all** cyclic routes the aggregator can return, not just ETH → WETH.

---

## 2. Complementary — detect ETH↔WETH wrap without a wallet

`useWrapCallback` returned `NOT_APPLICABLE` whenever no account was connected (a `!account` guard in the early return). So **before connecting a wallet**, native ETH → WETH (and WETH → ETH) was treated as a normal aggregator swap and hit the route path — which is what fed the cyclic route into `TradeRouteV3` in the first place. When a wallet *is* connected the same pair was already correctly a 1:1 wrap.

Detect wrap/unwrap independently of the wallet, and gate only `execute` (which sends the transaction) on `account`:

```diff
- if (!wethAddress || !inputCurrency || !outputCurrency || !account) return NOT_APPLICABLE
+ if (!wethAddress || !inputCurrency || !outputCurrency) return NOT_APPLICABLE
  ...
- execute: sufficientBalance && inputAmount ? async () => { … } : undefined
+ execute: account && sufficientBalance && inputAmount ? async () => { … } : undefined
```

Now no-wallet ETH↔WETH shows the 1:1 output immediately and never calls the aggregator, matching the wallet-connected behavior. The `SwapActionButton` already renders "Connect" first (its own `!account` check precedes the wrap branch), so no pre-connect state regresses.

> Note: the Route panel is gated only on the user's "show routes" preference (not on `isWrapOrUnwrap`), so it still mounts a trivial header for a wrap — but harmlessly: there is no real route composition and the cycle guard from commit 1 prevents any freeze regardless.

---

## Testing

- **Isolated loop simulation** on a cyclic route (`WETH ↔ USDC`): old code hits a 1,000,000-iteration cap (infinite); new code terminates in 3 iterations with sensible levels.
- **Browser, before fix (Optimism ETH → WETH, no wallet):** `evaluate_script` and even `take_screenshot` time out → renderer fully locked. Single `/route` request returns 200 (not a network storm).
- **Browser, after fix (no wallet):**
  - **Optimism ETH → WETH** — tab fully interactive; detected as WRAP, no aggregator `/routes` request, 1:1 output (`2.5 → 2.5`), "Connect" button, no freeze.
  - **Optimism WETH → ETH** — detected as UNWRAP, 1:1 output, tab responsive.
  - **Optimism ETH → USDC (regression)** — still a normal swap: real rate `1 ETH = 1,775.42 USDC`, multi-hop route viz renders, tab responsive.
- `eslint` clean, `tsc --noEmit` 0 errors (both files).

## Repro (no wallet needed)

`/swap/optimism/eth-to-0x4200000000000000000000000000000000000006`
