### PR TITLE
fix(earn): align pool chart labels and loading state

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/utils.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/utils.ts
@@ -54,18 +54,55 @@ export const formatCompactUsd = (value?: number) => {
   })
 }
 
-type TimeLabelOptions = {
-  dateOnly?: boolean
+export const getUniqueDateAxisTicks = <T extends { ts: number }>(points: T[], window: PoolAnalyticsWindow) => {
+  if (window === '24h') return undefined
+
+  const dates = new Set<string>()
+
+  return points.reduce<number[]>((ticks, point) => {
+    const date = dayjs.unix(point.ts).format('YYYY-MM-DD')
+
+    if (!dates.has(date)) {
+      dates.add(date)
+      ticks.push(point.ts)
+    }
+
+    return ticks
+  }, [])
 }
 
-export const formatAxisTimeLabel = (timestamp: number, window: PoolAnalyticsWindow, options?: TimeLabelOptions) => {
-  if (options?.dateOnly) return dayjs.unix(timestamp).format('MMM D')
-  if (window === '24h') return dayjs.unix(timestamp).format('HH:mm')
-  if (window === '7d') return dayjs.unix(timestamp).format('MMM D, HH:mm')
-  return dayjs.unix(timestamp).format('MMM D')
+export enum TimeLabelFormat {
+  Date = 'date',
+  DateTime = 'dateTime',
+  Time = 'time',
 }
 
-export const formatTooltipTimeLabel = (timestamp: number, _window: PoolAnalyticsWindow, options?: TimeLabelOptions) => {
-  if (options?.dateOnly) return dayjs.unix(timestamp).format('MMM D')
-  return dayjs.unix(timestamp).format('MMM D, HH:mm')
+type AxisTimeLabelOptions = {
+  format?: TimeLabelFormat.Date | TimeLabelFormat.Time
+}
+
+type TooltipTimeLabelOptions = {
+  format?: TimeLabelFormat.Date | TimeLabelFormat.DateTime
+}
+
+const TIME_LABEL_FORMATS: Record<TimeLabelFormat, string> = {
+  [TimeLabelFormat.Date]: 'MMM D',
+  [TimeLabelFormat.DateTime]: 'MMM D, HH:mm',
+  [TimeLabelFormat.Time]: 'HH:mm',
+}
+
+export const formatAxisTimeLabel = (timestamp: number, window: PoolAnalyticsWindow, options?: AxisTimeLabelOptions) => {
+  const format = options?.format ?? (window === '24h' ? TimeLabelFormat.Time : TimeLabelFormat.Date)
+
+  return dayjs.unix(timestamp).format(TIME_LABEL_FORMATS[format])
+}
+
+export const formatTooltipTimeLabel = (
+  timestamp: number,
+  window: PoolAnalyticsWindow,
+  options?: TooltipTimeLabelOptions,
+) => {
+  const format = options?.format ?? (window === '24h' ? TimeLabelFormat.DateTime : TimeLabelFormat.Date)
+
+  return dayjs.unix(timestamp).format(TIME_LABEL_FORMATS[format])
 }

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
@@ -11,8 +11,10 @@ import SegmentedControl from 'components/SegmentedControl'
 import useTheme from 'hooks/useTheme'
 import {
   CHART_WINDOW_OPTIONS,
+  TimeLabelFormat,
   formatAxisTimeLabel,
   formatTooltipTimeLabel,
+  getUniqueDateAxisTicks,
 } from 'pages/Earns/PoolDetail/Information/utils'
 import PoolChartState, { PoolChartWrapper } from 'pages/Earns/PoolDetail/components/PoolChartState'
 import { ProgramType } from 'pages/Earns/types'
@@ -50,7 +52,9 @@ const AprHistoryTooltip = ({
       className="flex min-w-[220px] flex-col gap-3 rounded-xl border border-border bg-tableHeader/80 px-4 py-3"
       style={{ boxShadow: `0 12px 32px ${theme.shadow}` }}
     >
-      <span className="text-xs text-subText">{formatTooltipTimeLabel(point.ts, window)}</span>
+      <span className="text-xs text-subText">
+        {formatTooltipTimeLabel(point.ts, window, { format: TimeLabelFormat.DateTime })}
+      </span>
       <div className="grid grid-cols-[auto_auto] gap-x-4 gap-y-2">
         {showActiveApr && point.activeApr !== undefined ? (
           <>
@@ -91,7 +95,6 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId, programs, currentAp
 
   const upToSmall = useMedia(`(max-width: ${MEDIA_WIDTHS.upToSmall}px)`)
   const chartHeight = upToSmall ? 280 : 360
-  const volumeBarSize = window === '24h' ? (upToSmall ? 10 : 16) : 8
 
   const activeDotStroke = theme.buttonBlack
   const aprLineColor = theme.blue
@@ -112,7 +115,10 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId, programs, currentAp
 
   const isPositionChart = !!positionId
   const aprHistoryData = isPositionChart ? positionAprHistoryQuery.data : poolAprHistoryQuery.data
+  const displayWindow = aprHistoryData?.window ?? window
+
   const isError = isPositionChart ? positionAprHistoryQuery.isError : poolAprHistoryQuery.isError
+  const isFetching = isPositionChart ? positionAprHistoryQuery.isFetching : poolAprHistoryQuery.isFetching
   const isLoading = isPositionChart ? positionAprHistoryQuery.isLoading : poolAprHistoryQuery.isLoading
 
   const chartData = useMemo(
@@ -125,6 +131,8 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId, programs, currentAp
       }),
     [aprHistoryData?.points, volumeDownColor, volumeUpColor],
   )
+
+  const dateAxisTicks = useMemo(() => getUniqueDateAxisTicks(chartData, displayWindow), [chartData, displayWindow])
 
   const latestAprPoint = chartData[chartData.length - 1]
   const activeApr = currentApr?.activeApr ?? latestAprPoint?.activeApr
@@ -175,10 +183,11 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId, programs, currentAp
         height={chartHeight}
         isEmpty={!chartData.length}
         isError={isError}
+        isFetching={isFetching}
         isLoading={isLoading}
         skeletonType="line"
       >
-        <PoolChartWrapper $height={chartHeight}>
+        <PoolChartWrapper height={chartHeight}>
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={chartData} margin={{ top: 16, right: 0, bottom: 8, left: 0 }}>
               <CartesianGrid stroke={gridColor} strokeDasharray="3 3" vertical={false} />
@@ -188,8 +197,9 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId, programs, currentAp
                 minTickGap={24}
                 stroke={theme.subText}
                 tick={{ fill: theme.subText, fontSize: 12 }}
-                tickFormatter={(value: number) => formatAxisTimeLabel(value, window)}
+                tickFormatter={(value: number) => formatAxisTimeLabel(value, displayWindow)}
                 tickLine={false}
+                ticks={dateAxisTicks}
               />
               <YAxis
                 axisLine={false}
@@ -212,12 +222,12 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId, programs, currentAp
                     active={active}
                     point={payload?.[0]?.payload}
                     showActiveApr={showActiveApr}
-                    window={window}
+                    window={displayWindow}
                   />
                 )}
                 cursor={{ stroke: cursorColor, strokeDasharray: '4 4' }}
               />
-              <Bar barSize={volumeBarSize} dataKey="volumeUsd" radius={[2, 2, 0, 0]} yAxisId="volumeUsd">
+              <Bar dataKey="volumeUsd" radius={[2, 2, 0, 0]} yAxisId="volumeUsd">
                 {chartData.map(point => (
                   <Cell key={`${point.ts}-volumeUsd`} fill={point.volumeBarColor} />
                 ))}

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/LiquidityFlowsChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/LiquidityFlowsChart.tsx
@@ -18,10 +18,12 @@ import SegmentedControl from 'components/SegmentedControl'
 import useTheme from 'hooks/useTheme'
 import {
   CHART_WINDOW_OPTIONS,
+  TimeLabelFormat,
   formatAxisTimeLabel,
   formatCompactUsd,
   formatTooltipTimeLabel,
   formatUsd,
+  getUniqueDateAxisTicks,
 } from 'pages/Earns/PoolDetail/Information/utils'
 import PoolChartState, { PoolChartWrapper } from 'pages/Earns/PoolDetail/components/PoolChartState'
 import { MEDIA_WIDTHS } from 'theme'
@@ -65,7 +67,9 @@ const LiquidityFlowsTooltip = ({
       style={{ boxShadow: `0 12px 32px ${theme.shadow}` }}
     >
       <span className="text-xs text-subText">
-        {formatTooltipTimeLabel(point.ts, window, { dateOnly: isDailyWindow })}
+        {formatTooltipTimeLabel(point.ts, window, {
+          format: isDailyWindow ? TimeLabelFormat.Date : TimeLabelFormat.DateTime,
+        })}
       </span>
       <div className="grid grid-cols-[auto_auto] gap-x-4 gap-y-2">
         <span className="text-xs text-subText">Add Liquidity</span>
@@ -104,12 +108,14 @@ const LiquidityFlowsChart = ({ chainId, poolAddress }: LiquidityFlowsChartProps)
   const {
     data: liquidityFlowData,
     isError,
+    isFetching,
     isLoading,
   } = usePoolLiquidityFlowsQuery({
     chainId,
     address: poolAddress,
     window,
   })
+  const displayWindow = liquidityFlowData?.window ?? window
 
   const chartData = useMemo<LiquidityFlowPoint[]>(
     () =>
@@ -120,6 +126,7 @@ const LiquidityFlowsChart = ({ chainId, poolAddress }: LiquidityFlowsChartProps)
       })),
     [liquidityFlowData?.buckets],
   )
+  const dateAxisTicks = useMemo(() => getUniqueDateAxisTicks(chartData, displayWindow), [chartData, displayWindow])
 
   const handleSelectWindow = (value: PoolAnalyticsWindow) => {
     setWindow(value)
@@ -140,10 +147,11 @@ const LiquidityFlowsChart = ({ chainId, poolAddress }: LiquidityFlowsChartProps)
         height={chartHeight}
         isEmpty={!chartData.length}
         isError={isError}
+        isFetching={isFetching}
         isLoading={isLoading}
       >
         <div className="flex flex-col gap-3">
-          <PoolChartWrapper $height={chartHeight}>
+          <PoolChartWrapper height={chartHeight}>
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart
                 barCategoryGap={upToSmall ? '20%' : '16%'}
@@ -158,8 +166,9 @@ const LiquidityFlowsChart = ({ chainId, poolAddress }: LiquidityFlowsChartProps)
                   minTickGap={24}
                   stroke={theme.subText}
                   tick={{ fill: theme.subText, fontSize: 12 }}
-                  tickFormatter={(value: number) => formatAxisTimeLabel(value, window)}
+                  tickFormatter={(value: number) => formatAxisTimeLabel(value, displayWindow)}
                   tickLine={false}
+                  ticks={dateAxisTicks}
                 />
                 <YAxis
                   axisLine={false}
@@ -186,7 +195,7 @@ const LiquidityFlowsChart = ({ chainId, poolAddress }: LiquidityFlowsChartProps)
                     <LiquidityFlowsTooltip
                       active={props.active}
                       point={props.payload?.[0]?.payload as LiquidityFlowPoint | undefined}
-                      window={window}
+                      window={displayWindow}
                     />
                   )}
                   cursor={{ stroke: cursorColor, strokeDasharray: '4 4' }}

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolChartState.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolChartState.tsx
@@ -1,33 +1,29 @@
-import { Component, type ReactNode, forwardRef } from 'react'
+import { Component, type HTMLAttributes, type PropsWithChildren, type ReactNode, forwardRef } from 'react'
 
 import { ReactComponent as PriceChartEmptyIcon } from 'assets/svg/price-chart-empty.svg'
-import ProgressBar from 'components/ProgressBar'
+import Loader from 'components/Loader'
 import Skeleton from 'components/Skeleton'
-import { HStack, Stack } from 'components/Stack'
+import { Center, HStack, Stack } from 'components/Stack'
 import useTheme from 'hooks/useTheme'
 import { cn } from 'utils/cn'
 
 const DEFAULT_CHART_HEIGHT = 360
+type PoolChartSkeletonType = 'line' | 'bar' | 'candle'
 
-interface PoolChartWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
-  $height?: number
-}
+export const PoolChartWrapper = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement> & { height?: number }>(
+  function PoolChartWrapper({ height, style, children, ...rest }, ref) {
+    return (
+      <div ref={ref} className="w-full" style={{ height: `${height ?? DEFAULT_CHART_HEIGHT}px`, ...style }} {...rest}>
+        {children}
+      </div>
+    )
+  },
+)
 
-export const PoolChartWrapper = forwardRef<HTMLDivElement, PoolChartWrapperProps>(function PoolChartWrapper(
-  { $height, style, children, ...rest },
-  ref,
-) {
-  return (
-    <div ref={ref} className="w-full" style={{ height: `${$height ?? DEFAULT_CHART_HEIGHT}px`, ...style }} {...rest}>
-      {children}
-    </div>
-  )
-})
-
-const SkeletonBar = ({ $height, children }: { $height: number; children?: ReactNode }) => (
+const SkeletonBar = ({ children, height }: PropsWithChildren<{ height: number }>) => (
   <div
     className="relative min-w-1 max-w-3 flex-1 overflow-hidden rounded-t bg-text/[0.04]"
-    style={{ height: `${$height}%` }}
+    style={{ height: `${height}%` }}
   >
     {children}
   </div>
@@ -43,42 +39,26 @@ const SkeletonBarShimmer = () => (
   />
 )
 
-type PoolChartSkeletonProps = {
-  height?: number
-  type?: 'line' | 'bar' | 'candle'
-}
-
-type PoolChartMessageProps = {
-  height?: number
-  message: string
-  showIcon?: boolean
-  textColor?: string
-  textWeight?: number
-}
-
-type PoolChartStateProps = {
-  children: ReactNode
-  emptyMessage?: string
-  errorMessage?: string
-  exclusiveType?: 'earning-chart' | 'liquidity-flow'
-  height?: number
-  isEmpty?: boolean
-  isError?: boolean
-  isFetching?: boolean
-  isLoading?: boolean
-  skeletonType?: PoolChartSkeletonProps['type']
-}
-
-const ChartFetchingOverlay = ({ children }: { children: ReactNode }) => (
-  <div className="pointer-events-none absolute inset-0 z-[1] bg-background/[0.06] pt-1 backdrop-blur">{children}</div>
+const ChartFetchingContent = ({ children, isFetching }: PropsWithChildren<{ isFetching?: boolean }>) => (
+  <div className="relative w-full">
+    {children}
+    {isFetching && (
+      <Center className="pointer-events-none absolute inset-0 z-[1] justify-start">
+        <Center className="relative top-[20%] rounded-full bg-background/80 p-2 text-primary shadow-sm">
+          <Loader size="24px" strokeWidth="2.5" />
+        </Center>
+      </Center>
+    )}
+  </div>
 )
 
+type PoolChartRenderBoundaryState = {
+  error: Error | null
+}
+
 class PoolChartRenderBoundary extends Component<
-  {
-    children: ReactNode
-    fallback: (error: Error) => ReactNode
-  },
-  { error: Error | null }
+  PropsWithChildren<{ fallback: (error: Error) => ReactNode }>,
+  PoolChartRenderBoundaryState
 > {
   state = { error: null }
 
@@ -95,15 +75,12 @@ class PoolChartRenderBoundary extends Component<
   }
 }
 
-const PoolChartStateLayout = ({
-  children,
-  gap,
-  height = DEFAULT_CHART_HEIGHT,
-}: {
-  children: ReactNode
+type PoolChartStateLayoutProps = PropsWithChildren<{
   gap: number
   height?: number
-}) => {
+}>
+
+const PoolChartStateLayout = ({ children, gap, height = DEFAULT_CHART_HEIGHT }: PoolChartStateLayoutProps) => {
   return (
     <Stack
       className="w-full items-center justify-center rounded-2xl border border-dashed border-border p-5 text-center"
@@ -148,7 +125,7 @@ const BarChartSkeleton = ({ height }: { height: number }) => {
     <div style={{ height: `${Math.max(height - 64, 0)}px`, width: '100%' }}>
       <HStack className="size-full items-end justify-center gap-2 p-2">
         {barHeights.map((barHeight, index) => (
-          <SkeletonBar $height={barHeight * 0.8} key={index}>
+          <SkeletonBar height={barHeight * 0.8} key={index}>
             <SkeletonBarShimmer />
           </SkeletonBar>
         ))}
@@ -240,6 +217,11 @@ const CandleChartSkeleton = ({ height }: { height: number }) => {
   )
 }
 
+type PoolChartSkeletonProps = {
+  height?: number
+  type?: PoolChartSkeletonType
+}
+
 export const PoolChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT, type = 'line' }: PoolChartSkeletonProps) => {
   return (
     <PoolChartStateLayout gap={12} height={height}>
@@ -250,7 +232,7 @@ export const PoolChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT, type = 'line'
   )
 }
 
-const LiquidityFlowChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT }: PoolChartSkeletonProps) => {
+const LiquidityFlowChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT }: { height?: number }) => {
   return (
     <Stack className="gap-3">
       <PoolChartSkeleton height={height} type="bar" />
@@ -265,7 +247,7 @@ const LiquidityFlowChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT }: PoolChart
   )
 }
 
-const EarningChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT }: PoolChartSkeletonProps) => {
+const EarningChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT }: { height?: number }) => {
   const isCompact = height <= 240
   const breakdownChartSize = isCompact ? 160 : 180
 
@@ -289,13 +271,21 @@ const EarningChartSkeleton = ({ height = DEFAULT_CHART_HEIGHT }: PoolChartSkelet
   )
 }
 
+type PoolChartEmptyStateProps = {
+  height?: number
+  message: string
+  showIcon?: boolean
+  textColor?: string
+  textWeight?: number
+}
+
 const PoolChartEmptyState = ({
   height = DEFAULT_CHART_HEIGHT,
   message,
   showIcon = false,
   textColor,
   textWeight,
-}: PoolChartMessageProps) => {
+}: PoolChartEmptyStateProps) => {
   const theme = useTheme()
 
   return (
@@ -307,6 +297,18 @@ const PoolChartEmptyState = ({
     </PoolChartStateLayout>
   )
 }
+
+type PoolChartStateProps = PropsWithChildren<{
+  emptyMessage?: string
+  errorMessage?: string
+  exclusiveType?: 'earning-chart' | 'liquidity-flow'
+  height?: number
+  isEmpty?: boolean
+  isError?: boolean
+  isFetching?: boolean
+  isLoading?: boolean
+  skeletonType?: PoolChartSkeletonType
+}>
 
 const PoolChartState = ({
   children,
@@ -340,20 +342,9 @@ const PoolChartState = ({
     return <PoolChartEmptyState height={height} message={emptyMessage} showIcon />
   }
 
-  const content = isFetching ? (
-    <div className="relative w-full">
-      {children}
-      <ChartFetchingOverlay>
-        <ProgressBar loading height="3px" width="100%" />
-      </ChartFetchingOverlay>
-    </div>
-  ) : (
-    children
-  )
-
   return (
     <PoolChartRenderBoundary fallback={error => <PoolChartEmptyState height={height} message={error.message} />}>
-      {content}
+      <ChartFetchingContent isFetching={isFetching}>{children}</ChartFetchingContent>
     </PoolChartRenderBoundary>
   )
 }

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningChart.tsx
@@ -13,6 +13,7 @@ import {
   formatCompactUsd,
   formatTooltipTimeLabel,
   formatUsd,
+  getUniqueDateAxisTicks,
 } from 'pages/Earns/PoolDetail/Information/utils'
 import PoolChartState, { PoolChartWrapper } from 'pages/Earns/PoolDetail/components/PoolChartState'
 import PoolEarningPieChart from 'pages/Earns/PoolDetail/components/PoolEarningPieChart'
@@ -111,13 +112,9 @@ const EarningsTooltip = ({
 }) => {
   if (!active || !point) return null
 
-  const isDailyWindow = window === '7d' || window === '30d'
-
   return (
     <TooltipCard>
-      <span className="text-xs text-subText">
-        {formatTooltipTimeLabel(point.ts, window, { dateOnly: isDailyWindow })}
-      </span>
+      <span className="text-xs text-subText">{formatTooltipTimeLabel(point.ts, window)}</span>
       <TooltipGrid>
         <span className="text-xs text-subText">Total Earn</span>
         <span className="text-right text-xs font-medium text-text">{formatUsd(point.totalUsd)}</span>
@@ -153,7 +150,10 @@ const PoolEarningChart = ({ chainId, poolAddress, positionId }: PoolEarningChart
   )
 
   const earningsData = isPositionChart ? positionEarningsQuery.data : poolEarningsQuery.data
+  const displayWindow = earningsData?.window ?? window
+
   const chartIsError = isPositionChart ? positionEarningsQuery.isError : poolEarningsQuery.isError
+  const chartIsFetching = isPositionChart ? positionEarningsQuery.isFetching : poolEarningsQuery.isFetching
   const chartIsLoading = isPositionChart ? positionEarningsQuery.isLoading : poolEarningsQuery.isLoading
   const buckets = useMemo(() => earningsData?.buckets ?? [], [earningsData?.buckets])
   const hasBonusUsd = useMemo(() => buckets.some(bucket => bucket.bonusUsd !== undefined), [buckets])
@@ -170,17 +170,18 @@ const PoolEarningChart = ({ chainId, poolAddress, positionId }: PoolEarningChart
   }, [hasBonusUsd, theme.blue])
 
   const chartData = useMemo<EarningsChartPoint[]>(() => {
-    const visibleLabelStep = getVisibleLabelStep(buckets.length, upToSmall, window)
+    const visibleLabelStep = getVisibleLabelStep(buckets.length, upToSmall, displayWindow)
 
     return buckets.map((bucket, index) => ({
       ...bucket,
       showTotalLabel: index % visibleLabelStep === 0 || index === buckets.length - 1,
       topSegmentKey: getTopSegmentKey(bucket, breakdownConfig),
     }))
-  }, [breakdownConfig, buckets, upToSmall, window])
+  }, [breakdownConfig, buckets, displayWindow, upToSmall])
+
+  const dateAxisTicks = useMemo(() => getUniqueDateAxisTicks(chartData, displayWindow), [chartData, displayWindow])
 
   const hasChartData = chartData.length > 0
-  const isDailyWindow = window === '7d' || window === '30d'
 
   return (
     <Stack className="gap-4">
@@ -196,10 +197,11 @@ const PoolEarningChart = ({ chainId, poolAddress, positionId }: PoolEarningChart
         height={chartHeight}
         isEmpty={!hasChartData}
         isError={chartIsError}
+        isFetching={chartIsFetching}
         isLoading={chartIsLoading}
         skeletonType="bar"
       >
-        <PoolChartWrapper $height={chartHeight}>
+        <PoolChartWrapper height={chartHeight}>
           <ResponsiveContainer height="100%" width="100%">
             <ComposedChart
               barCategoryGap={upToSmall ? '24%' : '18%'}
@@ -214,7 +216,8 @@ const PoolEarningChart = ({ chainId, poolAddress, positionId }: PoolEarningChart
                 stroke={theme.subText}
                 tick={{ fill: theme.subText, fontSize: 12 }}
                 tickLine={false}
-                tickFormatter={(value: number) => formatAxisTimeLabel(value, window, { dateOnly: isDailyWindow })}
+                tickFormatter={(value: number) => formatAxisTimeLabel(value, displayWindow)}
+                ticks={dateAxisTicks}
               />
               <YAxis
                 axisLine={false}
@@ -231,7 +234,7 @@ const PoolEarningChart = ({ chainId, poolAddress, positionId }: PoolEarningChart
                     active={active}
                     breakdownConfig={breakdownConfig}
                     point={payload?.[0]?.payload as EarningsChartPoint | undefined}
-                    window={window}
+                    window={displayWindow}
                   />
                 )}
                 cursor={{ stroke: cursorColor, strokeDasharray: '4 4' }}

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolPriceChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolPriceChart.tsx
@@ -19,6 +19,7 @@ import TokenLogo from 'components/TokenLogo'
 import useTheme from 'hooks/useTheme'
 import {
   CHART_WINDOW_OPTIONS,
+  TimeLabelFormat,
   formatAxisTimeLabel,
   formatRate,
   formatSignedPercent,
@@ -131,7 +132,7 @@ const getChartOptions = ({
   },
   timeScale: {
     borderVisible: false,
-    tickMarkFormatter: (time: number) => formatAxisTimeLabel(time, window, { dateOnly: window !== '24h' }),
+    tickMarkFormatter: (time: number) => formatAxisTimeLabel(time, window),
     timeVisible: window === '24h',
   },
   localization: {
@@ -215,7 +216,9 @@ const PriceChartTooltip = ({ tooltip, window }: { tooltip: TooltipState; window:
       className="pointer-events-none absolute z-[2] min-w-[220px] gap-3 rounded-xl border border-border bg-tableHeader/80 px-4 py-3"
       style={{ left, top, boxShadow: `0 12px 32px ${theme.shadow}` }}
     >
-      <span className="text-xs text-subText">{formatTooltipTimeLabel(candle.time, window)}</span>
+      <span className="text-xs text-subText">
+        {formatTooltipTimeLabel(candle.time, window, { format: TimeLabelFormat.DateTime })}
+      </span>
 
       <div className="grid grid-cols-[auto_auto] gap-x-4 gap-y-2">
         <span className="text-xs text-subText">Open</span>
@@ -282,12 +285,14 @@ const PoolPriceChart = ({ chainId, poolAddress }: PoolPriceChartProps) => {
   const {
     data: priceData,
     isError,
+    isFetching,
     isLoading,
   } = usePoolPriceQuery({
     chainId,
     address: poolAddress,
     window,
   })
+  const displayWindow = priceData?.window ?? window
 
   const displayedToken0 = revertPrice ? secondaryToken : primaryToken
   const displayedToken1 = revertPrice ? primaryToken : secondaryToken
@@ -317,9 +322,9 @@ const PoolPriceChart = ({ chainId, poolAddress }: PoolPriceChartProps) => {
         crosshairColor,
         gridColor,
         subTextColor,
-        window,
+        window: displayWindow,
       }),
-    [chartHeight, crosshairColor, gridColor, subTextColor, window],
+    [chartHeight, crosshairColor, displayWindow, gridColor, subTextColor],
   )
   const candlestickSeriesOptions = useMemo(
     () =>
@@ -483,7 +488,7 @@ const PoolPriceChart = ({ chainId, poolAddress }: PoolPriceChartProps) => {
     return scheduleAfterNextPaint(() => {
       chartRef.current?.timeScale().fitContent()
     })
-  }, [chartData, volumeDownColor, volumeUpColor, window])
+  }, [chartData, displayWindow, volumeDownColor, volumeUpColor])
 
   return (
     <Stack className="gap-4">
@@ -533,13 +538,14 @@ const PoolPriceChart = ({ chainId, poolAddress }: PoolPriceChartProps) => {
         height={chartHeight}
         isEmpty={!chartData.length}
         isError={isError}
+        isFetching={isFetching}
         isLoading={isLoading}
         skeletonType="candle"
       >
         <div className="relative w-full" style={{ height: chartHeight }}>
-          {tooltip ? <PriceChartTooltip tooltip={tooltip} window={window} /> : null}
+          {tooltip ? <PriceChartTooltip tooltip={tooltip} window={displayWindow} /> : null}
           <div className="box-border size-full pb-6 pl-6 pr-3">
-            <PoolChartWrapper $height={chartHeight - 12} ref={chartContainerRef} />
+            <PoolChartWrapper height={chartHeight - 12} ref={chartContainerRef} />
           </div>
         </div>
       </PoolChartState>

--- a/apps/kyberswap-interface/src/pages/SwapV3/Components/TokenPriceChartCanvas.tsx
+++ b/apps/kyberswap-interface/src/pages/SwapV3/Components/TokenPriceChartCanvas.tsx
@@ -552,7 +552,7 @@ const TokenPriceChartCanvas = ({
     <div className="relative w-full" style={{ height: `${chartHeight}px` }}>
       {tooltip && isViewportReady ? <PriceChartTooltip timeFrame={timeFrame} tooltip={tooltip} /> : null}
       <PoolChartWrapper
-        $height={chartHeight}
+        height={chartHeight}
         ref={chartContainerRef}
         style={{ visibility: isViewportReady ? 'visible' : 'hidden' }}
       />

--- a/apps/kyberswap-interface/src/services/earn/types.ts
+++ b/apps/kyberswap-interface/src/services/earn/types.ts
@@ -203,6 +203,7 @@ export interface PoolAprHistoryPoint {
 export interface PoolAprHistoryData {
   chainId: number
   poolAddress: string
+  window?: PoolAnalyticsWindow
   points: Array<PoolAprHistoryPoint>
 }
 

--- a/apps/kyberswap-interface/src/services/earn/utils.ts
+++ b/apps/kyberswap-interface/src/services/earn/utils.ts
@@ -120,6 +120,7 @@ export const transformAprHistoryData = (data: PoolAprHistoryData, window: PoolAn
 
   return {
     ...data,
+    window,
     points: window === '30d' ? aggregateFourHourAprHistoryPoints(points) : points,
   }
 }


### PR DESCRIPTION
## Summary
- Align Earns pool chart time labels with the response window and avoid duplicate daily axis labels on multi-day charts
- Keep chart content visible during refetches with a centered fetching indicator
- Carry the APR history request window into transformed data and update shared chart wrapper height usage