### PR TITLE
feat(seo): prerender crawlable public pages

### DIFF
--- a/apps/kyberswap-interface/etc/nginx.conf
+++ b/apps/kyberswap-interface/etc/nginx.conf
@@ -23,6 +23,14 @@ server {
     # what file to server as index
     index index.html index.htm;
 
+    # Serve the prerendered homepage only for exact `/`. Keep index.html as the empty-body SPA fallback
+    # for dynamic routes that cannot be safely enumerated at build time.
+    location = / {
+        try_files /index-root.html =404;
+        add_header Cache-Control "no-store" always;
+        add_header Link '<https://kyberswap.com/.well-known/api-catalog>; rel="api-catalog", <https://kyberswap.com/sitemap.xml>; rel="sitemap"; type="application/xml", <https://kyberswap.com/llms.txt>; rel="alternate"; type="text/plain"' always;
+    }
+
     location = /index.html {
         add_header Cache-Control no-store always;
         add_header Link '<https://kyberswap.com/.well-known/api-catalog>; rel="api-catalog", <https://kyberswap.com/sitemap.xml>; rel="sitemap"; type="application/xml", <https://kyberswap.com/llms.txt>; rel="alternate"; type="text/plain"' always;
@@ -42,12 +50,20 @@ server {
         # of `$uri/`, which makes nginx 301 to add a trailing slash — and that redirect leaks the internal
         # upstream Host. Falls back to the SPA shell for non-prerendered routes.
         try_files $uri $uri/index.html /index.html;
-        # Advertise agent/SEO discovery endpoints on every HTML response served here — including the homepage
-        # `/`, which try_files serves from index.html WITHOUT entering `location = /index.html`.
+        # `try_files` serves extensionless prerendered routes in this location, so the `.html` regex above
+        # is not selected. Set the HTML cache policy here as well to avoid stale hashed asset references.
+        add_header Cache-Control "no-store" always;
+        # Advertise agent/SEO discovery endpoints on every HTML response served here. Exact `/` uses the
+        # dedicated prerendered document above and declares the same discovery headers there.
         add_header Link '<https://kyberswap.com/.well-known/api-catalog>; rel="api-catalog", <https://kyberswap.com/sitemap.xml>; rel="sitemap"; type="application/xml", <https://kyberswap.com/llms.txt>; rel="alternate"; type="text/plain"' always;
     }
 
     location ^~ /.well-known/ {
+        try_files $uri =404;
+    }
+
+    location = /.well-known/api-catalog {
+        default_type application/linkset+json;
         try_files $uri =404;
     }
 

--- a/apps/kyberswap-interface/index.html
+++ b/apps/kyberswap-interface/index.html
@@ -128,6 +128,7 @@
     <style type="text/css" class="preloadhtml-style">
       .preloadhtml {
         position: fixed;
+        z-index: 9999;
         top: 0;
         left: 0;
         right: 0;

--- a/apps/kyberswap-interface/public/sitemap.xml
+++ b/apps/kyberswap-interface/public/sitemap.xml
@@ -6,10 +6,7 @@
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://kyberswap.com</loc>
-  </url>
-  <url>
-    <loc>https://kyberswap.com/swap</loc>
+    <loc>https://kyberswap.com/</loc>
   </url>
   <url>
     <loc>https://kyberswap.com/about/kyberswap</loc>
@@ -97,5 +94,8 @@
   </url>
   <url>
     <loc>https://kyberswap.com/swap/megaeth</loc>
+  </url>
+  <url>
+    <loc>https://kyberswap.com/swap/robinhood</loc>
   </url>
 </urlset>

--- a/apps/kyberswap-interface/scripts/prerender.mjs
+++ b/apps/kyberswap-interface/scripts/prerender.mjs
@@ -51,6 +51,7 @@ function setupBrowserGlobals() {
   const localStorage = makeStorage()
   const sessionStorage = makeStorage()
   const noop = () => {}
+  const navigatorShim = { userAgent: 'node', language: 'en-US', languages: ['en-US'] }
   const documentShim = {
     title: 'KyberSwap',
     cookie: '',
@@ -82,7 +83,7 @@ function setupBrowserGlobals() {
       search: '',
     },
     history: { pushState: noop, replaceState: noop, go: noop, back: noop, forward: noop, length: 0, state: null },
-    navigator: { userAgent: 'node', language: 'en-US' },
+    navigator: navigatorShim,
     open: noop,
     addEventListener: noop,
     removeEventListener: noop,
@@ -105,8 +106,9 @@ function setupBrowserGlobals() {
   g.document = documentShim
   // NB: do NOT set bare globalThis.location/history — they collide with Vite/Node URL internals
   // ("Invalid URL"). App code reads window.location, which is shimmed above.
-  if (!g.navigator)
-    Object.defineProperty(g, 'navigator', { value: { userAgent: 'node', language: 'en-US' }, configurable: true })
+  // Node 21 exposes a configurable global Navigator object whose userAgent is undefined. Replace it
+  // deterministically because React DOM reads navigator.userAgent during module evaluation.
+  Object.defineProperty(g, 'navigator', { value: navigatorShim, configurable: true })
   for (const name of [
     'Element',
     'HTMLElement',

--- a/apps/kyberswap-interface/scripts/prerender.mjs
+++ b/apps/kyberswap-interface/scripts/prerender.mjs
@@ -7,7 +7,7 @@
 // HTML, injects the route-specific <head>, and writes build/<route>/index.html. nginx serves these
 // directly and SPA-falls-back to build/index.html for every other route — no Node runtime in prod.
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
 
@@ -63,6 +63,7 @@ function setupBrowserGlobals() {
     getElementsByClassName: () => [],
     getElementsByTagName: () => [],
     createElement: () => ({ style: {}, setAttribute: noop, appendChild: noop, classList: { add: noop, remove: noop } }),
+    createTextNode: () => ({}),
     createTreeWalker: () => ({ nextNode: () => null, currentNode: null }),
     addEventListener: noop,
     removeEventListener: noop,
@@ -137,11 +138,25 @@ function setupBrowserGlobals() {
 // throw (fail the build loudly) instead of emitting the dev URL — strip any `?query` suffix before lookup.
 function rewriteAssetUrls(html, manifest) {
   return html.replace(/\/src\/[^"')\s>]+/g, m => {
-    const entry = manifest[m.slice(1).split('?')[0]] // strip leading '/' + any ?query suffix
-    if (!entry?.file) {
-      throw new Error(`Prerender emitted a dev asset URL with no manifest entry (would 404 in prod): ${m}`)
-    }
-    return `/${entry.file}`
+    const sourceUrl = m.slice(1).split('?')[0] // strip leading '/' + any ?query suffix
+    const entry = manifest[sourceUrl]
+    if (entry?.file) return `/${entry.file}`
+
+    // Vite inlines assets below assetsInlineLimit in the client bundle, so they intentionally have no
+    // manifest entry even though ssrLoadModule returns their /src URL. Inline the same local asset into
+    // static HTML instead of emitting a production 404.
+    const mime = {
+      '.gif': 'image/gif',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.png': 'image/png',
+      '.svg': 'image/svg+xml',
+      '.webp': 'image/webp',
+    }[extname(sourceUrl).toLowerCase()]
+    if (!mime) throw new Error(`Prerender emitted a dev asset URL with no manifest entry: ${m}`)
+
+    const data = readFileSync(resolve(appRoot, sourceUrl)).toString('base64')
+    return `data:${mime};base64,${data}`
   })
 }
 
@@ -162,6 +177,9 @@ async function main() {
     appType: 'custom',
     server: { middlewareMode: true },
     logLevel: 'warn',
+    // Ledger's ESM build contains extensionless relative imports. Browser bundling resolves them, but
+    // Node's external ESM loader does not; let Vite transform this package for the static renderer too.
+    ssr: { noExternal: ['@ledgerhq/hw-app-btc'] },
     // vite.config defines `process.env` -> the whole env object (a client-only workaround). Under
     // Node SSR that splices a giant literal into deps like @lingui/react and breaks parsing — and
     // Node already has a real `process.env`, so neutralize the replacement here (identity).
@@ -172,9 +190,17 @@ async function main() {
     // After the config has loaded (so the shim's window.location can't break Vite's URL internals),
     // but before module evaluation so module-scope browser access in built widgets is satisfied.
     setupBrowserGlobals()
-    const { renderRouteSkeleton, buildHeadHtml, prerenderRoutes, sitemapRoutes, siteUrl } = await vite.ssrLoadModule(
-      '/src/entry-server.tsx',
-    )
+    const {
+      renderRouteApp,
+      renderRouteSkeleton,
+      buildHeadHtml,
+      prerenderRoutes,
+      appPrerenderRoutes,
+      rootPrerenderSourceRoute,
+      sitemapRoutes,
+      siteUrl,
+    } = await vite.ssrLoadModule('/src/entry-server.tsx')
+    const appRoutes = new Set(appPrerenderRoutes)
 
     // Fail loudly if the hardcoded shim origin drifts from the app's canonical domain (KYBERSWAP_URL,
     // re-exported as siteUrl) — the two are kept in sync by hand because the shim is set up before the
@@ -195,9 +221,21 @@ async function main() {
       throw new Error('Template is missing the `<!-- ssr-skeleton:start/end -->` markers (build/index.html)')
     }
 
+    // Keep build/index.html as the empty-body fallback for non-enumerated SPA routes. nginx serves this
+    // separate document only for exact `/`, whose client redirect resolves to rootPrerenderSourceRoute.
+    const rootSkeleton = rewriteAssetUrls(renderRouteSkeleton(rootPrerenderSourceRoute), manifest)
+    const rootApp = rewriteAssetUrls(await renderRouteApp(rootPrerenderSourceRoute), manifest)
+    let rootHtml = template.replace(
+      /<!-- ssr-skeleton:start[\s\S]*?<!-- ssr-skeleton:end -->/,
+      () => `<!-- ssr-skeleton:start -->\n      ${rootSkeleton}\n      <!-- ssr-skeleton:end -->`,
+    )
+    rootHtml = rootHtml.replace('<div id="app"></div>', () => `<div id="app">${rootApp}</div>`)
+    writeFileSync(resolve(appRoot, 'build/index-root.html'), rootHtml, 'utf8')
+    console.log(`✓ prerendered / (app ${rootApp.length} B, skeleton ${rootSkeleton.length} B)`)
+
     for (const url of prerenderRoutes) {
       const head = buildHeadHtml(url)
-      // Every inject uses a replacement FUNCTION, not a string: rendered head/skeleton HTML can contain
+      // Every inject uses a replacement FUNCTION, not a string: rendered HTML can contain
       // `$` sequences ($&, $', $<n>) that String.replace would otherwise interpret as special replacement
       // patterns and silently corrupt the output. A function's return value is inserted verbatim.
       let html = template.replace(
@@ -207,18 +245,25 @@ async function main() {
 
       // Swap the generic cold-load logo for this route's page-shell skeleton (the same <RouteFallback>
       // the client shows while the lazy chunk downloads) so the cold load shows the page shape, not a
-      // spinner. Cosmetic only — the body stays the empty <div id="app"></div>; the client createRoot-
-      // renders into it (no server-rendered body, no hydration).
+      // spinner. This overlay remains cosmetic and is removed when the interactive client mounts.
       const skeleton = rewriteAssetUrls(renderRouteSkeleton(url), manifest)
       html = html.replace(
         /<!-- ssr-skeleton:start[\s\S]*?<!-- ssr-skeleton:end -->/,
         () => `<!-- ssr-skeleton:start -->\n      ${skeleton}\n      <!-- ssr-skeleton:end -->`,
       )
 
+      // Render the actual route tree for indexable pages as well. This is static build output (not a
+      // production Node server), and the client intentionally mounts a fresh interactive tree instead of
+      // hydrating persisted wallet state into deterministic build-time markup.
+      const app = appRoutes.has(url) ? rewriteAssetUrls(await renderRouteApp(url), manifest) : ''
+      if (app) html = html.replace('<div id="app"></div>', () => `<div id="app">${app}</div>`)
+
       const outDir = resolve(appRoot, 'build', url.replace(/^\//, ''))
       mkdirSync(outDir, { recursive: true })
       writeFileSync(resolve(outDir, 'index.html'), html, 'utf8')
-      console.log(`✓ prerendered ${url} (head ${head.length} B, skeleton ${skeleton.length} B)`)
+      console.log(
+        `✓ prerendered ${url} (head ${head.length} B, app ${app.length || 'skipped'} B, skeleton ${skeleton.length} B)`,
+      )
     }
 
     // Emit standalone page-shell skeleton fragments for the dynamic routes the og-service serves but the

--- a/apps/kyberswap-interface/src/components/Footer/Footer.tsx
+++ b/apps/kyberswap-interface/src/components/Footer/Footer.tsx
@@ -42,7 +42,7 @@ export const FooterSocialLink = () => {
 
 function Footer() {
   return (
-    <div className="w-full shrink-0 bg-buttonGray/20">
+    <footer className="w-full shrink-0 bg-buttonGray/20">
       <div className="mx-auto flex w-full max-w-[1480px] flex-col-reverse items-center justify-between gap-4 p-4 sm:flex-row sm:px-6">
         <div className="flex items-start gap-4 text-xs text-subText max-sm:gap-6 sm:items-center">
           <div className="flex items-center gap-2 max-sm:flex-col max-sm:gap-3">
@@ -111,7 +111,7 @@ function Footer() {
         </div>
         <FooterSocialLink />
       </div>
-    </div>
+    </footer>
   )
 }
 

--- a/apps/kyberswap-interface/src/components/Header/index.tsx
+++ b/apps/kyberswap-interface/src/components/Header/index.tsx
@@ -88,7 +88,10 @@ export default function Header() {
           </Link>
         )}
         {!isEmbeddedSwap && (
-          <div className="flex w-full flex-row flex-nowrap items-center justify-center gap-1 max-lg:justify-end">
+          <nav
+            aria-label="Primary"
+            className="flex w-full flex-row flex-nowrap items-center justify-center gap-1 max-lg:justify-end"
+          >
             <SwapNavGroup dropdownAlign={navGroupDropdownAlign} />
             <EarnNavGroup dropdownAlign={navGroupDropdownAlign} />
 
@@ -106,7 +109,7 @@ export default function Header() {
             )}
             {!upToSmall && <AboutNavGroup dropdownAlign={navGroupDropdownAlign} />}
             <RecapButton />
-          </div>
+          </nav>
         )}
       </div>
 

--- a/apps/kyberswap-interface/src/entry-server.tsx
+++ b/apps/kyberswap-interface/src/entry-server.tsx
@@ -1,15 +1,34 @@
+import { ChainId } from '@kyberswap/ks-sdk-core'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import utc from 'dayjs/plugin/utc'
+import { LanguageProvider } from 'i18n'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { prerender } from 'react-dom/static'
+import { Provider } from 'react-redux'
 import { StaticRouter } from 'react-router-dom/server'
+import { WagmiProvider } from 'wagmi'
 
 import RouteFallback from 'components/RouteFallback'
+import { wagmiConfig } from 'components/Web3Provider'
 import { APP_PATHS, KYBERSWAP_URL } from 'constants/index'
 import { MAINNET_NETWORKS, NETWORKS_INFO } from 'constants/networks'
+import App from 'pages/App'
+import { makeStore } from 'state'
+import { updateChainId } from 'state/user/actions'
 import ThemeProvider from 'theme'
+import { getChainIdFromSlug } from 'utils/string'
+
+// Match the client entry before any lazy route module evaluates helpers that depend on these plugins.
+dayjs.extend(utc)
+dayjs.extend(duration)
+dayjs.extend(relativeTime)
 
 // Build-time prerender support (no Node runtime in production — this module is loaded once by
-// scripts/prerender.mjs via Vite's ssrLoadModule). The app body is NEVER server-rendered: every route is
-// head-only — prerender injects the per-route <head> (buildHeadHtml) and bakes the route's page-shell
-// skeleton (renderRouteSkeleton) into the cold-load overlay; the body is client-rendered after load.
+// scripts/prerender.mjs via Vite's ssrLoadModule). Indexable routes get both their route-specific <head>
+// and static app body at build time; the existing client entry mounts the interactive app after load.
 
 // Re-export so the prerender script can read the per-route <head> from the same module.
 export { buildHeadHtml } from 'components/Seo/seoConfig'
@@ -20,9 +39,9 @@ export const siteUrl = KYBERSWAP_URL
 
 /**
  * Bounded public routes to prerender (en-US only), derived from app constants so the list tracks
- * network/campaign changes. Every route is head-only: the per-route <head> + cold-load skeleton are
- * baked into a static index.html, the body is client-rendered. The home route is intentionally omitted:
- * the SPA-fallback build/index.html already serves it with the (identical) default head.
+ * network/campaign changes. Every route gets its per-route <head> and cold-load skeleton; the indexable
+ * subset also gets its app body. The home route is intentionally omitted from this directory-route list
+ * because scripts/prerender.mjs emits it separately without changing the empty-body SPA fallback.
  */
 export const prerenderRoutes: string[] = [
   `${APP_PATHS.ABOUT}/kyberswap`,
@@ -66,13 +85,72 @@ export const sitemapRoutes: string[] = [
   ...Array.from(new Set(MAINNET_NETWORKS)).map(chainId => `${APP_PATHS.SWAP}/${NETWORKS_INFO[chainId].route}`),
 ]
 
+// The client resolves `/` to the default Ethereum swap route. Prerender that same existing route tree
+// into a dedicated exact-root document; build/index.html remains an empty-body SPA fallback for dynamic
+// URLs that cannot be enumerated at build time.
+export const rootPrerenderSourceRoute = `${APP_PATHS.SWAP}/${NETWORKS_INFO[ChainId.MAINNET].route}`
+
+// Full body prerender is an SEO concern, so keep it aligned with the index,follow routes. Noindex
+// campaigns and wallet-gated pages retain their route-specific head/skeleton without pulling their
+// wallet-only dependency graph into the Node build renderer.
+export const appPrerenderRoutes = sitemapRoutes.filter(route => route !== '/')
+
+function createRouteApp(url: string) {
+  const store = makeStore()
+  const networkSlug = url.startsWith(`${APP_PATHS.SWAP}/`)
+    ? url.slice(APP_PATHS.SWAP.length + 1).split(/[/?#]/, 1)[0]
+    : undefined
+  const routeChainId = getChainIdFromSlug(networkSlug)
+  if (routeChainId !== undefined) store.dispatch(updateChainId(routeChainId))
+
+  const queryClient = new QueryClient()
+  return (
+    <Provider store={store} stabilityCheck="never" identityFunctionCheck="never">
+      <WagmiProvider config={wagmiConfig}>
+        <QueryClientProvider client={queryClient}>
+          <StaticRouter location={url}>
+            <LanguageProvider>
+              <ThemeProvider>
+                <App />
+              </ThemeProvider>
+            </LanguageProvider>
+          </StaticRouter>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </Provider>
+  )
+}
+
+/**
+ * Render the real route tree to static HTML. React's static prerender API waits for lazy route chunks,
+ * unlike renderToString. Once those chunks are resolved, renderToStaticMarkup emits a flat document
+ * without React's hidden Suspense reveal payload, so headings and links are directly present even when
+ * scripts are disabled. Each pass gets isolated Redux and Query clients to prevent state leakage.
+ */
+export async function renderRouteApp(url: string): Promise<string> {
+  const renderErrors: unknown[] = []
+
+  const { prelude } = await prerender(createRouteApp(url), {
+    onError(error) {
+      renderErrors.push(error)
+    },
+  })
+  await new Response(prelude).text()
+
+  if (renderErrors.length) {
+    throw new AggregateError(renderErrors, `Failed to prerender ${url}`)
+  }
+
+  return renderToStaticMarkup(createRouteApp(url))
+}
+
 /**
  * Render a route's Suspense fallback (the page-shell skeleton from <RouteFallback>) to static HTML for
  * the cold-load placeholder. Reuses the SAME React skeleton the app shows while a lazy chunk loads, so
  * the build-baked cold-load shape and the post-hydrate fallback come from ONE source (no drift). The
  * skeletons are pure presentational (no wallet/data/Trans), so only a router (RouteFallback reads
  * useLocation) + ThemeProvider (Skeleton reads useTheme) are needed. renderToStaticMarkup emits no
- * hydration markers — the client createRoot just clears #app and re-renders, so this is purely cosmetic.
+ * hydration markers — this is a separate cosmetic cold-load overlay.
  */
 export function renderRouteSkeleton(url: string): string {
   return renderToStaticMarkup(

--- a/apps/kyberswap-interface/src/index.tsx
+++ b/apps/kyberswap-interface/src/index.tsx
@@ -112,9 +112,10 @@ const ReactApp = () => {
   )
 }
 
-// Prerendered routes are head-only: the served #app is always empty (the cold-load skeleton lives in the
-// .preloadhtml overlay, dropped by hideLoader on mount), so the body is always client-rendered. No route
-// ships server-rendered body markup, so there is nothing to hydrate.
+// Prerendered routes can contain deterministic build-time markup for crawlers. Mount a fresh interactive
+// tree instead of hydrating it: wallet/localStorage state and responsive media queries are client-only and
+// can legitimately differ from the static build. The .preloadhtml overlay hides this replacement and is
+// dropped synchronously by ReactApp before paint.
 const container = document.getElementById('app') as HTMLElement
 createRoot(container).render(<ReactApp />)
 

--- a/apps/kyberswap-interface/src/pages/App.tsx
+++ b/apps/kyberswap-interface/src/pages/App.tsx
@@ -74,11 +74,11 @@ const AppWrapper = ({ children }: { children: React.ReactNode }) => (
 )
 
 const HeaderWrapper = ({ children }: { children: React.ReactNode }) => (
-  <div className="z-[3] flex w-full shrink-0 flex-row flex-nowrap justify-between">{children}</div>
+  <header className="z-[3] flex w-full shrink-0 flex-row flex-nowrap justify-between">{children}</header>
 )
 
 const BodyWrapper = ({ children }: { children: React.ReactNode }) => (
-  <div className="relative z-[1] flex w-full flex-1 flex-col items-center">{children}</div>
+  <main className="relative z-[1] flex w-full flex-1 flex-col items-center">{children}</main>
 )
 
 const preloadImages = () => {

--- a/apps/kyberswap-interface/src/render.smoke.test.tsx
+++ b/apps/kyberswap-interface/src/render.smoke.test.tsx
@@ -1,49 +1,40 @@
-import { QueryClientProvider } from '@tanstack/react-query'
-import { renderToString } from 'react-dom/server'
-import { Provider } from 'react-redux'
-import { StaticRouter } from 'react-router-dom/server'
-import { beforeAll, describe, expect, it } from 'vitest'
-import { WagmiProvider } from 'wagmi'
+import { describe, expect, it } from 'vitest'
 
-// Phase 1 SSR render smoke test: each representative public route must render to non-empty
-// HTML in a node environment without throwing. This proves the app is importable + renderable
-// server-side (foundation for the Phase 2/3 prerender). Ordered lightest import-graph first.
+// Representative public routes must complete the same async static render used by the build. This waits
+// for React.lazy route chunks, so it validates route content rather than only the Suspense fallback.
 const ROUTES = ['/about/kyberswap', '/earn', '/earn/pools', '/', '/swap/ethereum']
 
 describe('SSR render smoke', () => {
-  beforeAll(async () => {
-    // Activate the default catalog synchronously so LanguageProvider renders content.
-    const { activateInitialLocale } = await import('i18n')
-    activateInitialLocale()
+  it.each(ROUTES)('renders %s without throwing', async location => {
+    const { renderRouteApp } = await import('entry-server')
+    const html = await renderRouteApp(location)
+
+    expect(html.length).toBeGreaterThan(0)
+    expect(html).toContain('<main')
   })
 
-  it.each(ROUTES)('renders %s without throwing', async location => {
-    const { makeStore } = await import('state')
-    const { LanguageProvider } = await import('i18n')
-    const ThemeProvider = (await import('theme')).default
-    const { wagmiConfig, queryClient } = await import('components/Web3Provider')
-    const { default: App } = await import('pages/App')
+  it('includes route headings and links in the static swap HTML', async () => {
+    const { renderRouteApp } = await import('entry-server')
+    const html = await renderRouteApp('/swap/ethereum')
 
-    const store = makeStore()
-    let html = ''
-    expect(() => {
-      html = renderToString(
-        <Provider store={store}>
-          <WagmiProvider config={wagmiConfig}>
-            <QueryClientProvider client={queryClient}>
-              <StaticRouter location={location}>
-                <LanguageProvider>
-                  <ThemeProvider>
-                    <App />
-                  </ThemeProvider>
-                </LanguageProvider>
-              </StaticRouter>
-            </QueryClientProvider>
-          </WagmiProvider>
-        </Provider>,
-      )
-    }).not.toThrow()
-    // Non-empty assertion also catches a regression where LanguageProvider renders null.
-    expect(html.length).toBeGreaterThan(0)
+    expect(html).toContain('<h1')
+    expect(html).toContain('<h2')
+    expect(html).toContain('<nav')
+    expect(html).toMatch(/<a\b[^>]*href="\//)
+    expect(html).toMatch(/<a\b[^>]*href="https?:\/\//)
+    expect(html).not.toContain('<div hidden id="S:')
+    expect(html).not.toContain('<!--$?-->')
+    expect(html).not.toContain('$RC(')
+    expect(html).not.toContain('<script')
+  })
+
+  it('uses the route network in static swap navigation', async () => {
+    const { renderRouteApp } = await import('entry-server')
+    const ethereumHtml = await renderRouteApp('/swap/ethereum')
+    const lineaHtml = await renderRouteApp('/swap/linea')
+
+    expect(ethereumHtml).toMatch(/<a\b(?=[^>]*aria-current="page")(?=[^>]*href="\/swap\/ethereum")[^>]*>/)
+    expect(lineaHtml).toMatch(/<a\b(?=[^>]*aria-current="page")(?=[^>]*href="\/swap\/linea")[^>]*>/)
+    expect(lineaHtml).not.toMatch(/<a\b(?=[^>]*aria-current="page")(?=[^>]*href="\/swap\/ethereum")[^>]*>/)
   })
 })

--- a/apps/kyberswap-interface/src/state/index.ts
+++ b/apps/kyberswap-interface/src/state/index.ts
@@ -58,7 +58,7 @@ const PERSISTED_KEYS: string[] = ['user', 'transactions', 'profile', 'crossChain
 // Client-only: read persisted state from localStorage and migrate from old version to
 // new version, preventing lost favorite tokens of user. Returns {} under SSR/prerender.
 function getClientPreloadedState(): Partial<AppState> {
-  if (typeof window === 'undefined') return {}
+  if (import.meta.env.SSR || typeof window === 'undefined') return {}
   const preloadedState: any = load({ states: PERSISTED_KEYS })
   if ('user' in preloadedState) {
     const userState: UserState = preloadedState.user
@@ -226,7 +226,7 @@ export const getClientStore = (): AppStore => {
 }
 
 // Default export: lazy client singleton in the browser; a fresh empty store under Node (prerender).
-const store: AppStore = typeof window !== 'undefined' ? getClientStore() : makeStore()
+const store: AppStore = !import.meta.env.SSR && typeof window !== 'undefined' ? getClientStore() : makeStore()
 export default store
 
 /**

--- a/apps/kyberswap-interface/test/smoke.setup.ts
+++ b/apps/kyberswap-interface/test/smoke.setup.ts
@@ -28,6 +28,7 @@ const storage = {
 
 const noop = () => {}
 const g = globalThis as any
+const navigatorShim = { userAgent: 'node', language: 'en-US', languages: ['en-US'] }
 
 g.localStorage = g.localStorage || storage
 g.sessionStorage = g.sessionStorage || storage
@@ -64,7 +65,7 @@ const windowShim = {
     search: '',
   },
   history: { pushState: noop, replaceState: noop, go: noop, back: noop, forward: noop, length: 0, state: null },
-  navigator: { userAgent: 'node', language: 'en-US' },
+  navigator: navigatorShim,
   open: noop,
   addEventListener: noop,
   removeEventListener: noop,
@@ -114,9 +115,6 @@ for (const name of ['ResizeObserver', 'IntersectionObserver', 'MutationObserver'
   if (!g[name]) g[name] = ObserverStub
 }
 
-if (!g.navigator) {
-  Object.defineProperty(g, 'navigator', {
-    value: { userAgent: 'node', language: 'en-US', languages: ['en-US'] },
-    configurable: true,
-  })
-}
+// Node 21 exposes a configurable global Navigator object whose userAgent is undefined. Replace it
+// deterministically because React DOM reads navigator.userAgent during module evaluation.
+Object.defineProperty(g, 'navigator', { value: navigatorShim, configurable: true })

--- a/apps/kyberswap-interface/test/smoke.setup.ts
+++ b/apps/kyberswap-interface/test/smoke.setup.ts
@@ -44,6 +44,7 @@ const documentShim = {
   getElementsByClassName: () => [],
   getElementsByTagName: () => [],
   createElement: () => ({ style: {}, setAttribute: noop, appendChild: noop, classList: { add: noop, remove: noop } }),
+  createTextNode: () => ({}),
   createTreeWalker: () => ({ nextNode: () => null, currentNode: null }),
   addEventListener: noop,
   removeEventListener: noop,


### PR DESCRIPTION
## Summary

- Render the real application body into build-time HTML for indexable home, about, earn, KyberDAO, and per-network swap routes so crawlers receive headings, navigation, and links before client JavaScript runs.
- Serve a dedicated prerendered document for `/` while preserving the empty SPA fallback for non-enumerated dynamic routes.
- Track the completed crawlability work and refresh sitemap and discovery-serving behavior.

## Implementation

- Use React static prerender to resolve lazy route modules, then `renderToStaticMarkup` with isolated Redux and Query clients to emit flat HTML without hidden Suspense reveal payloads.
- Initialize swap render state from the route network so each `/swap/<network>` artifact exposes the correct active chain.
- Keep noindex campaigns and wallet-gated routes head-and-skeleton-only; full-body output remains aligned with sitemap routes.
- Retain `createRoot` for client takeover so persisted wallet, local storage, and responsive state are rebuilt on the client instead of hydrated against deterministic build state.
- Add semantic `header`, `nav`, `main`, and `footer` landmarks, and keep the preload overlay above static markup until client mount.

## Serving behavior

- Map exact `/` to `index-root.html`.
- Serve per-route `index.html` artifacts before falling back to the SPA `index.html`.
- Apply `no-store` to extensionless HTML responses and return the API catalog with the linkset JSON media type.
- Regenerate the sitemap from the approved public route list.

## Coverage

- Exercise representative asynchronous route renders through the production prerender entry.
- Assert swap HTML includes H1, H2, semantic navigation, internal and external anchors, no hidden Suspense reveal script, and the correct route-network navigation.