### PR TITLE
feat(earn): show zap fee in add liquidity settings

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityRoutePreview.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityRoutePreview.tsx
@@ -12,6 +12,7 @@ import {
   getOutputTokenItems,
   getZapFeePercent,
 } from 'pages/Earns/PoolDetail/AddLiquidity/utils'
+import { ExternalLink } from 'theme'
 import { formatDisplayNumber } from 'utils/numbers'
 
 type RouteTokenItem = {
@@ -97,13 +98,10 @@ const AddLiquidityRoutePreview = ({
             <div className="flex items-center justify-between gap-4">
               <TextHelper
                 tooltip={
-                  <div className="flex flex-col items-start gap-1 [&_a]:text-primary [&_a]:no-underline">
+                  <span>
                     Fees charged for automatically zapping into a liquidity pool. You still have to pay the standard gas
-                    fees.
-                    <a href={API_URLS.DOCUMENT.ZAP_FEE_MODEL} target="_blank" rel="noopener norefferer noreferrer">
-                      {'>'} More details
-                    </a>
-                  </div>
+                    fees. <ExternalLink href={API_URLS.DOCUMENT.ZAP_FEE_MODEL}>More details ↗</ExternalLink>
+                  </span>
                 }
                 placement="left"
                 color="var(--ks-subText)"

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidgetSkeleton.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidgetSkeleton.tsx
@@ -41,9 +41,9 @@ const AddLiquidityWidgetSkeleton = () => {
       <Stack className="gap-4">
         <Skeleton width="100%" height={38} />
         <Stack className="gap-3 rounded-xl border border-buttonGray p-2">
-          <Skeleton width={160} height={18} />
-          <Skeleton width={240} height={18} />
-          <Skeleton width={160} height={18} />
+          <Skeleton width={160} height={20} />
+          <Skeleton width={240} height={20} />
+          <Skeleton width={160} height={20} />
         </Stack>
         <Skeleton width="100%" height={44} borderRadius={22} />
       </Stack>

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidgetSkeleton.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/AddLiquidityWidgetSkeleton.tsx
@@ -41,8 +41,9 @@ const AddLiquidityWidgetSkeleton = () => {
       <Stack className="gap-4">
         <Skeleton width="100%" height={38} />
         <Stack className="gap-3 rounded-xl border border-buttonGray p-2">
-          <Skeleton width={160} height={20} />
-          <Skeleton width={240} height={20} />
+          <Skeleton width={160} height={18} />
+          <Skeleton width={240} height={18} />
+          <Skeleton width={160} height={18} />
         </Stack>
         <Skeleton width="100%" height={44} borderRadius={22} />
       </Stack>

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/SlippageControl.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/SlippageControl.tsx
@@ -1,4 +1,4 @@
-import { DEXES_INFO, NETWORKS_INFO, Pool, PoolType, ZapRouteDetail } from '@kyber/schema'
+import { API_URLS, DEXES_INFO, NETWORKS_INFO, Pool, PoolType, ZapRouteDetail } from '@kyber/schema'
 import { translateZapMessage } from '@kyber/ui'
 import { PI_LEVEL, getZapImpact } from '@kyber/utils'
 import { Trans } from '@lingui/macro'
@@ -9,9 +9,15 @@ import { HStack, Stack } from 'components/Stack'
 import { TextHelper } from 'components/Text'
 import { MAX_DEGEN_SLIPPAGE_IN_BIPS, MAX_NORMAL_SLIPPAGE_IN_BIPS } from 'constants/index'
 import useTheme from 'hooks/useTheme'
-import { getSlippageNotice, getSlippageStorageKey } from 'pages/Earns/PoolDetail/AddLiquidity/utils'
+import {
+  formatPercent,
+  getSlippageNotice,
+  getSlippageStorageKey,
+  getZapFeePercent,
+} from 'pages/Earns/PoolDetail/AddLiquidity/utils'
 import { NoteCard } from 'pages/Earns/PoolDetail/styled'
 import { useDegenModeManager } from 'state/user/hooks'
+import { ExternalLink } from 'theme'
 import { cn } from 'utils/cn'
 
 const PRESET_SLIPPAGE_OPTIONS = [5, 10, 50, 100]
@@ -281,6 +287,24 @@ const SlippageControl = ({ context, value, onTrackEvent, onSlippageChange }: Sli
         )}
 
         <ZapImpact route={route} />
+
+        <HStack className="w-full items-center justify-between gap-4">
+          <TextHelper
+            tooltip={
+              <span>
+                Fees charged for automatically zapping into a liquidity pool. You still have to pay the standard gas
+                fees. <ExternalLink href={API_URLS.DOCUMENT.ZAP_FEE_MODEL}>More details ↗</ExternalLink>
+              </span>
+            }
+            placement="bottom"
+            className="text-subText"
+            fontSize={14}
+            width="fit-content"
+          >
+            Zap Fee
+          </TextHelper>
+          <span className="text-sm font-medium text-text">{formatPercent(getZapFeePercent(route))}</span>
+        </HStack>
       </Stack>
     </Stack>
   )


### PR DESCRIPTION
## Summary
- show the route-derived zap fee in the Add Liquidity slippage control
- use the shared external link for zap fee documentation in route summaries
- align the Add Liquidity skeleton with the additional fee row