### PR TITLE
fix(cross-chain): keep allowance state in sync

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
@@ -2,7 +2,6 @@ import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
 import { t } from '@lingui/macro'
 import { useWalletSelector } from '@near-wallet-selector/react-hook'
 import { useWallet } from '@solana/wallet-adapter-react'
-import { useState } from 'react'
 
 import { ButtonPrimary } from 'components/Button'
 import Dots from 'components/Dots'
@@ -10,13 +9,14 @@ import { useBitcoinWallet } from 'components/Web3Provider/BitcoinProvider'
 import { useSolanaTokenBalances } from 'components/Web3Provider/SolanaProvider'
 import { ZERO_ADDRESS } from 'constants/index'
 import { useActiveWeb3React } from 'hooks'
-import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
+import { ApprovalState } from 'hooks/useApproveCallback'
 import { restrictedTokenMessage, useIsTokenAddressRestricted } from 'hooks/useRestrictedTokens'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
 import { NonEvmChain } from 'pages/CrossChainSwap/adapters'
 import { ConfirmationPopup } from 'pages/CrossChainSwap/components/ConfirmationPopup'
 import useAcceptTermAndPolicy from 'pages/CrossChainSwap/hooks/useAcceptTermAndPolicy'
+import { useCrossChainApproval } from 'pages/CrossChainSwap/hooks/useCrossChainApproval'
 import { useCrossChainSwap } from 'pages/CrossChainSwap/hooks/useCrossChainSwap'
 import { useNearBalances } from 'pages/CrossChainSwap/hooks/useNearBalances'
 import { useSolanaConnectModal } from 'pages/CrossChainSwap/provider/SolanaConnectModalProvider'
@@ -26,8 +26,6 @@ import { isEvmChain } from 'utils'
 import { getTokenAddress } from 'utils/tokenInfo'
 
 export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean) => void }) => {
-  const { account, chainId } = useActiveWeb3React()
-  const { trackingHandler } = useTracking()
   const {
     showPreview,
     setShowPreview,
@@ -41,11 +39,16 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
     selectedQuote,
     recipient,
   } = useCrossChainSwap()
+  const { account, chainId } = useActiveWeb3React()
+  const { trackingHandler } = useTracking()
 
   const isFromEvm = isEvmChain(fromChainId)
   const isFromNear = fromChainId === NonEvmChain.Near
   const isFromSol = fromChainId === NonEvmChain.Solana
   const isFromBitcoin = fromChainId === NonEvmChain.Bitcoin
+  const inputAmount =
+    isFromEvm && currencyIn ? CurrencyAmount.fromRawAmount(currencyIn as Currency, amountInWei || '0') : undefined
+
   const balance = useCurrencyBalance(
     isFromEvm ? (currencyIn as Currency) : undefined,
     isFromEvm ? (fromChainId as ChainId) : undefined,
@@ -55,29 +58,24 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
   const { walletInfo, balance: btcBalance } = useBitcoinWallet()
   const btcAddress = walletInfo?.address
 
+  const { signedAccountId } = useWalletSelector()
+  const { publicKey: solanaAddress } = useWallet()
   const toggleWalletModal = useWalletModalToggle()
   const { changeNetwork } = useChangeNetwork()
-
-  const { signedAccountId } = useWalletSelector()
-
-  const inputAmount =
-    isEvmChain(fromChainId) && currencyIn
-      ? CurrencyAmount.fromRawAmount(currencyIn as Currency, amountInWei || '0')
-      : undefined
-
-  const [approvalState, approve] = useApproveCallback({
-    amount: inputAmount,
-    spender: selectedQuote?.quote.contractAddress,
-  })
-  const [clickedApprove, setClickedApprove] = useState(false)
-  const { publicKey: solanaAddress } = useWallet()
-
   const { termAndPolicyModal, onOpenWallet } = useAcceptTermAndPolicy()
   const { setIsOpen } = useSolanaConnectModal()
+  const isAddressRestricted = useIsTokenAddressRestricted()
+
+  const { approvalState, approve, isApproving, isChecking, isRevalidating, revalidateAllowance } =
+    useCrossChainApproval({
+      amount: inputAmount,
+      fromChainId,
+      spender: selectedQuote?.quote.contractAddress,
+    })
+
   const isFindingRoute = loading || (allLoading && !selectedQuote)
 
   // Restricted-token check applies only to EVM sides (the restricted list is keyed by EVM chainId).
-  const isAddressRestricted = useIsTokenAddressRestricted()
   const restrictedCurrency =
     isFromEvm && currencyIn && isAddressRestricted(fromChainId as ChainId, getTokenAddress(currencyIn as Currency))
       ? currencyIn
@@ -88,30 +86,54 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       ? currencyOut
       : undefined
 
+  const openPreview = () => {
+    setShowPreview(true)
+    trackingHandler(TRACKING_EVENT_TYPE.CC_REVIEW_OPENED, {
+      from_token: currencyIn?.symbol,
+      to_token: currencyOut?.symbol,
+      from_chain: fromChainId,
+      to_chain: toChainId,
+      amount_in: selectedQuote?.quote.inputUsd,
+      amount_out_estimated: selectedQuote?.quote.outputUsd,
+      routing_source: selectedQuote?.adapter.getName(),
+    })
+  }
+
+  const checkAllowanceAndOpenPreview = async () => {
+    const hasSufficientAllowance = await revalidateAllowance()
+    if (!hasSufficientAllowance) return
+
+    openPreview()
+  }
+
   const {
     label,
     disabled = false,
     onClick,
   } = (() => {
-    if (approvalState === ApprovalState.PENDING || clickedApprove) {
+    if (isApproving) {
       return {
-        label: t`Approving...`,
+        label: <Dots>{t`Approving`}</Dots>,
         disabled: true,
-        onClick: () => {},
       }
     }
-    if (isFindingRoute)
+    if (isFindingRoute) {
       return {
         label: <Dots>{t`Finding the best route`}</Dots>,
         disabled: true,
-        onClick: () => {},
       }
+    }
+    if (isChecking) {
+      return {
+        label: <Dots>{t`Checking approval`}</Dots>,
+        disabled: true,
+      }
+    }
 
     if (!fromChainId || !toChainId || !currencyIn || !currencyOut) {
       return {
         label: t`Please select a token`,
         disabled: true,
-        onClick: () => {},
       }
     }
 
@@ -119,7 +141,6 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       return {
         label: restrictedTokenMessage(restrictedCurrency.symbol),
         disabled: true,
-        onClick: () => {},
       }
     }
 
@@ -127,7 +148,6 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       return {
         label: t`Please input an amount`,
         disabled: true,
-        onClick: () => {},
       }
     }
 
@@ -140,13 +160,14 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       }
     }
 
-    if (isFromEvm && !account)
+    if (isFromEvm && !account) {
       return {
         label: t`Connect Wallet`,
         onClick: () => {
           toggleWalletModal()
         },
       }
+    }
 
     if (isFromNear && !signedAccountId) {
       return {
@@ -156,6 +177,7 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
         },
       }
     }
+
     if (isFromSol && !solanaAddress) {
       return {
         label: t`Connect Solana Wallet`,
@@ -169,7 +191,6 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       return {
         label: t`No route found`,
         disabled: true,
-        onClick: () => {},
       }
 
     let notEnougBalance = false
@@ -184,7 +205,6 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       return {
         label: t`Insufficient Balance`,
         disabled: true,
-        onClick: () => {},
       }
     }
 
@@ -201,36 +221,21 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       return {
         label: t`Enter Recipient`,
         disabled: true,
-        onClick: () => {},
       }
     }
 
-    if (approvalState === 'NOT_APPROVED' && selectedQuote.quote.contractAddress !== ZERO_ADDRESS) {
+    if (approvalState === ApprovalState.NOT_APPROVED && selectedQuote.quote.contractAddress !== ZERO_ADDRESS) {
       return {
         label: t`Approve`,
-        onClick: () => {
-          setClickedApprove(true)
-          approve(inputAmount).finally(() => {
-            setClickedApprove(false)
-          })
-        },
+        disabled: isRevalidating,
+        onClick: approve,
       }
     }
 
     return {
       label: t`Review the Cross-chain Swap`,
-      onClick: () => {
-        setShowPreview(true)
-        trackingHandler(TRACKING_EVENT_TYPE.CC_REVIEW_OPENED, {
-          from_token: currencyIn?.symbol,
-          to_token: currencyOut?.symbol,
-          from_chain: fromChainId,
-          to_chain: toChainId,
-          amount_in: selectedQuote?.quote.inputUsd,
-          amount_out_estimated: selectedQuote?.quote.outputUsd,
-          routing_source: selectedQuote?.adapter.getName(),
-        })
-      },
+      disabled: isRevalidating,
+      onClick: checkAllowanceAndOpenPreview,
     }
   })()
 

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainApproval.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainApproval.ts
@@ -1,0 +1,206 @@
+import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useReadContract, useWaitForTransactionReceipt } from 'wagmi'
+
+import { ZERO_ADDRESS } from 'constants/index'
+import { useActiveWeb3React } from 'hooks'
+import { ApprovalState, ApprovalStatus, useApproveCallback } from 'hooks/useApproveCallback'
+import { Chain } from 'pages/CrossChainSwap/adapters'
+import { useCrossChainTransactions } from 'state/crossChainSwap'
+import { useHasPendingApproval } from 'state/transactions/hooks'
+import { isEvmChain } from 'utils'
+import { Address, Hash, parseAbi } from 'utils/viem'
+
+const ALLOWANCE_ABI = parseAbi(['function allowance(address owner, address spender) view returns (uint256)'])
+const ALLOWANCE_SYNC_DELAYS = [0, 1_000, 1_000]
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const getTransactionTokenAddress = (token: unknown) => {
+  if (!token || typeof token !== 'object') return undefined
+  const storedToken = token as { address?: string; wrapped?: { address?: string } }
+  return storedToken.address ?? storedToken.wrapped?.address
+}
+
+type UseCrossChainApprovalParams = {
+  amount: CurrencyAmount<Currency> | undefined
+  fromChainId: Chain | undefined
+  spender: string | undefined
+}
+
+/**
+ * Keeps CrossChainSwap approval state synchronized with the on-chain allowance.
+ *
+ * `useApproveCallback` refreshes its allowance when an approval transaction changes state. However, an exact allowance
+ * is also consumed by the source swap, which is stored in `crossChainSwap.transactions` instead of the shared EVM
+ * transaction store. Therefore, the source swap does not update `pendingApproval` and can leave the cached allowance
+ * stale after a completed transaction.
+ *
+ * This hook reuses the shared approval transaction flow, performs bounded allowance retries after approval and source
+ * swap receipts, and revalidates once more before Review. The retries are transaction-triggered and never run on idle.
+ */
+export const useCrossChainApproval = ({ amount, fromChainId, spender }: UseCrossChainApprovalParams) => {
+  const { account, chainId } = useActiveWeb3React()
+
+  const isFromEvm = fromChainId !== undefined && isEvmChain(fromChainId)
+  const tokenAddress = amount?.currency.isNative ? undefined : amount?.currency.wrapped.address
+  const requiredAllowance = amount ? BigInt(amount.quotient.toString()) : undefined
+  const canReadAllowance =
+    isFromEvm &&
+    chainId === fromChainId &&
+    !!account &&
+    !!amount &&
+    !!tokenAddress &&
+    !!spender &&
+    spender !== ZERO_ADDRESS
+  const allowanceScope = canReadAllowance ? `${chainId}:${account}:${tokenAddress}:${spender}`.toLowerCase() : undefined
+
+  const {
+    data: onChainAllowance,
+    isError: isAllowanceError,
+    refetch: refetchAllowance,
+  } = useReadContract({
+    address: tokenAddress as Address | undefined,
+    abi: ALLOWANCE_ABI,
+    functionName: 'allowance',
+    args: account && spender ? [account as Address, spender as Address] : undefined,
+    chainId: isFromEvm ? (fromChainId as ChainId) : undefined,
+    query: { enabled: canReadAllowance },
+  })
+
+  const pendingApproval = useHasPendingApproval(tokenAddress, spender)
+  const needsApproval =
+    canReadAllowance &&
+    requiredAllowance !== undefined &&
+    onChainAllowance !== undefined &&
+    requiredAllowance > onChainAllowance
+
+  const [fallbackApprovalState, approveCallback] = useApproveCallback({
+    amount,
+    spender,
+    forceApprove: needsApproval,
+  })
+  const approvalState =
+    !canReadAllowance || isAllowanceError
+      ? fallbackApprovalState
+      : onChainAllowance === undefined
+      ? ApprovalState.UNKNOWN
+      : needsApproval
+      ? ApprovalState.NOT_APPROVED
+      : ApprovalState.APPROVED
+
+  const [crossChainTransactions] = useCrossChainTransactions()
+  const sourceTxHash = canReadAllowance
+    ? crossChainTransactions.find(
+        tx =>
+          tx.sourceChain === fromChainId &&
+          tx.sender?.toLowerCase() === account.toLowerCase() &&
+          getTransactionTokenAddress(tx.sourceToken)?.toLowerCase() === tokenAddress.toLowerCase(),
+      )?.sourceTxHash
+    : undefined
+  const { data: sourceTxReceipt } = useWaitForTransactionReceipt({
+    hash: sourceTxHash as Hash | undefined,
+    chainId: isFromEvm ? (fromChainId as ChainId) : undefined,
+    query: { enabled: canReadAllowance && !!sourceTxHash },
+  })
+
+  const [approvalInProgressScope, setApprovalInProgressScope] = useState<string | undefined>(
+    pendingApproval ? allowanceScope : undefined,
+  )
+  const [isRevalidatingAllowance, setIsRevalidatingAllowance] = useState(false)
+
+  const previousPendingApproval = useRef(pendingApproval)
+  const clearApprovalInProgress = useCallback(() => {
+    setApprovalInProgressScope(currentScope => (currentScope === allowanceScope ? undefined : currentScope))
+  }, [allowanceScope])
+
+  const getLatestAllowance = useCallback(async () => {
+    setIsRevalidatingAllowance(true)
+    try {
+      const { data, isError } = await refetchAllowance()
+      return isError ? undefined : data
+    } finally {
+      setIsRevalidatingAllowance(false)
+    }
+  }, [refetchAllowance])
+
+  const syncAllowance = useCallback(
+    async (isSynced: (allowance: bigint) => boolean = () => false) => {
+      for (const delay of ALLOWANCE_SYNC_DELAYS) {
+        if (delay) await sleep(delay)
+
+        const { data, isError } = await refetchAllowance()
+        if (!isError && data !== undefined && isSynced(data)) return
+      }
+    },
+    [refetchAllowance],
+  )
+
+  const approve = useCallback(async (): Promise<ApprovalStatus> => {
+    if (!amount || !allowanceScope || requiredAllowance === undefined) return ApprovalStatus.SKIPPED
+
+    const allowance = await getLatestAllowance()
+    if (allowance === undefined || requiredAllowance <= allowance) return ApprovalStatus.SKIPPED
+
+    setApprovalInProgressScope(allowanceScope)
+    let status = ApprovalStatus.FAILED
+    try {
+      status = await approveCallback(amount)
+      return status
+    } finally {
+      if (status !== ApprovalStatus.SUBMITTED) clearApprovalInProgress()
+    }
+  }, [allowanceScope, amount, approveCallback, clearApprovalInProgress, getLatestAllowance, requiredAllowance])
+
+  // Keep Approving visible until the approval receipt has refreshed the allowance.
+  useEffect(() => {
+    const wasPendingApproval = previousPendingApproval.current
+    previousPendingApproval.current = pendingApproval
+
+    if (!allowanceScope) return
+    if (pendingApproval) {
+      setApprovalInProgressScope(allowanceScope)
+      return
+    }
+    if (!wasPendingApproval || requiredAllowance === undefined) return
+
+    void syncAllowance(allowance => allowance >= requiredAllowance).finally(clearApprovalInProgress)
+  }, [allowanceScope, clearApprovalInProgress, pendingApproval, requiredAllowance, syncAllowance])
+
+  // The source swap can consume an exact allowance without changing pendingApproval.
+  useEffect(() => {
+    if (!allowanceScope || !sourceTxHash || sourceTxReceipt?.transactionHash !== sourceTxHash) return
+    void syncAllowance()
+  }, [allowanceScope, sourceTxHash, sourceTxReceipt?.transactionHash, syncAllowance])
+
+  // Clear the optimistic state if another trigger observed the updated allowance first.
+  useEffect(() => {
+    if (
+      approvalInProgressScope === allowanceScope &&
+      !pendingApproval &&
+      onChainAllowance !== undefined &&
+      !needsApproval
+    ) {
+      setApprovalInProgressScope(undefined)
+    }
+  }, [allowanceScope, approvalInProgressScope, needsApproval, onChainAllowance, pendingApproval])
+
+  // Fail closed when the latest allowance cannot be read before Review.
+  const revalidateAllowance = useCallback(async () => {
+    if (!canReadAllowance || requiredAllowance === undefined) return true
+
+    const allowance = await getLatestAllowance()
+    return allowance !== undefined && requiredAllowance <= allowance
+  }, [canReadAllowance, getLatestAllowance, requiredAllowance])
+
+  return {
+    approvalState,
+    approve,
+    isApproving:
+      (!!allowanceScope && approvalInProgressScope === allowanceScope) ||
+      pendingApproval ||
+      fallbackApprovalState === ApprovalState.PENDING,
+    isChecking: canReadAllowance && approvalState === ApprovalState.UNKNOWN,
+    isRevalidating: isRevalidatingAllowance,
+    revalidateAllowance,
+  }
+}


### PR DESCRIPTION
## Summary
- keep cross-chain ERC20 approval state synchronized after approval and source swap receipts
- revalidate allowance before approval and review actions to prevent stale state from submitting invalid swaps
- show consistent approval and checking states with bounded transaction-triggered retries