### PR TITLE
feat(cross-chain): enable Robinhood for Symbiosis

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
@@ -177,6 +177,7 @@ export class SymbiosisAdapter extends BaseSwapAdapter {
       ChainId.BLAST,
       ChainId.SONIC,
       ChainId.BERA,
+      ChainId.ROBINHOOD,
     ]
   }
 


### PR DESCRIPTION
## Summary

- Enable Robinhood as a supported Symbiosis chain for cross-chain routing.