### PR TITLE
fix(swap): increase smart settlement gas buffer

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenPriceChart/index.tsx
+++ b/apps/kyberswap-interface/src/components/TokenPriceChart/index.tsx
@@ -169,8 +169,9 @@ const TokenPriceChart = ({ tokens, flatten }: TokenPriceChartProps) => {
 
   const latestPageData = infiniteData?.pages[0]
   const currentPrice = latestPageData?.latestPrice ?? chartData.at(-1)?.close
-  const priceChange = latestPageData?.change24h ?? 0
-  const priceChangeColor = priceChange >= 0 ? theme.primary : theme.red
+  const priceChange = latestPageData?.change24h
+  const hasPriceChange = priceChange !== null && priceChange !== undefined
+  const priceChangeColor = hasPriceChange ? (priceChange >= 0 ? theme.primary : theme.red) : undefined
 
   const activityCandles = useMemo(() => activityData?.candles ?? [], [activityData?.candles])
   const shouldUseActivityState = activityCandles.length > 0
@@ -264,15 +265,19 @@ const TokenPriceChart = ({ tokens, flatten }: TokenPriceChartProps) => {
                   <HStack className="flex-nowrap items-baseline gap-2">
                     <span className="text-xl font-medium text-text">{formatPrice(currentPrice)}</span>
 
-                    <HStack className="items-center gap-1">
-                      <span className="text-sm font-medium" style={{ color: priceChangeColor }}>
-                        {formatSignedPercent(priceChange)}
-                      </span>
-                      <span className="text-[10px]" style={{ color: priceChangeColor }}>
-                        {priceChange >= 0 ? '▲' : '▼'}
-                      </span>
-                    </HStack>
-                    <span className="text-sm text-subText">(24h)</span>
+                    {hasPriceChange && (
+                      <>
+                        <HStack className="items-center gap-1">
+                          <span className="text-sm font-medium" style={{ color: priceChangeColor }}>
+                            {formatSignedPercent(priceChange)}
+                          </span>
+                          <span className="text-[10px]" style={{ color: priceChangeColor }}>
+                            {priceChange >= 0 ? '▲' : '▼'}
+                          </span>
+                        </HStack>
+                        <span className="text-sm text-subText">(24h)</span>
+                      </>
+                    )}
                   </HStack>
                 )}
               </Stack>

--- a/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
+++ b/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
@@ -142,7 +142,7 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
           wallet: walletKey,
         },
         chainId,
-        gasLimitMarginBps: isSmartSettlement ? 3_000 : undefined,
+        gasLimitMarginBps: isSmartSettlement ? 5_000 : undefined,
         onRequestSignature,
       })
       if (response?.hash === undefined) throw new Error('sendTransaction returned undefined.')

--- a/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
+++ b/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
@@ -24,6 +24,7 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
 
   const { recipient: recipientAddressOrName, routeSummary } = useSwapFormContext()
   const { parsedAmountIn: inputAmount, parsedAmountOut: outputAmount, priceImpact } = routeSummary || {}
+  const isSmartSettlement = routeSummary?.isSmartSettlement
 
   const [allowedSlippage] = useUserSlippageTolerance()
   const [searchParams] = useSearchParams()
@@ -141,13 +142,14 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
           wallet: walletKey,
         },
         chainId,
+        gasLimitMarginBps: isSmartSettlement ? 3_000 : undefined,
         onRequestSignature,
       })
       if (response?.hash === undefined) throw new Error('sendTransaction returned undefined.')
       handleSwapResponse(response)
       return response?.hash
     },
-    [account, chainId, handleSwapResponse, inputAmount, walletKey, isSmartConnector],
+    [account, chainId, handleSwapResponse, inputAmount, walletKey, isSmartConnector, isSmartSettlement],
   )
 
   return swapCallbackForEVM

--- a/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
+++ b/apps/kyberswap-interface/src/pages/PartnerSwap/index.tsx
@@ -187,10 +187,6 @@ const PartnerSwap = ({ mode = 'partner' }: Props) => {
     swaps: routeSummary?.route,
   })
 
-  const isSmartSettlementActive = useMemo(
-    () => routeSummary?.route?.some(route => route.some(swap => swap.extra?._ce)),
-    [routeSummary?.route],
-  )
   const hasSupportedTokenPriceChart = Boolean(PRICE_CHART_QUOTE_TOKEN_BY_CHAIN[swapChainId])
 
   const setActiveTab = useCallback(
@@ -276,7 +272,7 @@ const PartnerSwap = ({ mode = 'partner' }: Props) => {
             defaultCollapsed={hasSupportedTokenPriceChart && isShowPricingChart}
             inputAmount={routeSummary?.parsedAmountIn}
             outputAmount={routeSummary?.parsedAmountOut}
-            isSmartSettlementActive={isSmartSettlementActive}
+            isSmartSettlement={routeSummary?.isSmartSettlement}
           />
         )}
       </>

--- a/apps/kyberswap-interface/src/pages/Swap/components/SwapRightPanel.tsx
+++ b/apps/kyberswap-interface/src/pages/Swap/components/SwapRightPanel.tsx
@@ -1,5 +1,4 @@
 import type { Currency } from '@kyberswap/ks-sdk-core'
-import { useMemo } from 'react'
 
 import TokenPriceChart from 'components/TokenPriceChart'
 import { PRICE_CHART_QUOTE_TOKEN_BY_CHAIN } from 'constants/tokens'
@@ -26,11 +25,6 @@ export const SwapRightPanel = ({ currencyIn, currencyOut, routeSummary }: Props)
     swaps: routeSummary?.route,
   })
 
-  const isSmartSettlementActive = useMemo(
-    () => routeSummary?.route?.some(route => route.some(swap => swap.extra?._ce)),
-    [routeSummary?.route],
-  )
-
   const hasSupportedTokenPriceChart = Boolean(PRICE_CHART_QUOTE_TOKEN_BY_CHAIN[chainId])
 
   return (
@@ -44,7 +38,7 @@ export const SwapRightPanel = ({ currencyIn, currencyOut, routeSummary }: Props)
           defaultCollapsed={hasSupportedTokenPriceChart && isShowPricingChart}
           inputAmount={routeSummary?.parsedAmountIn}
           outputAmount={routeSummary?.parsedAmountOut}
-          isSmartSettlementActive={isSmartSettlementActive}
+          isSmartSettlement={routeSummary?.isSmartSettlement}
         />
       )}
     </>

--- a/apps/kyberswap-interface/src/pages/Swap/components/SwapTradeRoute.tsx
+++ b/apps/kyberswap-interface/src/pages/Swap/components/SwapTradeRoute.tsx
@@ -42,7 +42,7 @@ type SwapTradeRouteProps = {
   defaultCollapsed?: boolean
   inputAmount: CurrencyAmount<Currency> | undefined
   outputAmount: CurrencyAmount<Currency> | undefined
-  isSmartSettlementActive?: boolean
+  isSmartSettlement?: boolean
   scrollOnExpand?: boolean
 }
 
@@ -53,7 +53,7 @@ const SwapTradeRoute = ({
   defaultCollapsed = false,
   inputAmount,
   outputAmount,
-  isSmartSettlementActive = false,
+  isSmartSettlement = false,
   scrollOnExpand = true,
 }: SwapTradeRouteProps) => {
   const panelRef = useRef<HTMLDivElement>(null)
@@ -140,7 +140,7 @@ const SwapTradeRoute = ({
               </div>
             ) : null}
 
-            {isSmartSettlementActive && (
+            {isSmartSettlement && (
               <ClickTooltip text={smartSettlementTooltip} width="360px" placement="top">
                 <div
                   role="button"

--- a/apps/kyberswap-interface/src/services/route/utils.ts
+++ b/apps/kyberswap-interface/src/services/route/utils.ts
@@ -84,6 +84,7 @@ export const parseGetRouteResponse = (
     fee: calculateFee(parsedAmountIn, parsedAmountOut, rawRouteSummary),
     priceImpact: calculatePriceImpact(Number(rawRouteSummary.amountInUsd), Number(rawRouteSummary.amountOutUsd)),
     executionPrice,
+    isSmartSettlement: rawRouteSummary.route?.some(route => route.some(swap => Boolean(swap.extra?._ce))) ?? false,
     routerAddress: rawData.routerAddress,
   }
 

--- a/apps/kyberswap-interface/src/services/tokenChart.ts
+++ b/apps/kyberswap-interface/src/services/tokenChart.ts
@@ -54,7 +54,7 @@ export type TokenChartCandle = {
 
 export type TokenChartData = {
   candles: Array<TokenChartCandle>
-  change24h: number
+  change24h?: number | null
   latestPrice: number
   quoteAddress?: string
   summary?: {

--- a/apps/kyberswap-interface/src/types/route.ts
+++ b/apps/kyberswap-interface/src/types/route.ts
@@ -65,5 +65,6 @@ export type DetailedRouteSummary = {
   extraFee: ExtraFeeConfig
 
   route: Route[][]
+  isSmartSettlement: boolean
   routerAddress: string
 }

--- a/apps/kyberswap-interface/src/utils/index.ts
+++ b/apps/kyberswap-interface/src/utils/index.ts
@@ -60,13 +60,14 @@ export const shortenHash = (hash: string, chars = 3): string => {
 }
 
 /**
- * Add a margin amount equal to max of 20000 or 20% of estimatedGas
- * total = estimate + max(20k, 20% * estimate) (50% on Polygon and Optimism).
+ * Add a margin amount equal to max of 20000 or the configured percentage of estimatedGas.
+ * The default percentage is 20% (50% on Polygon and Optimism).
  */
-export function calculateGasMarginBigInt(value: bigint, chainId?: ChainId): bigint {
+export function calculateGasMarginBigInt(value: bigint, chainId?: ChainId, minimumMarginBps = 2000): bigint {
   const defaultGasLimitMargin = BigInt(DEFAULT_GAS_LIMIT_MARGIN)
   const needHigherGas = [ChainId.MATIC, ChainId.OPTIMISM].includes(chainId as ChainId)
-  const gasMargin = (value * (needHigherGas ? 5000n : 2000n)) / 10000n
+  const chainMarginBps = needHigherGas ? 5000 : 2000
+  const gasMargin = (value * BigInt(Math.max(chainMarginBps, minimumMarginBps))) / 10000n
   return gasMargin >= defaultGasLimitMargin ? value + gasMargin : value + defaultGasLimitMargin
 }
 

--- a/apps/kyberswap-interface/src/utils/sendTransaction.ts
+++ b/apps/kyberswap-interface/src/utils/sendTransaction.ts
@@ -123,6 +123,7 @@ export async function sendEVMTransaction({
   errorInfo,
   isSmartConnector,
   chainId,
+  gasLimitMarginBps,
   onRequestSignature,
 }: {
   account: string
@@ -135,6 +136,7 @@ export async function sendEVMTransaction({
   }
   isSmartConnector: boolean
   chainId: ChainId
+  gasLimitMarginBps?: number
   // Fired once the tx is fully prepared (gas + fees estimated) and we're about to
   // ask the wallet to sign — lets the UI switch from "preparing" to "awaiting
   // signature" instead of claiming the wallet is open while we're still estimating.
@@ -202,7 +204,7 @@ export async function sendEVMTransaction({
     )
   }
 
-  const gasLimit = calculateGasMarginBigInt(gasEstimate, chainId)
+  const gasLimit = calculateGasMarginBigInt(gasEstimate, chainId, gasLimitMarginBps)
 
   // Build the full eth_sendTransaction payload ethers v5 used to populate
   // (type, chainId, fees, gas). Hardware wallets like SafePal can't decode a


### PR DESCRIPTION
## Summary
- derive and reuse Smart Settlement metadata from the parsed route summary
- use a 30% minimum gas margin for Smart Settlement swaps while preserving higher chain-specific margins

