### PR TITLE
fix(token-selector): make other-chain search results selectable

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/OtherChainTokens.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/OtherChainTokens.tsx
@@ -1,23 +1,69 @@
+import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
-import { ReactNode } from 'react'
+import { ReactNode, useMemo } from 'react'
 
 import { ButtonPrimary } from 'components/Button'
 import CurrencyLogo from 'components/CurrencyLogo'
+import Skeleton from 'components/Skeleton'
 import { HStack, Stack } from 'components/Stack'
+import { Balance } from 'components/TokenSelectorModal/components'
 import { NETWORKS_INFO } from 'constants/networks'
 import type { NetworkInfo } from 'constants/networks/type'
-import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
+import { useActiveWeb3React } from 'hooks'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
+import { useCurrencyBalances } from 'state/wallet/hooks'
 import { cn } from 'utils/cn'
 
 type OtherChainTokensProps = {
   tokens: WrappedTokenInfo[]
   loading: boolean
   loadingFallback: ReactNode
+  /**
+   * The chain the app itself is on. Tokens here are "other chain" only relative to the chain selector,
+   * so one can still sit on this chain — those need no network switch and offer a plain row click.
+   */
+  anchorChainId: ChainId
+  /** Pick a token listed here; the parent owns the import and switch-chain gates. */
+  onSelect: (token: WrappedTokenInfo) => void
 }
 
-export const OtherChainTokens = ({ tokens, loading, loadingFallback }: OtherChainTokensProps) => {
-  const { changeNetwork } = useChangeNetwork()
+export const OtherChainTokens = ({
+  tokens,
+  loading,
+  loadingFallback,
+  anchorChainId,
+  onSelect,
+}: OtherChainTokensProps) => {
+  const { account } = useActiveWeb3React()
+
+  // Only the rows on the app's own chain show a balance, and they all share that chain, so one lookup
+  // serves them — balances for the rows still behind a network switch would be noise anyway.
+  const anchorChainTokens = useMemo(
+    () => tokens.filter(token => token.chainId === anchorChainId),
+    [tokens, anchorChainId],
+  )
+  const anchorChainBalances = useCurrencyBalances(anchorChainTokens, anchorChainId)
+  const balanceByAddress = useMemo(
+    () =>
+      anchorChainTokens.reduce<Record<string, CurrencyAmount<Currency> | undefined>>((map, token, index) => {
+        map[token.address] = anchorChainBalances[index]
+        return map
+      }, {}),
+    [anchorChainTokens, anchorChainBalances],
+  )
+
+  // Mirrors the in-list balance column: the amount once known, a skeleton while a connected wallet's
+  // balances land, and "0" with no wallet (where the balance stays undefined).
+  const renderBalance = (token: WrappedTokenInfo) => {
+    const balance = balanceByAddress[token.address]
+    if (balance) return <Balance balance={balance} />
+    if (account) return <Skeleton width={56} height={18} className="my-[3px]" variant="darkSubtle" />
+    return (
+      <span className="max-w-full truncate text-xs text-text sm:text-sm" data-testid="token-balance">
+        0
+      </span>
+    )
+  }
 
   if (loading && !tokens.length) {
     return loadingFallback
@@ -34,12 +80,14 @@ export const OtherChainTokens = ({ tokens, loading, loadingFallback }: OtherChai
         {tokens.map(token => {
           const networkInfo = NETWORKS_INFO[token.chainId] as NetworkInfo
           const isDimmed = !token.isWhitelisted
+          const needsSwitch = token.chainId !== anchorChainId
 
           return (
             <HStack
               key={`${token.chainId}-${token.address}`}
               data-testid="other-chain-token-item"
-              className="min-h-14 w-full items-center justify-between gap-4 rounded-lg px-3 py-1 hover:bg-subText-04"
+              onClick={() => onSelect(token)}
+              className="min-h-14 w-full cursor-pointer items-center justify-between gap-4 rounded-lg px-3 py-1 hover:bg-subText-04"
             >
               <HStack className="min-w-0 items-center gap-2">
                 <CurrencyLogo currency={token} size="24px" style={isDimmed ? { opacity: 0.5 } : undefined} />
@@ -51,17 +99,24 @@ export const OtherChainTokens = ({ tokens, loading, loadingFallback }: OtherChai
                   </HStack>
                 </Stack>
               </HStack>
-              <ButtonPrimary
-                data-testid="other-chain-switch-btn"
-                width="fit-content"
-                padding="6px 12px"
-                fontWeight={500}
-                fontSize="14px"
-                className={cn(isDimmed && 'opacity-50')}
-                onClick={() => changeNetwork(token.chainId)}
-              >
-                <Trans>Switch Chain</Trans>
-              </ButtonPrimary>
+              {needsSwitch ? (
+                <ButtonPrimary
+                  data-testid="other-chain-switch-btn"
+                  width="fit-content"
+                  padding="6px 12px"
+                  fontWeight={500}
+                  fontSize="14px"
+                  className={cn(isDimmed && 'opacity-50')}
+                  onClick={event => {
+                    event.stopPropagation()
+                    onSelect(token)
+                  }}
+                >
+                  <Trans>Switch Chain</Trans>
+                </ButtonPrimary>
+              ) : (
+                renderBalance(token)
+              )}
             </HStack>
           )
         })}

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
@@ -12,6 +12,7 @@ import Loader from 'components/Loader'
 import Skeleton from 'components/Skeleton'
 import { Center, HStack, Stack } from 'components/Stack'
 import { getDisplayTokenInfo } from 'components/TokenSelectorModal/PinnedTokens'
+import { Balance } from 'components/TokenSelectorModal/components'
 import { TokenRowExtra, TokenRowExtraMap, tokenRowKey } from 'components/TokenSelectorModal/types'
 import { getNeedsImport } from 'components/TokenSelectorModal/utils'
 import { useActiveWeb3React } from 'hooks'
@@ -39,18 +40,6 @@ const EMPTY_ITEM_STYLE: CSSProperties = {}
 // Stable empties so gated balance/price subscriptions never allocate a fresh array to disable them.
 const EMPTY_CURRENCIES: Currency[] = []
 const EMPTY_ADDRESSES: string[] = []
-
-const Balance = ({ balance }: { balance: CurrencyAmount<Currency> }) => {
-  return (
-    <span
-      className="max-w-full truncate text-xs text-text sm:text-sm"
-      data-testid="token-balance"
-      title={balance.toExact()}
-    >
-      {balance.toSignificant(10)}
-    </span>
-  )
-}
 
 // Compact age badge for the New tab, counted from when the token was whitelisted: "NEW" under 12h,
 // then hours ("15H") up to a day, then days ("3D").

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -63,8 +63,14 @@ import { useIsTokenRestricted, useNotifyRestrictedToken } from 'hooks/useRestric
 import { fetchListTokenByAddresses, useAllTokens } from 'hooks/useTokens'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import SortIcon, { Direction } from 'pages/MarketOverview/SortIcon'
+import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
-import { useRemoveUserAddedToken, useUserAddedTokens, useUserFavoriteTokens } from 'state/user/hooks'
+import {
+  useIsTokenImported,
+  useRemoveUserAddedToken,
+  useUserAddedTokens,
+  useUserFavoriteTokens,
+} from 'state/user/hooks'
 import { CloseIcon, MEDIA_WIDTHS } from 'theme'
 import { filterTruthy, isAddress } from 'utils'
 import { cn } from 'utils/cn'
@@ -173,6 +179,7 @@ export const TokenSelectorContent = ({
     return [...supportedChains].sort((a, b) => (chainVolumes[b.chainId] ?? -1) - (chainVolumes[a.chainId] ?? -1))
   }, [supportedChains, chainVolumes])
   const removeToken = useRemoveUserAddedToken()
+  const isTokenImported = useIsTokenImported()
   const isTokenRestricted = useIsTokenRestricted()
   const notifyRestrictedToken = useNotifyRestrictedToken()
 
@@ -553,6 +560,22 @@ export const TokenSelectorContent = ({
     switchChainAndSelect(token)
   }, [switchChainToken, switchChainAndSelect])
 
+  // A hit in the "other chains" group is other-chain only relative to the chain selector, which the
+  // wallet need not be on — so the token can well sit on the app's own chain. Aim the selector at it
+  // and hand off to the row select path, which gates on the app chain and so asks for a network switch
+  // only when one is really needed.
+  const handleOtherChainSelect = useCallback(
+    (token: WrappedTokenInfo) => {
+      setSelectedChainId(token.chainId)
+      if (getNeedsImport(token, address => isTokenImported(token.chainId, address), !!onImportToken)) {
+        onImportToken?.(token.wrapped)
+        return
+      }
+      handleCurrencySelect(token)
+    },
+    [handleCurrencySelect, isTokenImported, onImportToken],
+  )
+
   const handleInput = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const input = event.target.value
@@ -908,6 +931,8 @@ export const TokenSelectorContent = ({
                   tokens={otherChainTokens}
                   loading={isCheckingOtherChains}
                   loadingFallback={<SearchLoading />}
+                  anchorChainId={anchorChainId}
+                  onSelect={handleOtherChainSelect}
                 />
               ) : (
                 <NoResult message={debouncedQuery ? undefined : emptyMessage} />

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/components.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/components.tsx
@@ -1,8 +1,21 @@
+import { Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
 import { ComponentProps, ComponentPropsWithoutRef, forwardRef } from 'react'
 import { Search } from 'react-feather'
 
 import Column, { AutoColumn } from 'components/Column'
 import { cn } from 'utils/cn'
+
+export const Balance = ({ balance }: { balance: CurrencyAmount<Currency> }) => {
+  return (
+    <span
+      className="max-w-full truncate text-xs text-text sm:text-sm"
+      data-testid="token-balance"
+      title={balance.toExact()}
+    >
+      {balance.toSignificant(10)}
+    </span>
+  )
+}
 
 export const ContentWrapper = ({ className, ...rest }: ComponentProps<typeof Column>) => (
   <Column className={cn('relative w-full flex-1', className)} {...rest} />

--- a/apps/kyberswap-interface/src/state/user/hooks.tsx
+++ b/apps/kyberswap-interface/src/state/user/hooks.tsx
@@ -237,6 +237,18 @@ export function useUserAddedTokens(customChain?: ChainId): Token[] {
   }, [serializedTokensMap, chainId])
 }
 
+/**
+ * Whether an address is a user-imported token on a given chain. Unlike `useUserAddedTokens`, the chain
+ * is an argument rather than baked in, so one caller can ask about several chains at once.
+ */
+export function useIsTokenImported(): (chainId: ChainId, address: string) => boolean {
+  const serializedTokensMap = useSelector<AppState, AppState['user']['tokens']>(({ user: { tokens } }) => tokens)
+  return useCallback(
+    (chainId: ChainId, address: string) => !!serializedTokensMap[chainId]?.[address],
+    [serializedTokensMap],
+  )
+}
+
 export function usePairAdderByTokens(): (token0: Token, token1: Token) => void {
   const dispatch = useDispatch<AppDispatch>()
 


### PR DESCRIPTION
The chain selector is modal-local state, so a hit under "Available on other chains" is other-chain only relative to it — the token can still sit on the chain the app and wallet are already on. Its Switch Chain button asked changeNetwork for that same chain, which returns early when already there, and passed no success callback, so the click did nothing at all.

Hand the pick to the parent instead, which points the chain selector at the token and routes through the select path the in-list rows use, gating on the app chain so a network switch is requested only when one is really needed. A token already on the app's chain has nothing to switch: it drops the button, shows its balance the way the in-list rows do, and selects on a plain row click.

Balances are read for the app's chain, which every button-less row shares, so a single lookup serves them. useIsTokenImported keeps the import warning intact for these rows: useUserAddedTokens is fixed to a single chain and cannot answer for a token found on another one.