### PR TITLE
feat(token-info): surface security warnings on the swap info icon

### DIFF
--- a/apps/kyberswap-interface/src/components/swapv2/TokenInfo/index.tsx
+++ b/apps/kyberswap-interface/src/components/swapv2/TokenInfo/index.tsx
@@ -1,6 +1,6 @@
 import { Currency } from '@kyberswap/ks-sdk-core'
 import { Trans, t } from '@lingui/macro'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ChevronLeft } from 'react-feather'
 
 import { ReactComponent as Coingecko } from 'assets/svg/coingecko_color.svg'
@@ -15,6 +15,7 @@ import { TextDashed } from 'components/Text'
 import { MouseoverTooltip } from 'components/Tooltip'
 import MarketInfo from 'components/swapv2/TokenInfo/MarketInfo'
 import SecurityInfo from 'components/swapv2/TokenInfo/SecurityInfo'
+import { useSecurityLevelOfCurrency } from 'components/swapv2/TokenInfo/useTokenSecurityLevel'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 import { Field } from 'state/swap/actions'
@@ -70,15 +71,32 @@ const TokenInfoTab = ({ currencies, onBack }: { currencies: { [field in Field]?:
   const outputToken = outputNativeCurrency?.wrapped
 
   const [activeTab, setActiveTab] = useState(TAB.TOKEN_IN)
+  const isTabPickedByUser = useRef(false)
+
+  const inputSecurityLevel = useSecurityLevelOfCurrency(currencies[Field.INPUT])
+  const outputSecurityLevel = useSecurityLevelOfCurrency(currencies[Field.OUTPUT])
 
   const selectedToken = activeTab === TAB.TOKEN_OUT ? outputToken : inputToken
   const isOneToken = !!inputToken?.address && inputToken.address === outputToken?.address
   const isActiveTokenIn = activeTab === TAB.TOKEN_IN
   const isActiveTokenOut = activeTab === TAB.TOKEN_OUT
 
+  const onSelectTab = (tab: TAB) => {
+    isTabPickedByUser.current = true
+    setActiveTab(tab)
+  }
+
   useEffect(() => {
+    isTabPickedByUser.current = false
     inputToken?.address && setActiveTab(TAB.TOKEN_IN)
-  }, [chainId, inputToken?.address])
+  }, [chainId, inputToken?.address, outputToken?.address])
+
+  // Land on the token carrying the warning — security data arrives async, so this
+  // runs once it resolves. The input token wins ties, and a manual pick always sticks.
+  useEffect(() => {
+    if (isTabPickedByUser.current) return
+    setActiveTab(outputSecurityLevel > inputSecurityLevel ? TAB.TOKEN_OUT : TAB.TOKEN_IN)
+  }, [inputSecurityLevel, outputSecurityLevel])
 
   return (
     <div className="flex flex-col">
@@ -109,12 +127,12 @@ const TokenInfoTab = ({ currencies, onBack }: { currencies: { [field in Field]?:
             <TokenTabButton
               currency={inputNativeCurrency}
               isActive={isActiveTokenIn}
-              onClick={() => setActiveTab(TAB.TOKEN_IN)}
+              onClick={() => onSelectTab(TAB.TOKEN_IN)}
             />
             <TokenTabButton
               currency={outputNativeCurrency}
               isActive={isActiveTokenOut}
-              onClick={() => setActiveTab(TAB.TOKEN_OUT)}
+              onClick={() => onSelectTab(TAB.TOKEN_OUT)}
             />
           </div>
         )}

--- a/apps/kyberswap-interface/src/components/swapv2/TokenInfo/useTokenSecurityLevel.ts
+++ b/apps/kyberswap-interface/src/components/swapv2/TokenInfo/useTokenSecurityLevel.ts
@@ -1,0 +1,39 @@
+import { ChainId, Currency } from '@kyberswap/ks-sdk-core'
+import { useMemo } from 'react'
+import { useGetSecurityTokenInfoQuery } from 'services/coingecko'
+
+import { getSecurityTokenInfo } from 'components/swapv2/TokenInfo/utils'
+import { Field } from 'state/swap/actions'
+
+/** Ordered by severity so levels can be compared/merged across tokens. */
+export enum SecurityLevel {
+  NONE = 0,
+  WARNING = 1,
+  RISKY = 2,
+}
+
+export const useSecurityLevelOfCurrency = (currency: Currency | undefined): SecurityLevel => {
+  const token = currency?.wrapped
+
+  const { data, error } = useGetSecurityTokenInfoQuery(
+    { chainId: token?.chainId as ChainId, address: token?.address ?? '' },
+    { skip: !token?.address },
+  )
+
+  return useMemo(() => {
+    const { totalRiskContract, totalRiskTrading, totalWarningContract, totalWarningTrading } = getSecurityTokenInfo(
+      error ? undefined : data,
+    )
+    if (totalRiskContract + totalRiskTrading > 0) return SecurityLevel.RISKY
+    if (totalWarningContract + totalWarningTrading > 0) return SecurityLevel.WARNING
+    return SecurityLevel.NONE
+  }, [data, error])
+}
+
+/** Highest severity found across the tokens of the swap form. */
+export const useSwapTokensSecurityLevel = (currencies: { [field in Field]?: Currency }): SecurityLevel => {
+  const inputLevel = useSecurityLevelOfCurrency(currencies[Field.INPUT])
+  const outputLevel = useSecurityLevelOfCurrency(currencies[Field.OUTPUT])
+
+  return Math.max(inputLevel, outputLevel)
+}

--- a/apps/kyberswap-interface/src/components/swapv2/TokenInfoIcon.tsx
+++ b/apps/kyberswap-interface/src/components/swapv2/TokenInfoIcon.tsx
@@ -4,8 +4,10 @@ import { isMobile } from 'react-device-detect'
 import { Info } from 'react-feather'
 
 import { MouseoverTooltip } from 'components/Tooltip'
+import { SecurityLevel, useSwapTokensSecurityLevel } from 'components/swapv2/TokenInfo/useTokenSecurityLevel'
 import { StyledActionButtonSwapForm } from 'components/swapv2/styleds'
 import { Field } from 'state/swap/actions'
+import { cn } from 'utils/cn'
 
 type TokenInfoIconProps = {
   currencies: { [field in Field]?: Currency }
@@ -13,11 +15,39 @@ type TokenInfoIconProps = {
   size?: number
 }
 
-const TokenInfoIcon = ({ onClick, size }: TokenInfoIconProps) => {
+const TokenInfoIcon = ({ currencies, onClick, size }: TokenInfoIconProps) => {
+  const securityLevel = useSwapTokensSecurityLevel(currencies)
+
+  const tooltipText =
+    securityLevel === SecurityLevel.RISKY
+      ? t`Risky items detected on these tokens. Check Token Info before trading`
+      : securityLevel === SecurityLevel.WARNING
+      ? t`Attention items detected on these tokens. Check Token Info before trading`
+      : t`Token Info`
+
   return (
     <StyledActionButtonSwapForm onClick={onClick}>
-      <MouseoverTooltip text={t`Token Info`} placement="top" width="fit-content" disableTooltip={isMobile}>
-        <Info className="text-subText" size={size || 20} />
+      <MouseoverTooltip text={tooltipText} placement="top" width="fit-content" disableTooltip={isMobile}>
+        <span className="relative inline-flex leading-none">
+          <Info
+            className={cn(
+              securityLevel === SecurityLevel.RISKY
+                ? 'text-red'
+                : securityLevel === SecurityLevel.WARNING
+                ? 'text-warning'
+                : 'text-subText',
+            )}
+            size={size || 20}
+          />
+          {securityLevel !== SecurityLevel.NONE && (
+            <span
+              className={cn(
+                'absolute -right-0.5 -top-0.5 size-1.5 rounded-full',
+                securityLevel === SecurityLevel.RISKY ? 'bg-red' : 'bg-warning',
+              )}
+            />
+          )}
+        </span>
       </MouseoverTooltip>
     </StyledActionButtonSwapForm>
   )


### PR DESCRIPTION
Tint the (i) icon red or orange with a matching dot when either swap token has a GoPlus risky or attention item, so the warning is visible without opening the panel.

Opening the panel now lands on the token carrying the warning instead of always defaulting to the input token; a manual tab pick still sticks.

Severity is derived from the same getSecurityTokenInfo() the panel uses, and the RTK Query cache is shared, so no extra requests are made.