### PR TITLE
fix(token-selector): drop the focus ring from the token list tabs

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TabBar.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TabBar.tsx
@@ -93,7 +93,7 @@ export const TabBar = memo(({ tabs, activeTab, onChange }: TabBarProps) => {
             onClick={() => onChange(tab)}
             className={cn(
               '-mb-px flex shrink-0 items-center gap-1 border-b-2 pb-2 text-sm font-medium transition-colors',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              'focus-visible:outline-none',
               isActive ? 'border-primary text-primary' : 'border-transparent text-text',
             )}
           >


### PR DESCRIPTION
Clicking a tab and then pressing any key makes Chrome match :focus-visible on the still-focused tab, so a green ring appeared at seemingly random times. The active tab already reads as selected through its green label and underline.

outline-none stays: without it the browser draws its own ring in the same spot.