### PR TITLE
feat(swap): support ERC-8056 scaled UI amounts

### DIFF
--- a/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
@@ -155,7 +155,7 @@ const BalanceRow = ({
   selectedCurrencyBalance,
 }: BalanceRowProps) => {
   const showTopActions = (onMax || onHalf) && positionMax === 'top' && currency && account
-  const balance = customBalanceText || selectedCurrencyBalance?.toSignificant(10) || 0
+  const balance = customBalanceText ?? selectedCurrencyBalance?.toSignificant(10) ?? 0
 
   return (
     <div className="flex min-h-5 items-center justify-between text-xs">
@@ -336,6 +336,7 @@ interface CurrencyInputPanelProps {
   showPinnedTokens?: boolean
   customBalanceText?: string
   hideLogo?: boolean
+  highlightCurrencySelect?: boolean
   fontSize?: string
   customCurrencySelect?: ReactNode
   estimatedUsd?: string
@@ -379,6 +380,7 @@ export default function CurrencyInputPanel({
   showPinnedTokens,
   customBalanceText,
   hideLogo = false,
+  highlightCurrencySelect = false,
   fontSize,
   customCurrencySelect,
   estimatedUsd,
@@ -456,7 +458,11 @@ export default function CurrencyInputPanel({
                 isDisable={disableCurrencySelect}
                 hideInput={hideInput}
                 selected={!!currency}
-                className={cn('open-currency-select-button', selectClassName)}
+                className={cn(
+                  'open-currency-select-button',
+                  highlightCurrencySelect && '!border-blue !bg-blue/20',
+                  selectClassName,
+                )}
                 onClick={() => {
                   if (disableCurrencySelect) return
                   if (!isSwitchMode) {

--- a/apps/kyberswap-interface/src/components/SwapForm/ERC8056Info.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/ERC8056Info.tsx
@@ -1,0 +1,68 @@
+import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
+import { Trans } from '@lingui/macro'
+import { Info } from 'react-feather'
+
+import { useERC8056DisplayBalance, useERC8056TokenInfo } from 'hooks/useERC8056Token'
+
+export type ERC8056DisplayInfo = { currency: Currency | undefined }
+
+type UseERC8056SwapInfoProps = {
+  chainId: ChainId
+  currencyIn: Currency | undefined
+  currencyOut: Currency | undefined
+  balanceIn: CurrencyAmount<Currency> | undefined
+  balanceOut: CurrencyAmount<Currency> | undefined
+}
+
+export const useERC8056SwapInfo = ({
+  chainId,
+  currencyIn,
+  currencyOut,
+  balanceIn,
+  balanceOut,
+}: UseERC8056SwapInfoProps) => {
+  const inputInfo = useERC8056TokenInfo(currencyIn, chainId)
+  const outputInfo = useERC8056TokenInfo(currencyOut, chainId)
+  const displayBalanceIn = useERC8056DisplayBalance(inputInfo, balanceIn)
+  const displayBalanceOut = useERC8056DisplayBalance(outputInfo, balanceOut)
+
+  return {
+    input: {
+      balanceText:
+        displayBalanceIn && inputInfo.enabled && (inputInfo.isLoading || inputInfo.isScaled)
+          ? displayBalanceIn.toSignificant(10)
+          : undefined,
+      isScaled: inputInfo.isScaled,
+    },
+    output: {
+      balanceText:
+        displayBalanceOut && outputInfo.enabled && (outputInfo.isLoading || outputInfo.isScaled)
+          ? displayBalanceOut.toSignificant(10)
+          : undefined,
+      isScaled: outputInfo.isScaled,
+    },
+    tokens: [
+      { currency: inputInfo.isScaled ? currencyIn : undefined },
+      { currency: outputInfo.isScaled ? currencyOut : undefined },
+    ],
+  }
+}
+
+const ERC8056Info = ({ tokens }: { tokens: ERC8056DisplayInfo[] }) => {
+  const symbolsText = [...new Set(tokens.flatMap(({ currency }) => (currency?.symbol ? [currency.symbol] : [])))].join(
+    ' and ',
+  )
+  if (!symbolsText) return null
+
+  return (
+    <p className="text-xs font-medium italic text-blue">
+      <Info className="inline-block size-3 align-[-2px]" />{' '}
+      <Trans>
+        {symbolsText}: accrued dividends are included in the balance display. The tradeable amount and wallet signing
+        prompt will reflect the base balance.
+      </Trans>
+    </p>
+  )
+}
+
+export default ERC8056Info

--- a/apps/kyberswap-interface/src/components/SwapForm/InputCurrencyPanel.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/InputCurrencyPanel.tsx
@@ -14,6 +14,8 @@ type Props = {
   currencyIn: Currency | undefined
   currencyOut: Currency | undefined
   balanceIn: CurrencyAmount<Currency> | undefined
+  balanceText?: string
+  highlightToken?: boolean
   onChangeCurrencyIn: (c: Currency) => void
   setTypedValue: (v: string) => void
   customChainId?: ChainId
@@ -25,6 +27,8 @@ const InputCurrencyPanel: React.FC<Props> = ({
   currencyIn,
   currencyOut,
   balanceIn,
+  balanceText,
+  highlightToken,
   onChangeCurrencyIn,
   customChainId,
 }) => {
@@ -64,6 +68,8 @@ const InputCurrencyPanel: React.FC<Props> = ({
       id="swap-currency-input"
       dataTestId="swap-currency-input"
       showPinnedTokens={true}
+      customBalanceText={balanceText}
+      highlightCurrencySelect={highlightToken}
       estimatedUsd={
         trade?.amountInUsd
           ? formatDisplayNumber(trade.amountInUsd, { style: 'currency', significantDigits: 4 })

--- a/apps/kyberswap-interface/src/components/SwapForm/OutputCurrencyPanel.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/OutputCurrencyPanel.tsx
@@ -19,7 +19,8 @@ type Props = {
   currencyIn: Currency | undefined
   currencyOut: Currency | undefined
   amountOutUsd: string | undefined
-
+  balanceText?: string
+  highlightToken?: boolean
   onChangeCurrencyOut: (c: Currency) => void
   customChainId?: ChainId
   routeLoading: boolean
@@ -32,6 +33,8 @@ const OutputCurrencyPanel: React.FC<Props> = ({
   currencyIn,
   currencyOut,
   amountOutUsd,
+  balanceText,
+  highlightToken,
   onChangeCurrencyOut,
   customChainId,
   routeLoading,
@@ -76,6 +79,8 @@ const OutputCurrencyPanel: React.FC<Props> = ({
         id="swap-currency-output"
         dataTestId="swap-currency-output"
         showPinnedTokens={true}
+        customBalanceText={balanceText}
+        highlightCurrencySelect={highlightToken}
         estimatedUsd={routeLoading ? '' : getEstimatedUsd()}
         label={
           <TextHelper

--- a/apps/kyberswap-interface/src/components/SwapForm/index.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/index.tsx
@@ -10,6 +10,7 @@ import { NotificationType } from 'components/Announcement/type'
 import FeeControlGroup from 'components/FeeControlGroup'
 import WarningIcon from 'components/Icons/WarningIcon'
 import { NetworkSelector } from 'components/NetworkSelector'
+import ERC8056Info, { useERC8056SwapInfo } from 'components/SwapForm/ERC8056Info'
 import InputCurrencyPanel from 'components/SwapForm/InputCurrencyPanel'
 import MultichainKNCNote from 'components/SwapForm/MultichainKNCNote'
 import OutputCurrencyPanel from 'components/SwapForm/OutputCurrencyPanel'
@@ -162,6 +163,8 @@ const SwapForm: React.FC<SwapFormProps> = props => {
   }, [prefillInputAmount, updateInputAmount, notify])
 
   const parsedAmount = useParsedAmount(currencyIn, typedValue)
+  const erc8056Info = useERC8056SwapInfo({ chainId, currencyIn, currencyOut, balanceIn, balanceOut })
+
   const {
     wrapType,
     inputError: wrapInputError,
@@ -261,6 +264,8 @@ const SwapForm: React.FC<SwapFormProps> = props => {
                 currencyIn={currencyIn}
                 currencyOut={currencyOut}
                 balanceIn={balanceIn}
+                balanceText={erc8056Info.input.balanceText}
+                highlightToken={erc8056Info.input.isScaled}
                 onChangeCurrencyIn={handleChangeCurrencyIn}
                 customChainId={customChainId}
               />
@@ -287,11 +292,15 @@ const SwapForm: React.FC<SwapFormProps> = props => {
                 currencyIn={currencyIn}
                 currencyOut={currencyOut}
                 amountOutUsd={routeSummary?.amountOutUsd}
+                balanceText={erc8056Info.output.balanceText}
+                highlightToken={erc8056Info.output.isScaled}
                 onChangeCurrencyOut={handleChangeCurrencyOut}
                 customChainId={customChainId}
                 routeLoading={routeLoading}
               />
             </div>
+
+            <ERC8056Info tokens={erc8056Info.tokens} />
 
             {isDegenMode && !isWrapOrUnwrap && (
               <AddressInputPanel id="recipient" value={recipient} onChange={setRecipient} />

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
@@ -17,6 +17,7 @@ import { TokenRowExtra, TokenRowExtraMap, tokenRowKey } from 'components/TokenSe
 import { getNeedsImport } from 'components/TokenSelectorModal/utils'
 import { useActiveWeb3React } from 'hooks'
 import useCopyClipboard from 'hooks/useCopyClipboard'
+import { useERC8056DisplayBalance, useERC8056TokenInfo } from 'hooks/useERC8056Token'
 import { restrictedTokenKey, restrictedTokenMessage, useIsTokenRestricted } from 'hooks/useRestrictedTokens'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
 import { useUserAddedTokens, useUserFavoriteTokens } from 'state/user/hooks'
@@ -408,6 +409,13 @@ type VirtualRowData = {
   onWarnRestricted: (key: string) => void
 }
 
+const SelectedTokenBalance = ({ currency, balance }: { currency: Currency; balance: CurrencyAmount<Currency> }) => {
+  const info = useERC8056TokenInfo(currency, currency.chainId)
+  const displayBalance = useERC8056DisplayBalance(info, balance)
+
+  return <Balance balance={displayBalance ?? balance} />
+}
+
 const VirtualRow = memo(function VirtualRow({ index, style, data }: ListChildComponentProps<VirtualRowData>) {
   const currency = data.currencies[index]
   // The trailing slot (present while more pages can load) has no currency yet — show the loader.
@@ -441,6 +449,10 @@ const VirtualRow = memo(function VirtualRow({ index, style, data }: ListChildCom
   // Non-All tabs already carry price in the catalog extras; only the All tab fetches Redux prices.
   const priceForUsd = data.showPriceColumn ? extra?.price ?? 0 : data.tokenPrices[token.address] || 0
   const usdBalance = priceForUsd * parseFloat(currencyBalance?.toExact() || '0')
+  const customBalance =
+    currency.isToken && currencyBalance && (isSelected || otherSelected) ? (
+      <SelectedTokenBalance currency={currency} balance={currencyBalance} />
+    ) : undefined
 
   const restrictedKey = restrictedTokenKey(currency.chainId, getTokenAddress(currency))
   const restricted = data.isTokenRestricted(currency)
@@ -457,6 +469,7 @@ const VirtualRow = memo(function VirtualRow({ index, style, data }: ListChildCom
         style={rowStyle}
         currency={currency}
         currencyBalance={currencyBalance}
+        customBalance={customBalance}
         isSelected={isSelected}
         showFavoriteIcon={data.showFavoriteIcon}
         onSelect={data.onCurrencySelect}

--- a/apps/kyberswap-interface/src/hooks/useERC8056Token.ts
+++ b/apps/kyberswap-interface/src/hooks/useERC8056Token.ts
@@ -1,0 +1,76 @@
+import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
+import { useMemo } from 'react'
+import { useReadContract } from 'wagmi'
+
+import { useReadingContract } from 'hooks/useContract'
+import { parseAbi } from 'utils/viem'
+
+const UI_MULTIPLIER_SCALE = 10n ** 18n
+const ERC8056_CORE_INTERFACE_ID = '0xa60bf13d'
+const ERC8056_ABI = parseAbi([
+  'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+  'function uiMultiplier() view returns (uint256)',
+])
+
+export type ERC8056TokenInfo = {
+  enabled: boolean
+  isLoading: boolean
+  isScaled: boolean
+  multiplier: bigint | undefined
+}
+
+/** Detects a selected ERC-8056 token on supported chains and caches the result for the page session. */
+export const useERC8056TokenInfo = (currency: Currency | undefined, chainId: ChainId): ERC8056TokenInfo => {
+  const enabled = [ChainId.BSCMAINNET, ChainId.ROBINHOOD].includes(chainId) && Boolean(currency?.isToken)
+  const contract = useReadingContract(enabled ? currency?.wrapped.address : undefined, ERC8056_ABI, chainId)
+
+  // Keep ERC-165 as the detection gate, but only check the core interface
+  // needed for uiMultiplier(). Contract reverts are an expected negative
+  // result for ordinary tokens, so do not retry them and spend extra RPC quota.
+  const { data: supportsCore, isLoading: isLoadingSupport } = useReadContract({
+    address: contract?.address,
+    abi: ERC8056_ABI,
+    functionName: 'supportsInterface',
+    args: [ERC8056_CORE_INTERFACE_ID],
+    chainId,
+    query: { enabled: Boolean(contract), staleTime: Infinity, gcTime: Infinity, retry: false },
+  })
+  const supportsERC8056 = enabled && supportsCore === true
+  const { data: rawMultiplier, isLoading: isLoadingMultiplier } = useReadContract({
+    address: contract?.address,
+    abi: ERC8056_ABI,
+    functionName: 'uiMultiplier',
+    chainId,
+    query: { enabled: Boolean(contract) && supportsERC8056, staleTime: Infinity, gcTime: Infinity, retry: false },
+  })
+
+  // A missing/reverting/zero multiplier is treated as a regular token. A 1.0
+  // multiplier is compliant but has no display discrepancy, so it also needs
+  // neither scaling nor the user-facing notice.
+  const multiplier =
+    supportsERC8056 && rawMultiplier !== undefined && rawMultiplier > 0n && rawMultiplier !== UI_MULTIPLIER_SCALE
+      ? rawMultiplier
+      : undefined
+
+  return useMemo(
+    () => ({
+      enabled,
+      isLoading: enabled && (isLoadingSupport || (supportsERC8056 && isLoadingMultiplier)),
+      isScaled: multiplier !== undefined,
+      multiplier,
+    }),
+    [enabled, isLoadingMultiplier, isLoadingSupport, multiplier, supportsERC8056],
+  )
+}
+
+export const useERC8056DisplayBalance = (
+  info: ERC8056TokenInfo,
+  rawBalance: CurrencyAmount<Currency> | undefined,
+): CurrencyAmount<Currency> | undefined => {
+  return useMemo(() => {
+    if (!rawBalance || !info.multiplier) return rawBalance
+
+    const uiBalance = (BigInt(rawBalance.quotient.toString()) * info.multiplier) / UI_MULTIPLIER_SCALE
+    return CurrencyAmount.fromRawAmount(rawBalance.currency, uiBalance.toString())
+  }, [info.multiplier, rawBalance])
+}


### PR DESCRIPTION
## Summary
- detect ERC-8056 capabilities for selected BSC tokens while keeping quote, approval, build, and calldata amounts raw
- display scaled balances and amounts across Spot Swap, PartnerSwap, review, and transaction history
- handle scheduled multiplier changes, stale confirmations, chart safeguards, disclosures, and conversion tests