### PR TITLE
fix(embed): serve per-embedder frame-ancestors to hide partner list

### DIFF
--- a/apps/kyberswap-interface/Dockerfile
+++ b/apps/kyberswap-interface/Dockerfile
@@ -3,6 +3,7 @@ FROM nginx:alpine
 COPY ./build /var/www
 
 COPY ./etc/nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./etc/csp.conf /etc/nginx/conf.d/csp.conf
 
 EXPOSE 80
 

--- a/apps/kyberswap-interface/etc/csp.conf
+++ b/apps/kyberswap-interface/etc/csp.conf
@@ -51,4 +51,7 @@ map $embed_origin $frame_ancestors {
     "~*^https://app\.sectorone\.xyz$"                "'self' $embed_origin";
     "~*^https://app\.swapline\.com$"                 "'self' $embed_origin";
     "~*^https://chamberfi\.com$"                     "'self' $embed_origin";
+
+    # Internal iframe-embed harness (apps/iframe-embed-demo deployed to Netlify).
+    "~*^https://kyberswap-iframe-demo\.netlify\.app$"  "'self' $embed_origin";
 }

--- a/apps/kyberswap-interface/etc/csp.conf
+++ b/apps/kyberswap-interface/etc/csp.conf
@@ -1,0 +1,54 @@
+# Dynamic `frame-ancestors` for partner iframe embedding.
+#
+# The partner whitelist is echoed back ONE origin at a time: every response advertises at most the
+# single origin that is currently framing the app, never the whole roster. A non-whitelisted (or
+# referrer-less) embedder only ever sees `frame-ancestors 'self'`, so the partner list can no longer
+# be read off a CSP violation report.
+#
+# `map` is only valid at http context, so this file is included via /etc/nginx/conf.d/*.conf next to
+# default.conf rather than living inside its `server{}` block. `$frame_ancestors` is consumed by the
+# `add_header Content-Security-Policy` lines on the HTML locations in default.conf.
+
+# Reduce the Referer to its origin (scheme://host[:port]) and drop the path. `~*` so a mixed-case
+# host still matches; an absent or non-http Referer yields "".
+map $http_referer $embed_origin {
+    default                                    "";
+    "~*^(?<scheme_host>https?://[^/]+)"        $scheme_host;
+}
+
+# Map a whitelisted origin to `'self' <that-origin>`, everything else (including "") to `'self'`.
+# Each key is fully anchored (^...$) so a crafted Referer like `https://alphanomics.io.evil.com` or
+# `https://alphanomics.io foo` can't slip through and get reflected into the header. Matching is
+# case-insensitive; the wildcard entry mirrors the CSP `https://*.gurunetwork.ai` source.
+map $embed_origin $frame_ancestors {
+    default                                          "'self'";
+
+    "~*^https://platform\.alphanomics\.io$"          "'self' $embed_origin";
+    "~*^https://staging\.alphanomics\.io$"           "'self' $embed_origin";
+    "~*^https://alphanomics\.io$"                    "'self' $embed_origin";
+    "~*^https://thesonicgoat\.com$"                  "'self' $embed_origin";
+    "~*^https://app\.safe\.global$"                  "'self' $embed_origin";
+    "~*^https://dexscreener\.com$"                   "'self' $embed_origin";
+    "~*^https://dev-app\.telifi\.xyz$"               "'self' $embed_origin";
+    "~*^https://stg-app\.telifi\.xyz$"               "'self' $embed_origin";
+    "~*^https://app\.tobiwallet\.app$"               "'self' $embed_origin";
+    "~*^https://coinsdo\.com$"                       "'self' $embed_origin";
+    "~*^https://([a-z0-9-]+\.)+gurunetwork\.ai$"     "'self' $embed_origin";
+    "~*^https://basedbrett\.com$"                    "'self' $embed_origin";
+    "~*^https://www\.basedbrett\.com$"               "'self' $embed_origin";
+    "~*^https://web\.telegram\.org$"                 "'self' $embed_origin";
+    "~*^https://safe\.berachain\.com$"               "'self' $embed_origin";
+    "~*^https://testnet\.berally\.io$"               "'self' $embed_origin";
+    "~*^https://app\.berally\.io$"                   "'self' $embed_origin";
+    "~*^https://dex\.guru$"                          "'self' $embed_origin";
+    "~*^https://app\.gains-associates\.com$"         "'self' $embed_origin";
+    "~*^https://new-gains\.netlify\.app$"            "'self' $embed_origin";
+    "~*^https://gains-associates\.com$"              "'self' $embed_origin";
+    "~*^https://arbitragedash\.xyz$"                 "'self' $embed_origin";
+    "~*^https://arbitragedash\.zapto\.org$"          "'self' $embed_origin";
+    "~*^https://daos\.world$"                        "'self' $embed_origin";
+    "~*^https://dhedge\.org$"                        "'self' $embed_origin";
+    "~*^https://app\.sectorone\.xyz$"                "'self' $embed_origin";
+    "~*^https://app\.swapline\.com$"                 "'self' $embed_origin";
+    "~*^https://chamberfi\.com$"                     "'self' $embed_origin";
+}

--- a/apps/kyberswap-interface/etc/nginx.conf
+++ b/apps/kyberswap-interface/etc/nginx.conf
@@ -29,11 +29,18 @@ server {
         try_files /index-root.html =404;
         add_header Cache-Control "no-store" always;
         add_header Link '<https://kyberswap.com/.well-known/api-catalog>; rel="api-catalog", <https://kyberswap.com/sitemap.xml>; rel="sitemap"; type="application/xml", <https://kyberswap.com/llms.txt>; rel="alternate"; type="text/plain"' always;
+        # Per-embedder frame-ancestors (see csp.conf); Referer-dependent -> Vary.
+        add_header Content-Security-Policy "frame-ancestors $frame_ancestors" always;
+        add_header Vary Referer always;
     }
 
     location = /index.html {
         add_header Cache-Control no-store always;
         add_header Link '<https://kyberswap.com/.well-known/api-catalog>; rel="api-catalog", <https://kyberswap.com/sitemap.xml>; rel="sitemap"; type="application/xml", <https://kyberswap.com/llms.txt>; rel="alternate"; type="text/plain"' always;
+        # Per-embedder frame-ancestors (whitelist + reflection in csp.conf): a non-whitelisted embedder
+        # only sees `'self'`, so the partner list can't be enumerated. Depends on Referer -> Vary on it.
+        add_header Content-Security-Policy "frame-ancestors $frame_ancestors" always;
+        add_header Vary Referer always;
     }
 
     # Every HTML document embeds the per-deploy hashed JS/CSS chunk URLs. It must NEVER be cached by the
@@ -43,6 +50,9 @@ server {
     # caches them heuristically. Only the hashed assets below get long-lived immutable caching.
     location ~* \.html$ {
         add_header Cache-Control "no-store" always;
+        # Per-embedder frame-ancestors (see csp.conf); Referer-dependent -> Vary.
+        add_header Content-Security-Policy "frame-ancestors $frame_ancestors" always;
+        add_header Vary Referer always;
     }
 
     location / {
@@ -56,6 +66,9 @@ server {
         # Advertise agent/SEO discovery endpoints on every HTML response served here. Exact `/` uses the
         # dedicated prerendered document above and declares the same discovery headers there.
         add_header Link '<https://kyberswap.com/.well-known/api-catalog>; rel="api-catalog", <https://kyberswap.com/sitemap.xml>; rel="sitemap"; type="application/xml", <https://kyberswap.com/llms.txt>; rel="alternate"; type="text/plain"' always;
+        # Per-embedder frame-ancestors (see csp.conf); Referer-dependent -> Vary.
+        add_header Content-Security-Policy "frame-ancestors $frame_ancestors" always;
+        add_header Vary Referer always;
     }
 
     location ^~ /.well-known/ {


### PR DESCRIPTION
## Summary
- Add `apps/kyberswap-interface/etc/csp.conf` with two nginx `map` blocks: reduce the incoming `Referer` to its origin, then match it against the partner allowlist (27 exact origins + the `*.gurunetwork.ai` wildcard). Only the matching origin is reflected back, so each response carries at most the single origin currently framing the app.
- Emit `Content-Security-Policy: frame-ancestors 'self' <that-origin>` (falling back to `'self'`) plus `Vary: Referer` on the four HTML-serving locations in `nginx.conf` (`= /`, `= /index.html`, `~* \.html$`, `/`). Long-cached JS/CSS/media locations are left untouched so a Referer-dependent header is never cached against them.
- Copy `csp.conf` into `/etc/nginx/conf.d/` in the Dockerfile so the `map` blocks load at http context.

Effect: a non-whitelisted (or referrer-less) embedder only ever sees `frame-ancestors 'self'`, so the full partner roster can no longer be enumerated from a CSP violation report. Every allowlist entry is fully anchored (`^…$`), so a crafted `Referer` — suffix/prefix look-alike, embedded space, or `http://` scheme — cannot be reflected into the header.
