### PR TITLE
feat(token-selector): report chain ids alongside chain names in tracking

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -532,6 +532,7 @@ export const TokenSelectorContent = ({
         token_symbol: currency.symbol,
         token_address: isTokenNative(currency) ? 'NATIVE' : address,
         chain: NETWORKS_INFO[currency.chainId].name,
+        chain_id: currency.chainId,
         // Absent when the pick came from quick-select or the other-chain group rather than the list.
         row_index: rowIndex >= 0 ? rowIndex : undefined,
         is_search_result: !!debouncedQuery,
@@ -596,6 +597,7 @@ export const TokenSelectorContent = ({
         tab,
         previous_tab: activeTab,
         chain: NETWORKS_INFO[primaryChainId].name,
+        chain_id: primaryChainId,
       })
     },
     [activeTab, primaryChainId, trackingHandler, trackingSource],
@@ -607,7 +609,9 @@ export const TokenSelectorContent = ({
       trackingHandler(TRACKING_EVENT_TYPE.TS_CHAIN_SWITCHED, {
         source: trackingSource,
         from_chain: NETWORKS_INFO[selectedChainId].name,
+        from_chain_id: selectedChainId,
         to_chain: NETWORKS_INFO[chainId].name,
+        to_chain_id: chainId,
         tab: activeTab,
       })
     },


### PR DESCRIPTION
Follow-up to #3283, which added the token selector's tab / chain-switch / token-pick events.

Those events identify a chain only by display name. A name is a moving target — chains get renamed, and different tools spell them differently — so joining these events to anything keyed by chain id needs a lookup table that has to be kept in sync by hand.

This sends the numeric id next to the name:

| Event | Added |
| --- | --- |
| `Token Selector - Tab Selected` | `chain_id` |
| `Token Selector - Chain Switched` | `from_chain_id`, `to_chain_id` |
| `Token Selector - Token Selected` | `chain_id` |

The existing name fields are untouched, so queries already written against them keep working.

## Testing

Payloads read back in-browser (Formo does not transmit from local dev, so the values were observed at the `formoTrack` boundary with temporary instrumentation that is not part of this diff):

- Tab: `tab: new, previous_tab: trending, chain: Ethereum, chain_id: 1`
- Chain: `from_chain: Ethereum, from_chain_id: 1, to_chain: Base, to_chain_id: 8453`
- Token: `token_symbol: SPX, chain: Ethereum, chain_id: 1, row_index: 0, needs_chain_switch: false`

`sanitizeFormoPayload` only rewrites keys matching `/usd$/i` or `/^volume/i`, so the new numeric fields pass through unchanged.

`pnpm lint` and `pnpm type-check` clean.