### PR TITLE
fix(cross-chain): self-host Bitcoin connect icon

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/BitcoinConnectModal.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/BitcoinConnectModal.tsx
@@ -7,6 +7,7 @@ import Loader from 'components/Loader'
 import Modal from 'components/Modal'
 import { useBitcoinWallet } from 'components/Web3Provider/BitcoinProvider'
 import { DerivationPaths } from 'components/Web3Provider/BitcoinProvider/providers/ledger'
+import { BitcoinToken } from 'pages/CrossChainSwap/adapters/types'
 import { useNotify } from 'state/application/hooks'
 import { useIsAcceptedTerm } from 'state/user/hooks'
 import { cn } from 'utils/cn'
@@ -86,7 +87,7 @@ export const BitcoinConnectModal = ({ isOpen, onDismiss }: { isOpen: boolean; on
                       }}
                     >
                       <Icon>
-                        <img src="https://storage.googleapis.com/bitfi-static-35291d79/images/tokens/btc.svg" alt="" />
+                        <img src={BitcoinToken.logo} alt="" />
                       </Icon>
                       <span>{name}</span>
                       <span className="truncate text-sm font-normal text-subText">{path}</span>


### PR DESCRIPTION
## Summary

The Bitcoin wallet-connect (Ledger) modal loaded its BTC icon from `https://storage.googleapis.com/bitfi-static-35291d79/images/tokens/btc.svg` — a **third-party GCS bucket outside our control**. A security researcher reported (and it's verified) that this bucket namespace is now registered by an external party, and the referenced object already returns HTTP 403.

This swaps the `<img src>` to `BitcoinToken.logo` — the same Kyber-controlled `ks-setting` asset the chain selector already uses — so no UI asset in the wallet-connect flow depends on an origin we don't control.

## Severity

Low. It's a passive `<img>` load of a static image (SVGs via `<img>` don't execute JS → no XSS, no credential/asset risk); worst case was icon defacement in the modal. Fixing regardless as good hygiene — and the icon is currently broken (403).

## Changes

- `BitcoinConnectModal.tsx`: use `BitcoinToken.logo` instead of the hardcoded `bitfi-static-35291d79` URL.

## Test

- `grep -rn "bitfi-static" apps packages` → no matches.
- Open Cross-Chain Swap → Bitcoin connect modal → Ledger option; BTC icon renders from the Kyber-controlled asset with no request to `storage.googleapis.com/bitfi-static-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)