### PR TITLE
feat(token-selector): scroll hints for the chain dropdown + a calmer token-detail animation

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/ChainSelector.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/ChainSelector.tsx
@@ -1,7 +1,8 @@
 import { ChainId } from '@kyberswap/ks-sdk-core'
-import { KeyboardEvent, memo, useRef, useState } from 'react'
-import { ChevronDown, Globe } from 'react-feather'
+import { KeyboardEvent, memo, useCallback, useEffect, useRef, useState } from 'react'
+import { ChevronDown, ChevronUp, Globe } from 'react-feather'
 
+import { ScrollIndicator } from 'components/DropdownMenu/styles'
 import type { NetworkInfo } from 'constants/networks/type'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { cn } from 'utils/cn'
@@ -24,6 +25,26 @@ export const ChainSelector = memo(({ chains, selectedChainId, onChange }: ChainS
   const select = (chainId: ChainId) => {
     onChange(chainId)
     setOpen(false)
+  }
+
+  // Chevrons signal (and scroll to) the chains hidden above/below the list's max height.
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [canScrollUp, setCanScrollUp] = useState(false)
+  const [canScrollDown, setCanScrollDown] = useState(false)
+
+  const updateScrollIndicators = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setCanScrollUp(el.scrollTop > 0)
+    setCanScrollDown(el.scrollTop + el.clientHeight < el.scrollHeight - 1)
+  }, [])
+
+  useEffect(() => {
+    if (open) requestAnimationFrame(updateScrollIndicators)
+  }, [open, chains, updateScrollIndicators])
+
+  const handleScrollClick = (direction: 'up' | 'down') => {
+    scrollRef.current?.scrollBy({ top: direction === 'up' ? -100 : 100, behavior: 'smooth' })
   }
 
   return (
@@ -57,38 +78,56 @@ export const ChainSelector = memo(({ chains, selectedChainId, onChange }: ChainS
 
       {open && (
         <div
-          role="listbox"
-          aria-label="Network"
           data-testid="chain-selector-dropdown"
-          className="ks-scrollbar absolute right-0 top-[calc(100%+4px)] z-30 flex max-h-80 w-max origin-top-right animate-dropdownIn flex-col overflow-y-auto rounded-xl bg-tableHeader px-3 py-2 shadow-[0px_4px_12px_rgba(0,0,0,0.32)] motion-reduce:animate-none"
+          className="absolute right-0 top-[calc(100%+4px)] z-30 flex w-max origin-top-right animate-dropdownIn flex-col rounded-xl bg-tableHeader px-3 py-2 shadow-[0px_4px_12px_rgba(0,0,0,0.32)] motion-reduce:animate-none"
         >
-          {chains.map(chain => {
-            const selected = chain.chainId === selectedChainId
-            return (
-              <div
-                key={chain.chainId}
-                role="option"
-                aria-selected={selected}
-                data-testid={`chain-option-${chain.chainId}`}
-                tabIndex={0}
-                onClick={() => select(chain.chainId)}
-                onKeyDown={(e: KeyboardEvent) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    select(chain.chainId)
-                  }
-                }}
-                className={cn(
-                  'flex h-9 w-full shrink-0 cursor-pointer items-center gap-2 whitespace-nowrap rounded-xl px-2 text-sm text-text',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-                  selected ? 'bg-white-04' : 'hover:bg-white-04',
-                )}
-              >
-                <img src={chain.icon} alt={chain.name} className="size-[18px] shrink-0 rounded-full" />
-                <span className="truncate">{chain.name}</span>
-              </div>
-            )
-          })}
+          <ScrollIndicator $visible={canScrollUp} data-testid="chain-scroll-up" onClick={() => handleScrollClick('up')}>
+            <ChevronUp size={16} />
+          </ScrollIndicator>
+
+          <div
+            ref={scrollRef}
+            role="listbox"
+            aria-label="Network"
+            onScroll={updateScrollIndicators}
+            className="ks-scrollbar flex max-h-80 flex-col overflow-y-auto"
+          >
+            {chains.map(chain => {
+              const selected = chain.chainId === selectedChainId
+              return (
+                <div
+                  key={chain.chainId}
+                  role="option"
+                  aria-selected={selected}
+                  data-testid={`chain-option-${chain.chainId}`}
+                  tabIndex={0}
+                  onClick={() => select(chain.chainId)}
+                  onKeyDown={(e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      select(chain.chainId)
+                    }
+                  }}
+                  className={cn(
+                    'flex h-9 w-full shrink-0 cursor-pointer items-center gap-2 whitespace-nowrap rounded-xl px-2 text-sm text-text',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+                    selected ? 'bg-white-04' : 'hover:bg-white-04',
+                  )}
+                >
+                  <img src={chain.icon} alt={chain.name} className="size-[18px] shrink-0 rounded-full" />
+                  <span className="truncate">{chain.name}</span>
+                </div>
+              )
+            })}
+          </div>
+
+          <ScrollIndicator
+            $visible={canScrollDown}
+            data-testid="chain-scroll-down"
+            onClick={() => handleScrollClick('down')}
+          >
+            <ChevronDown size={16} />
+          </ScrollIndicator>
         </div>
       )}
     </div>

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/ChainSelector.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/ChainSelector.tsx
@@ -90,7 +90,7 @@ export const ChainSelector = memo(({ chains, selectedChainId, onChange }: ChainS
             role="listbox"
             aria-label="Network"
             onScroll={updateScrollIndicators}
-            className="ks-scrollbar flex max-h-80 flex-col overflow-y-auto"
+            className="ks-scrollbar flex max-h-[360px] flex-col overflow-y-auto"
           >
             {chains.map(chain => {
               const selected = chain.chainId === selectedChainId

--- a/apps/kyberswap-interface/tailwind.config.ts
+++ b/apps/kyberswap-interface/tailwind.config.ts
@@ -203,15 +203,16 @@ const config: Config = {
           from: { opacity: '0', transform: 'translateY(-6px) scale(0.97)' },
           to: { opacity: '1', transform: 'translateY(0) scale(1)' },
         },
-        // Push-navigation enter: a detail panel slides in from the right edge (paired with a "←" back).
+        // Push-navigation enter: a detail panel fades in with a short nudge from the right (paired with
+        // a "←" back). Kept to a few pixels — travelling the full panel width janks on slow devices.
         slideInRight: {
-          from: { transform: 'translateX(100%)' },
-          to: { transform: 'translateX(0)' },
+          from: { opacity: '0', transform: 'translateX(12px)' },
+          to: { opacity: '1', transform: 'translateX(0)' },
         },
-        // Push-navigation exit: the detail panel slides back out to the right on "←" back.
+        // Push-navigation exit: the detail panel fades back out toward the right on "←" back.
         slideOutRight: {
-          from: { transform: 'translateX(0)' },
-          to: { transform: 'translateX(100%)' },
+          from: { opacity: '1', transform: 'translateX(0)' },
+          to: { opacity: '0', transform: 'translateX(12px)' },
         },
       },
       animation: {
@@ -227,8 +228,8 @@ const config: Config = {
         'highlight-warning': 'highlight-warning 2s infinite alternate ease-in-out',
         'token-info-glow': 'token-info-glow 1.5s ease-in-out infinite',
         dropdownIn: 'dropdownIn 0.15s ease-out',
-        slideInRight: 'slideInRight 0.25s ease-out',
-        slideOutRight: 'slideOutRight 0.2s ease-in forwards',
+        slideInRight: 'slideInRight 0.15s ease-out',
+        slideOutRight: 'slideOutRight 0.12s ease-in forwards',
       },
     },
   },


### PR DESCRIPTION
Two small follow-ups to the token selector (#3243).

## Chain dropdown scroll hints

The chain list scrolls, but nothing told you so — chains below the fold were easy to miss. It now shows up/down chevrons whenever there is more to scroll, matching the protocol dropdown on My Positions (reuses `ScrollIndicator` from `components/DropdownMenu/styles`). Clicking a chevron scrolls by 100px.

The dropdown's max height also goes from 80px to 360px, so most chains are visible without scrolling at all.

## Token-detail animation

The detail panel behind each token's (i) button slid in across the full panel width (`translateX(100%)`, 250ms). The travel read as inertia and janked on slower machines. It now fades in with a 12px nudge over 150ms (120ms out) — same push-navigation feel, far less work per frame.

## Testing

Verified in-browser on `/swap/ethereum`:
- Chevrons appear/disappear correctly as the chain list scrolls; clicking them scrolls.
- Token-detail round trip still works: (i) opens the panel, "←" unmounts it and returns to the list. This is the one functional risk of the animation change, since the modal unmounts the detail view via `onAnimationEnd` on `slideOutRight` — confirmed the event still fires.

`pnpm lint` and `pnpm type-check` clean.