### PR TITLE
fix(kyberdao): resolve broken KNC logo in token logo lookup

### DIFF
--- a/apps/kyberswap-interface/src/pages/KyberDAO/StakeKNC/CurrencyInputForStake.tsx
+++ b/apps/kyberswap-interface/src/pages/KyberDAO/StakeKNC/CurrencyInputForStake.tsx
@@ -64,11 +64,7 @@ export default function CurrencyInputForStake({
         <NumericalInput value={value} onUserInput={setValue} disabled={disabled} />
         <span className="mr-1.5 text-sm text-border">~${kncValueInUsd}</span>
         <KNCLogoWrapper>
-          {getTokenLogoURL(tokenAddress, ChainId.MAINNET) !== '' ? (
-            <img src={`${getTokenLogoURL(tokenAddress, ChainId.MAINNET)}`} alt="knc-logo" width="24px" height="24px" />
-          ) : (
-            <img src={KNC} alt="knc-logo" width="24px" height="24px" />
-          )}
+          <img src={getTokenLogoURL(tokenAddress, ChainId.MAINNET) || KNC} alt="knc-logo" width="24px" height="24px" />
           {tokenName}
         </KNCLogoWrapper>
       </RowBetween>

--- a/apps/kyberswap-interface/src/utils/index.ts
+++ b/apps/kyberswap-interface/src/utils/index.ts
@@ -3,6 +3,8 @@ import dayjs from 'dayjs'
 import JSBI from 'jsbi'
 import Numeral from 'numeral'
 
+import KNCLogoUrl from 'assets/images/KNC.svg'
+import KNCLLogoUrl from 'assets/images/KNCL.png'
 import { ENV_KEY } from 'constants/env'
 import { DEFAULT_GAS_LIMIT_MARGIN, ETHER_ADDRESS, ZERO_ADDRESS } from 'constants/index'
 import { NETWORKS_INFO, SUPPORTED_NETWORKS } from 'constants/networks'
@@ -216,12 +218,12 @@ export const getTokenLogoURL = (inputAddress: string, chainId: ChainId): string 
     address = WETH[chainId].address
   }
 
-  if (address.toLowerCase() === KNC_ADDRESS) {
-    return 'https://raw.githubusercontent.com/KyberNetwork/kyberswap-interface/develop/src/assets/images/KNC.svg'
+  if (address.toLowerCase() === KNC_ADDRESS.toLowerCase()) {
+    return KNCLogoUrl
   }
 
   if (address.toLowerCase() === KNCL_ADDRESS.toLowerCase()) {
-    return 'https://raw.githubusercontent.com/KyberNetwork/kyberswap-interface/develop/src/assets/images/KNCL.png'
+    return KNCLLogoUrl
   }
 
   // WBTC


### PR DESCRIPTION
## Problem

The KNC logo renders broken on the `/kyberdao/*` pages (e.g. next to the `KNC: $x.xxxx` price in the **Stake KNC** header).

## Root cause

`getTokenLogoURL` has a dedicated branch for KNC, but it lowercases the input address and compares it against the checksum-cased `KNC_ADDRESS` constant, so the condition is never true:

```ts
if (address.toLowerCase() === KNC_ADDRESS) // '0xdefa4e…' !== '0xdeFA4e…'
```

The lookup therefore falls through to `mapWhitelistTokens[chainId][address]`. That map is only fetched for the **currently active chain**, so `getTokenLogoURL(KNC_ADDRESS, ChainId.MAINNET)` returns `''` whenever the wallet is on any chain other than Ethereum — producing `<img src="">`.

## Fix

- Compare both sides in lowercase so the KNC / KNCL branches actually match.
- Return the bundled `assets/images/KNC.svg` / `KNCL.png` instead of hotlinking `raw.githubusercontent.com/.../develop/src/assets/images/...` — that path belongs to the pre-monorepo layout and is an avoidable external request for a static logo.
- Collapse the now-redundant fallback ternary in `CurrencyInputForStake`.

Applies to every KNC/KNCL logo in the app, not just the KyberDAO pages.

## Testing

- `tsc --noEmit` — clean for the touched files (only the pre-existing `BitcoinProvider/providers/ledger.ts` errors remain)
- `eslint` + `prettier --check` — pass
