### PR TITLE
fix(analytics): stop the deferred Formo provider from remounting the app

### DIFF
--- a/apps/kyberswap-interface/src/components/Analytics/DeferredFormoProvider.tsx
+++ b/apps/kyberswap-interface/src/components/Analytics/DeferredFormoProvider.tsx
@@ -1,16 +1,24 @@
+import type { IFormoAnalytics } from '@formo/analytics'
 import { ComponentType, ReactNode, useEffect, useState } from 'react'
+
+import { LocalFormoContext } from 'components/Analytics/formoContext'
 
 // `@formo/analytics` (~65KB) is an analytics SDK that is never needed for first paint. We keep it off the
 // eager entry chunk by DYNAMICALLY importing FormoBridge (the only module that touches the SDK) during
-// browser idle. Until it loads, children render with our local Formo context defaulting to `null`, so
-// `useFormo()` consumers (from ./formoContext) safely no-op their `analytics?.track(...)` calls — exactly
-// the behaviour the package's own default context provides. Once the bridge mounts, the live instance flows
-// through and tracking resumes normally.
+// browser idle. Until it loads, `useFormo()` consumers (from ./formoContext) read `null` and safely no-op
+// their `analytics?.track(...)` calls — exactly the behaviour the package's own default context provides.
+// Once the bridge reports the live instance it flows through the context below and tracking resumes.
+//
+// `children` MUST keep a fixed position in the element tree. React reconciles by position, so moving them
+// under the bridge once it loads makes React unmount and remount the whole app — losing every piece of
+// state and re-running every effect. The bridge is therefore a sibling that renders nothing and only
+// reports the instance upwards.
 
-type BridgeComponent = ComponentType<{ children: ReactNode }>
+type BridgeComponent = ComponentType<{ onReady: (analytics: IFormoAnalytics | null) => void }>
 
 export default function DeferredFormoProvider({ children }: { children: ReactNode }) {
   const [Bridge, setBridge] = useState<BridgeComponent | null>(null)
+  const [analytics, setAnalytics] = useState<IFormoAnalytics | null>(null)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -39,7 +47,10 @@ export default function DeferredFormoProvider({ children }: { children: ReactNod
     }
   }, [])
 
-  if (!Bridge) return <>{children}</>
-
-  return <Bridge>{children}</Bridge>
+  return (
+    <LocalFormoContext.Provider value={analytics}>
+      {children}
+      {Bridge ? <Bridge onReady={setAnalytics} /> : null}
+    </LocalFormoContext.Provider>
+  )
 }

--- a/apps/kyberswap-interface/src/components/Analytics/FormoBridge.tsx
+++ b/apps/kyberswap-interface/src/components/Analytics/FormoBridge.tsx
@@ -1,26 +1,31 @@
-import { FormoAnalyticsProvider, useFormo as useRealFormo } from '@formo/analytics'
-import { ReactNode } from 'react'
+import { FormoAnalyticsProvider, type IFormoAnalytics, useFormo as useRealFormo } from '@formo/analytics'
+import { useEffect } from 'react'
 
-import { LocalFormoContext } from 'components/Analytics/formoContext'
 import { FORMO_WRITE_KEY } from 'constants/env'
 
 // This module is loaded ONLY via the deferred dynamic import in DeferredFormoProvider, so it (and the heavy
 // `@formo/analytics` SDK it pulls in) lives in a separate chunk, off the eager entry path.
 
-// Reads the real Formo analytics instance from the provider's context and republishes it into our local
-// context, so app-wide `useFormo()` consumers (which import from ./formoContext) receive the live instance.
-function FormoContextBridge({ children }: { children: ReactNode }) {
+// Reads the real analytics instance out of the SDK's own context and hands it back to
+// DeferredFormoProvider, which owns the context the rest of the app reads. Renders nothing: the SDK
+// provider only needs to be mounted somewhere, it does not need to wrap the app.
+function ReportInstance({ onReady }: { onReady: (analytics: IFormoAnalytics | null) => void }) {
   const analytics = useRealFormo()
-  return <LocalFormoContext.Provider value={analytics ?? null}>{children}</LocalFormoContext.Provider>
+
+  useEffect(() => {
+    onReady(analytics ?? null)
+  }, [analytics, onReady])
+
+  return null
 }
 
-export default function FormoBridge({ children }: { children: ReactNode }) {
+export default function FormoBridge({ onReady }: { onReady: (analytics: IFormoAnalytics | null) => void }) {
   return (
     <FormoAnalyticsProvider
       writeKey={FORMO_WRITE_KEY}
       disabled={typeof window !== 'undefined' && window.location.hostname.endsWith('.pr.kyberengineering.io')}
     >
-      <FormoContextBridge>{children}</FormoContextBridge>
+      <ReportInstance onReady={onReady} />
     </FormoAnalyticsProvider>
   )
 }


### PR DESCRIPTION
## Summary

- `DeferredFormoProvider` rendered `children` under a Fragment until the analytics bridge finished its idle dynamic import, then re-rendered them under the bridge. React reconciles by position, so that swap unmounted and remounted the whole tree below the provider — Redux store provider, router, i18n, wallet, theme and every page — about a second into each page load.
- Consequences: all component state discarded, every `useEffect` re-run (duplicate API calls, a second wallet reconnect, duplicate analytics), and a visible flash where the Singapore MAS notice closed and reopened with a fresh fade-in.
- Keep `children` at a fixed position: the provider now always renders the app-wide `LocalFormoContext.Provider` and mounts the bridge as a sibling that renders `null` and reports the analytics instance upwards via `onReady`.
- The SDK still loads during browser idle in its own chunk — `FormoBridge` remains a separate chunk and `@formo/analytics` stays out of the entry bundle.

## Verification

Instrumented the DOM node identity of the dialog overlay, `#app` subtree and header across a page load.

| | before | after |
|---|---|---|
| React takeover | dialog #1, appRoot #2 @256ms | dialog #1, appRoot #1 @355ms |
| FormoBridge chunk fetched | ~1s | 503ms |
| after the bridge loads | **dialog #2, appRoot #3 @1087ms** (remount) | no new instances through 13s |

The bridge chunk is confirmed loaded in the "after" run, so the absence of a remount is not a vacuous result.
