### PR TITLE
feat(token-selector): track tab, chain and token picks in the selector

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -519,6 +519,28 @@ export const TokenSelectorContent = ({
     (isNewTab && newLoading && !newTokens.length) ||
     (isTrendingTab && trendingLoading && !trendingTokens.length)
 
+  // Reported only once a pick actually reaches the consumer, so a selection blocked by the restricted
+  // check or still awaiting its chain-switch confirm doesn't count. Shared by every entry point — row
+  // click, quick-select, Enter, and the cross-chain confirm — so they all land the same shape.
+  const trackTokenSelected = useCallback(
+    (currency: Currency, needsChainSwitch: boolean) => {
+      const address = currency.wrapped.address
+      const rowIndex = visibleCurrencies.findIndex(item => item.wrapped.address === address)
+      trackingHandler(TRACKING_EVENT_TYPE.TS_TOKEN_SELECTED, {
+        source: trackingSource,
+        tab: activeTab,
+        token_symbol: currency.symbol,
+        token_address: isTokenNative(currency) ? 'NATIVE' : address,
+        chain: NETWORKS_INFO[currency.chainId].name,
+        // Absent when the pick came from quick-select or the other-chain group rather than the list.
+        row_index: rowIndex >= 0 ? rowIndex : undefined,
+        is_search_result: !!debouncedQuery,
+        needs_chain_switch: needsChainSwitch,
+      })
+    },
+    [activeTab, debouncedQuery, trackingHandler, trackingSource, visibleCurrencies],
+  )
+
   const handleCurrencySelect = useCallback(
     (currency: Currency) => {
       const resolved = isTokenNative(currency) ? NativeCurrencies[currency.chainId] : currency
@@ -532,10 +554,11 @@ export const TokenSelectorContent = ({
         setSwitchChainToken(resolved)
         return
       }
+      trackTokenSelected(resolved, false)
       onCurrencySelect?.(resolved)
       onDismiss?.()
     },
-    [anchorChainId, onCurrencySelect, onDismiss, isTokenRestricted, notifyRestrictedToken],
+    [anchorChainId, onCurrencySelect, onDismiss, isTokenRestricted, notifyRestrictedToken, trackTokenSelected],
   )
 
   // On confirm, switch to the token's chain and select it once the switch lands (see the hook — it
@@ -545,8 +568,9 @@ export const TokenSelectorContent = ({
     if (!switchChainToken) return
     const token = switchChainToken
     setSwitchChainToken(null)
+    trackTokenSelected(token, true)
     switchChainAndSelect(token)
-  }, [switchChainToken, switchChainAndSelect])
+  }, [switchChainToken, switchChainAndSelect, trackTokenSelected])
 
   // A hit in the "other chains" group is other-chain only relative to the chain selector, which the
   // wallet need not be on — so the token can well sit on the app's own chain. Aim the selector at it
@@ -562,6 +586,32 @@ export const TokenSelectorContent = ({
       handleCurrencySelect(token)
     },
     [handleCurrencySelect, isTokenImported, onImportToken],
+  )
+
+  const handleTabChange = useCallback(
+    (tab: TokenSelectorTab) => {
+      setActiveTab(tab)
+      trackingHandler(TRACKING_EVENT_TYPE.TS_TAB_SELECTED, {
+        source: trackingSource,
+        tab,
+        previous_tab: activeTab,
+        chain: NETWORKS_INFO[primaryChainId].name,
+      })
+    },
+    [activeTab, primaryChainId, trackingHandler, trackingSource],
+  )
+
+  const handleChainChange = useCallback(
+    (chainId: ChainId) => {
+      setSelectedChainId(chainId)
+      trackingHandler(TRACKING_EVENT_TYPE.TS_CHAIN_SWITCHED, {
+        source: trackingSource,
+        from_chain: NETWORKS_INFO[selectedChainId].name,
+        to_chain: NETWORKS_INFO[chainId].name,
+        tab: activeTab,
+      })
+    },
+    [activeTab, selectedChainId, trackingHandler, trackingSource],
   )
 
   const handleInput = useCallback(
@@ -818,7 +868,7 @@ export const TokenSelectorContent = ({
             )}
           </SearchWrapper>
           {showDiscoveryTabs && (
-            <ChainSelector chains={rankedChains} selectedChainId={selectedChainId} onChange={setSelectedChainId} />
+            <ChainSelector chains={rankedChains} selectedChainId={selectedChainId} onChange={handleChainChange} />
           )}
         </HStack>
 
@@ -842,7 +892,7 @@ export const TokenSelectorContent = ({
           </div>
         )}
 
-        {showDiscoveryTabs && <TabBar tabs={visibleTabs} activeTab={activeTab} onChange={setActiveTab} />}
+        {showDiscoveryTabs && <TabBar tabs={visibleTabs} activeTab={activeTab} onChange={handleTabChange} />}
       </PaddedColumn>
 
       <div

--- a/apps/kyberswap-interface/src/hooks/useTracking.ts
+++ b/apps/kyberswap-interface/src/hooks/useTracking.ts
@@ -246,6 +246,13 @@ export enum TRACKING_EVENT_TYPE {
   TOKEN_PAIR_REVERSED,
   MAX_BALANCE_CLICKED,
 
+  // Token selector modal interactions. TS_TOKEN_SELECTED is distinct from TOKEN_SELECTED above: it
+  // fires inside the modal, so it carries which tab the pick came from and covers every surface the
+  // modal serves (swap, limit order, cross-chain), not just the swap form.
+  TS_TAB_SELECTED,
+  TS_CHAIN_SWITCHED,
+  TS_TOKEN_SELECTED,
+
   // Swap settings interactions
   TRANSACTION_TIME_LIMIT_CHANGED,
   LIQUIDITY_SOURCES_TOGGLED,
@@ -437,6 +444,20 @@ export default function useTracking(currencies?: { [field in Field]?: Currency }
         // carried in `payload.trade_type` so all three flows roll up into one event.
         case TRACKING_EVENT_TYPE.TIP_LINK_TRADE: {
           formoTrack('Tip Link Trade', payload)
+          break
+        }
+        // Token selector browsing is anonymous on purpose: much of it happens before a wallet is
+        // connected, and gating these would drop that whole slice of the discovery funnel.
+        case TRACKING_EVENT_TYPE.TS_TAB_SELECTED: {
+          formoTrack('Token Selector - Tab Selected', payload)
+          break
+        }
+        case TRACKING_EVENT_TYPE.TS_CHAIN_SWITCHED: {
+          formoTrack('Token Selector - Chain Switched', payload)
+          break
+        }
+        case TRACKING_EVENT_TYPE.TS_TOKEN_SELECTED: {
+          formoTrack('Token Selector - Token Selected', payload)
           break
         }
       }


### PR DESCRIPTION
The modal reported only Token Searched, so the discovery revamp had no way to answer which tabs get used, whether the chain selector is discovered, or which tab a pick came from.

Token Selected already exists but fires from the swap form, where the tab is not knowable and limit-order and cross-chain picks never reach it. TS_TOKEN_SELECTED is a separate event fired inside the modal instead, so the older one keeps its meaning. It sits on the shared select path, covering row clicks, quick-select, Enter and the other-chain group, and reports only once a pick reaches the consumer — a restricted token or an unconfirmed chain switch does not count.

These three are anonymous events: much of token browsing happens before a wallet is connected, and gating them would drop that slice of the funnel. Note this makes their coverage wider than Token Searched, which stays wallet-gated.