### PR TITLE
fix(token-selector): polish modal layout and loading states

### DIFF
--- a/packages/token-selector/postcss.config.js
+++ b/packages/token-selector/postcss.config.js
@@ -7,6 +7,8 @@ export default {
     "postcss-prefix-selector": {
       prefix: ".ks-token-selector",
       transform: function (prefix, selector, prefixedSelector) {
+        if (selector === ":is(.ks-token-selector, kyber-portal.ks-ui-style)")
+          return selector;
         if (prefixOverrideList.includes(selector)) {
           return prefix;
         } else {

--- a/packages/token-selector/src/TokenImportConfirm.tsx
+++ b/packages/token-selector/src/TokenImportConfirm.tsx
@@ -3,8 +3,9 @@ import { useLingui } from "@lingui/react";
 import { useCopy } from "@kyber/hooks";
 import { ChainId, Token } from "@kyber/schema";
 import { Button, TokenLogo } from "@kyber/ui";
-import { getEtherscanLink } from "@kyber/utils";
 import { shortenAddress } from "@kyber/utils/crypto";
+
+import { getNetworkInfo } from "@/TokenInfo/utils";
 
 import IconAlertTriangle from "@/assets/alert-triangle.svg?react";
 import IconBack from "@/assets/arrow-left.svg?react";
@@ -28,12 +29,15 @@ const TokenImportConfirm = ({
   const Copy = useCopy({ text: token.address });
 
   const handleOpenExternalLink = () => {
-    const externalLink = getEtherscanLink(chainId, token.address, "address");
+    const scanLink = getNetworkInfo(chainId)?.scanLink;
+    const externalLink = scanLink
+      ? `${scanLink}/address/${token.address}`
+      : undefined;
     if (externalLink && window) window.open(externalLink, "_blank");
   };
 
   return (
-    <div className="w-full text-white">
+    <div className="h-full w-full overflow-y-auto text-white">
       <div className="flex items-center justify-between p-4 pb-2 border-b border-[#40444f]">
         <IconBack
           className="w-6 h-6 cursor-pointer hover:text-subText"
@@ -43,20 +47,20 @@ const TokenImportConfirm = ({
         <X className="cursor-pointer hover:text-subText" onClick={onClose} />
       </div>
       <div className="p-4 flex flex-col gap-4">
-        <div className="bg-warning-200 p-[15px] flex rounded-md text-warning items-start gap-2">
-          <IconAlertTriangle className="h-[18px]" />
+        <div className="flex items-start gap-2 rounded-md bg-warning-200 p-4 text-warning">
+          <IconAlertTriangle className="h-5" />
           <p className="text-sm">
             {i18n._(
               "This token isn't frequently swapped. Please do your own research before trading.",
             )}
           </p>
         </div>
-        <div className="bg-[#0f0f0f] rounded-md p-8 flex gap-[10px] items-start">
+        <div className="flex items-start gap-3 rounded-md bg-[#0f0f0f] p-8">
           <TokenLogo src={token.logo} size={44} />
           <div className="flex flex-col gap-1">
             <p className="text-lg">{token.symbol}</p>
             <p className="text-subText text-sm">{token.name}</p>
-            <p className="text-xs flex items-center gap-[5px]">
+            <p className="flex items-center gap-1 text-xs">
               <span>
                 {i18n._("Address: {address}", {
                   address: shortenAddress(token.address, 7),

--- a/packages/token-selector/src/TokenInfo/CollapseInfoItem.tsx
+++ b/packages/token-selector/src/TokenInfo/CollapseInfoItem.tsx
@@ -55,7 +55,7 @@ const CollapseInfoItem = ({
           onClick={onExpand}
         >
           <div className="flex items-center justify-between w-full pr-3">
-            <div className="flex items-center justify-start gap-[6px]">
+            <div className="flex items-center justify-start gap-2">
               <span>{icon}</span>
               <span>{title}</span>
             </div>
@@ -70,8 +70,8 @@ const CollapseInfoItem = ({
           </div>
         </AccordionTrigger>
         <AccordionContent className="px-5 py-4 bg-black bg-opacity-[0.2] rounded-b-md flex gap-3 justify-between flex-wrap">
-          <div className="flex items-center gap-[6px] justify-between basis-[45%] text-xs text-subText">
-            <div className="flex items-center gap-[6px]">
+          <div className="flex basis-[45%] items-center justify-between gap-2 text-xs text-subText">
+            <div className="flex items-center gap-2">
               <IconAlertOctagon className="h-4 w-4 text-error" />
               <span>
                 {totalRisk <= 1
@@ -82,8 +82,8 @@ const CollapseInfoItem = ({
             <span className="text-error font-medium">{totalRisk}</span>
           </div>
 
-          <div className="flex items-center gap-[6px] justify-between basis-[45%] text-xs text-subText">
-            <div className="flex items-center gap-[6px]">
+          <div className="flex basis-[45%] items-center justify-between gap-2 text-xs text-subText">
+            <div className="flex items-center gap-2">
               <IconAlertOctagon className="h-4 w-4 text-warning" />
               <span>
                 {totalWarning <= 1
@@ -120,7 +120,7 @@ const CollapseInfoItem = ({
             return (
               <div
                 key={label}
-                className="flex items-center gap-[6px] justify-between basis-[45%] text-xs text-subText"
+                className="flex basis-[45%] items-center justify-between gap-2 text-xs text-subText"
               >
                 <span>{label}</span>
                 <span

--- a/packages/token-selector/src/TokenInfo/MarketInfo.tsx
+++ b/packages/token-selector/src/TokenInfo/MarketInfo.tsx
@@ -24,8 +24,8 @@ const MarketInfo = ({
   const { i18n } = useLingui();
   const Copy = useCopy({
     text: tokenAddress,
-    copyClassName: "w-3 h-3 text-text hover:text-subText",
-    successClassName: "w-3 h-3",
+    copyClassName: "w-4 h-4 text-text hover:text-subText",
+    successClassName: "w-4 h-4",
   });
 
   const { marketTokenInfo, loading } = useMarketTokenInfo({
@@ -46,15 +46,13 @@ const MarketInfo = ({
           <span>{i18n._("Market Info")}</span>
         </div>
         <div className="flex items-center gap-1">
-          <span className="text-subText text-[10px]">
-            {i18n._("Powered by")}
-          </span>{" "}
-          <LogoCoingecko className="h-4 w-14" />
+          <span className="text-subText text-xs">{i18n._("Powered by")}</span>{" "}
+          <LogoCoingecko className="h-5" />
         </div>
       </div>
       <div
-        className={`flex flex-col gap-3 px-[26px] pt-[14px] transition-all ease-in-out duration-300 overflow-hidden ${
-          expand ? "h-[226px]" : "h-[86px]"
+        className={`flex flex-col gap-3 overflow-hidden px-6 pt-4 transition-all duration-300 ease-in-out ${
+          expand ? "h-56" : "h-[88px]"
         }`}
       >
         {(marketTokenInfo || []).map(
@@ -75,7 +73,7 @@ const MarketInfo = ({
           ),
         )}
       </div>
-      <div className="flex flex-col gap-3 px-[26px] py-[14px]">
+      <div className="flex flex-col gap-3 px-6 py-4">
         <div className="flex items-center justify-between text-xs">
           <span className="text-subText">{i18n._("Contract Address")}</span>
           <div className="flex items-center gap-1">
@@ -91,7 +89,7 @@ const MarketInfo = ({
           </div>
         </div>
         <div
-          className="text-xs text-accent cursor-pointer mx-auto w-fit flex items-center"
+          className="text-xs font-medium text-accent cursor-pointer mx-auto w-fit flex items-center"
           onClick={handleChangeExpand}
         >
           <span>{!expand ? i18n._("View more") : i18n._("View less")}</span>

--- a/packages/token-selector/src/TokenInfo/SecurityInfo.tsx
+++ b/packages/token-selector/src/TokenInfo/SecurityInfo.tsx
@@ -34,7 +34,7 @@ const SecurityInfo = ({
             text={i18n._(
               "Token security info provided by Goplus. Please conduct your own research before trading",
             )}
-            width="250px"
+            width="248px"
           >
             <span className="border-dashed border-b border-text">
               {i18n._("Security Info")}
@@ -42,13 +42,11 @@ const SecurityInfo = ({
           </MouseoverTooltip>
         </div>
         <div className="flex items-center gap-1">
-          <span className="text-subText text-[10px]">
-            {i18n._("Powered by")}
-          </span>{" "}
-          <LogoGoPlus className="h-4 w-14" />
+          <span className="text-subText text-xs">{i18n._("Powered by")}</span>{" "}
+          <LogoGoPlus className="h-5" />
         </div>
       </div>
-      <div className="flex flex-col gap-[14px] p-[14px]">
+      <div className="flex flex-col gap-4 p-4">
         <CollapseInfoItem
           icon={<IconSecurityTrading />}
           title={i18n._("Trading Security")}

--- a/packages/token-selector/src/TokenInfo/index.tsx
+++ b/packages/token-selector/src/TokenInfo/index.tsx
@@ -1,14 +1,10 @@
 import { useMemo } from "react";
 
-import {
-  ChainId,
-  NATIVE_TOKEN_ADDRESS,
-  NETWORKS_INFO,
-  Token,
-} from "@kyber/schema";
+import { ChainId, NATIVE_TOKEN_ADDRESS, Token } from "@kyber/schema";
 
 import MarketInfo from "@/TokenInfo/MarketInfo";
 import SecurityInfo from "@/TokenInfo/SecurityInfo";
+import { getNetworkInfo } from "@/TokenInfo/utils";
 import ChevronLeft from "@/assets/chevron-left.svg?react";
 
 const TokenInfo = ({
@@ -20,29 +16,38 @@ const TokenInfo = ({
   chainId: ChainId;
   onGoBack: () => void;
 }) => {
+  const networkInfo = getNetworkInfo(chainId);
   const tokenAddress = useMemo(
     () =>
       (token?.address
         ? token.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase()
-          ? NETWORKS_INFO[chainId].wrappedToken.address
+          ? networkInfo?.wrappedToken.address || ""
           : token.address
         : ""
       ).toLowerCase(),
-    [token, chainId],
+    [token, networkInfo],
   );
 
   return (
-    <div className="w-full mx-auto text-white overflow-hidden">
-      <div className="flex items-center gap-1 p-4 pb-[14px]">
+    <div className="h-full w-full overflow-y-auto text-white">
+      <div className="flex items-center gap-2 p-4">
         <ChevronLeft
-          className="text-subText w-[26px] h-[26px] cursor-pointer hover:text-text"
+          className="text-subText w-5 h-5 cursor-pointer hover:text-text"
           onClick={onGoBack}
         />
-        <span className="ml-1">{token.symbol || ""}</span>
-        <span className="text-xs text-subText mt-1">{token.name || ""}</span>
+        <span className="font-medium">{token.symbol || ""}</span>
+        <span className="text-xs text-subText">{token.name || ""}</span>
       </div>
-      <MarketInfo token={token} tokenAddress={tokenAddress} chainId={chainId} />
-      <SecurityInfo tokenAddress={tokenAddress} chainId={chainId} />
+      {tokenAddress ? (
+        <>
+          <MarketInfo
+            token={token}
+            tokenAddress={tokenAddress}
+            chainId={chainId}
+          />
+          <SecurityInfo tokenAddress={tokenAddress} chainId={chainId} />
+        </>
+      ) : null}
     </div>
   );
 };

--- a/packages/token-selector/src/TokenInfo/useMarketTokenInfo.ts
+++ b/packages/token-selector/src/TokenInfo/useMarketTokenInfo.ts
@@ -2,9 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { I18n } from "@lingui/core";
 
-import { API_URLS, ChainId, NETWORKS_INFO } from "@kyber/schema";
+import { API_URLS, ChainId } from "@kyber/schema";
 
-import { TokenInfo, getMarketTokenInfo } from "@/TokenInfo/utils";
+import {
+  TokenInfo,
+  getMarketTokenInfo,
+  getNetworkInfo,
+} from "@/TokenInfo/utils";
 
 const FETCH_INTERVAL = 60_000;
 
@@ -29,15 +33,25 @@ export default function useMarketTokenInfo({
     () => getMarketTokenInfo(marketTokenInfo, i18n),
     [marketTokenInfo, i18n],
   );
+  const networkInfo = useMemo(() => getNetworkInfo(chainId), [chainId]);
 
   const handleFetchCoingeckoData = useCallback(() => {
-    if (!tokenAddress) return;
+    if (!tokenAddress || !networkInfo) return;
+
+    const isNativeToken =
+      tokenAddress === networkInfo.wrappedToken.address.toLowerCase();
+    const requestUrl = isNativeToken
+      ? networkInfo.coingeckoNativeTokenId
+        ? `${API_URLS.COINGECKO_API_URL}/coins/${networkInfo.coingeckoNativeTokenId}`
+        : null
+      : networkInfo.coingeckoNetworkId
+        ? `${API_URLS.COINGECKO_API_URL}/coins/${networkInfo.coingeckoNetworkId}/contract/${tokenAddress}`
+        : null;
+
+    if (!requestUrl) return;
+
     setLoading(true);
-    fetch(
-      tokenAddress === NETWORKS_INFO[chainId].wrappedToken.address.toLowerCase()
-        ? `${API_URLS.COINGECKO_API_URL}/coins/${NETWORKS_INFO[chainId].coingeckoNativeTokenId}`
-        : `${API_URLS.COINGECKO_API_URL}/coins/${NETWORKS_INFO[chainId].coingeckoNetworkId}/contract/${tokenAddress}`,
-    )
+    fetch(requestUrl)
       .then((res) => res.json())
       .then((data) =>
         setMarketTokenInfo({
@@ -58,10 +72,11 @@ export default function useMarketTokenInfo({
         setMarketTokenInfo(null);
       })
       .finally(() => setLoading(false));
-  }, [tokenAddress, chainId]);
+  }, [networkInfo, tokenAddress]);
 
   useEffect(() => {
-    if (!tokenAddress) return;
+    setMarketTokenInfo(null);
+    if (!tokenAddress || !networkInfo) return;
 
     if (fetchIntervalRef.current) clearInterval(fetchIntervalRef.current);
     handleFetchCoingeckoData();
@@ -73,7 +88,7 @@ export default function useMarketTokenInfo({
     return () => {
       if (fetchIntervalRef.current) clearInterval(fetchIntervalRef.current);
     };
-  }, [tokenAddress, handleFetchCoingeckoData]);
+  }, [handleFetchCoingeckoData, networkInfo, tokenAddress]);
 
   return { marketTokenInfo: parsedMarketTokenInfo, loading };
 }

--- a/packages/token-selector/src/TokenInfo/utils.ts
+++ b/packages/token-selector/src/TokenInfo/utils.ts
@@ -1,5 +1,21 @@
 import type { I18n } from "@lingui/core";
 
+import { ChainId, NETWORKS_INFO, type Token } from "@kyber/schema";
+
+interface TokenSelectorNetworkInfo {
+  scanLink: string;
+  wrappedToken: Token;
+  coingeckoNetworkId: string | null;
+  coingeckoNativeTokenId: string | null;
+}
+
+export const getNetworkInfo = (
+  chainId: ChainId,
+): TokenSelectorNetworkInfo | undefined =>
+  Object.prototype.hasOwnProperty.call(NETWORKS_INFO, chainId)
+    ? NETWORKS_INFO[chainId]
+    : undefined;
+
 export interface TokenInfo {
   price: number;
   marketCap: number;

--- a/packages/token-selector/src/TokenModal.tsx
+++ b/packages/token-selector/src/TokenModal.tsx
@@ -17,11 +17,11 @@ const TokenInfo = lazy(() => import("@/TokenInfo"));
 
 /** Loading fallback for lazy-loaded TokenInfo */
 const TokenInfoLoader = () => (
-  <div className="w-full mx-auto text-white overflow-hidden">
-    <div className="flex items-center gap-1 p-4 pb-[14px] animate-pulse">
-      <div className="w-[26px] h-[26px] rounded bg-stroke" />
-      <div className="w-20 h-5 rounded bg-stroke ml-1" />
-      <div className="w-32 h-4 rounded bg-stroke mt-1" />
+  <div className="h-full w-full overflow-y-auto text-white">
+    <div className="flex animate-pulse items-center gap-2 p-4">
+      <div className="h-5 w-5 rounded bg-stroke" />
+      <div className="h-6 w-20 rounded bg-stroke" />
+      <div className="h-4 w-32 rounded bg-stroke" />
     </div>
     <div className="flex items-center justify-between px-4 py-2 bg-icon-200">
       <div className="flex items-center gap-2">
@@ -29,7 +29,7 @@ const TokenInfoLoader = () => (
         <div className="w-24 h-4 rounded bg-stroke" />
       </div>
     </div>
-    <div className="flex flex-col gap-3 px-[26px] py-[14px]">
+    <div className="flex flex-col gap-3 px-6 py-4">
       {Array.from({ length: 4 }).map((_, i) => (
         <div
           key={i}
@@ -158,16 +158,13 @@ const TokenModal = ({
     tokensIn,
   ]);
 
-  const isSelectorView = !tokenToShow && !tokenToImport;
-
   return (
     <Dialog onOpenChange={onClose} open={true}>
       <DialogContent
         containerClassName="ks-token-selector"
         className={
-          `bg-layer2 p-0 !max-h-[min(80vh,640px)] ` +
-          `${isSelectorView ? "h-[80vh] pb-6 overflow-hidden " : "overflow-y-auto "}` +
-          `${tokenToImport ? "max-w-[420px]" : "max-w-[435px]"}`
+          `h-[80vh] overflow-hidden !border-0 bg-layer2 p-0 !max-h-[min(80vh,640px)] ` +
+          `${tokenToImport ? "max-w-[420px]" : "max-w-[436px]"}`
         }
         skipClose
         aria-describedby={undefined}

--- a/packages/token-selector/src/TokenSelector.tsx
+++ b/packages/token-selector/src/TokenSelector.tsx
@@ -147,9 +147,9 @@ const TokenRow = memo(function TokenRow({
 
   if (warned) {
     return (
-      <div style={style} className="px-6 py-1">
-        <div className="flex flex-col justify-center gap-1 rounded-xl bg-warning-200 px-3 py-2 h-full">
-          <div className="flex items-center space-x-3 opacity-50 pointer-events-none">
+      <div style={style}>
+        <div className="flex h-full flex-col justify-center gap-1 bg-warning-200 px-6 py-2">
+          <div className="flex items-center gap-3 opacity-50 pointer-events-none">
             <TokenLogo src={token.logo} size={24} />
             <div>
               <TokenSymbol
@@ -173,15 +173,15 @@ const TokenRow = memo(function TokenRow({
   return (
     <div
       style={style}
-      className={`flex items-center justify-between py-2 px-6 cursor-pointer hover:bg-[#0f0f0f] ${
+      className={`flex cursor-pointer items-center justify-between px-6 py-2 hover:bg-[#0f0f0f] ${
         isSelected ? "bg-[#1d7a5f26]" : ""
       } ${token.disabled ? "!bg-stroke !cursor-not-allowed brightness-50" : ""}`}
       onClick={() => !token.disabled && onClickToken(token)}
     >
-      <div className="flex items-center space-x-3">
+      <div className="flex items-center gap-3">
         {mode === TOKEN_SELECT_MODE.ADD && (
           <div
-            className={`w-4 h-4 rounded-[4px] flex items-center justify-center cursor-pointer mr-1 ${
+            className={`w-4 h-4 rounded-[4px] flex items-center justify-center cursor-pointer ${
               modalTokensInAddress.has(token.address?.toLowerCase())
                 ? "bg-emerald-400"
                 : "bg-gray-700"
@@ -716,9 +716,9 @@ export default function TokenSelector({
     showUserPositions && onSelectLiquiditySource && !positionsOnly;
 
   return (
-    <div className="w-full mx-auto text-white overflow-hidden flex flex-col h-full">
-      <div className="space-y-4 flex flex-col flex-1 min-h-0">
-        <div className="flex justify-between items-center p-6 pb-0">
+    <div className="flex h-full w-full flex-col overflow-hidden text-white">
+      <div className="flex shrink-0 flex-col gap-4 px-6 py-4">
+        <div className="flex items-center justify-between">
           <h2 className="text-xl">
             {title || i18n._("Select Liquidity Source")}
           </h2>
@@ -731,7 +731,7 @@ export default function TokenSelector({
         </div>
 
         {showTabs && (
-          <div className="border rounded-full p-[2px] flex mx-6 !mt-0 text-sm gap-1 border-icon-200">
+          <div className="flex gap-1 rounded-full border border-icon-200 p-1 text-sm">
             <div
               className={`rounded-full w-full text-center py-2 cursor-pointer hover:bg-[#ffffff33] ${
                 modalTabSelected === MODAL_TAB.TOKENS ? "bg-[#ffffff33]" : ""
@@ -757,7 +757,7 @@ export default function TokenSelector({
 
         {mode === TOKEN_SELECT_MODE.SELECT &&
           modalTabSelected === MODAL_TAB.TOKENS && (
-            <p className="text-sm text-subText px-6">
+            <p className="text-sm text-subText">
               {i18n._("You can search and select")}{" "}
               <span className="text-text">{i18n._("any token(s)")}</span>{" "}
               {i18n._("on KyberSwap")}
@@ -765,9 +765,7 @@ export default function TokenSelector({
           )}
 
         {modalTabSelected === MODAL_TAB.POSITIONS && (
-          <p
-            className={`text-sm text-subText px-6 ${positionsOnly ? "!-mt-2" : ""}`}
-          >
+          <p className="text-sm text-subText">
             {i18n._(
               variant === "smart-exit"
                 ? "Select the position for setting up Smart Exit."
@@ -776,32 +774,32 @@ export default function TokenSelector({
           </p>
         )}
 
-        <div
-          className={`px-6 ${modalTabSelected === MODAL_TAB.POSITIONS ? "!mb-2" : ""} ${!showTabs ? "!mt-0" : ""}`}
-        >
+        <div>
           <div className="relative border-0">
             <Input
               type="text"
               placeholder={i18n._(
                 "Search by token name, token symbol or address",
               )}
-              className="h-[45px] pl-4 pr-10 py-2 bg-[#0f0f0f] border-[1.5px] border-[#0f0f0f] text-white placeholder-subText rounded-full focus:border-success outline-none"
+              className="h-11 rounded-full border-[1.5px] border-[#0f0f0f] bg-[#0f0f0f] py-2 pl-4 pr-10 text-white outline-none placeholder-subText focus:border-success"
               value={searchTerm}
               onChange={handleChangeSearch}
             />
-            <IconSearch className="absolute right-3 top-1/2 transform -translate-y-1/2 text-subText h-[18px]" />
+            <IconSearch className="absolute right-3 top-1/2 h-5 -translate-y-1/2 transform text-subText" />
           </div>
         </div>
 
         {mode === TOKEN_SELECT_MODE.ADD &&
           modalTabSelected === MODAL_TAB.TOKENS && (
-            <p className="text-sm text-subText px-6">
+            <p className="text-sm text-subText">
               {i18n._("The maximum number of tokens selected is {count}.", {
                 count: MAX_TOKENS,
               })}
             </p>
           )}
+      </div>
 
+      <div className="flex min-h-0 flex-1 flex-col">
         {modalTabSelected === MODAL_TAB.TOKENS && (
           <TokenFeature
             tabSelected={tabSelected}
@@ -818,165 +816,165 @@ export default function TokenSelector({
           />
         )}
 
-        <div className="token-scroll-container !mt-0 flex-1 min-h-0 flex flex-col">
-          {modalTabSelected === MODAL_TAB.TOKENS && (
-            <>
-              {tabSelected === TOKEN_TAB.ALL &&
-                unImportedTokens.map((token: Token, index) => {
-                  const restricted = Boolean(isTokenRestricted?.(token));
-                  const warned = warnedRestricted.has(
-                    token.address?.toLowerCase(),
-                  );
-                  if (warned) {
+        <div className="flex min-h-0 flex-1 flex-col gap-3 pb-4">
+          <div className="flex min-h-0 flex-1 flex-col">
+            {modalTabSelected === MODAL_TAB.TOKENS && (
+              <>
+                {tabSelected === TOKEN_TAB.ALL &&
+                  unImportedTokens.map((token: Token, index) => {
+                    const restricted = Boolean(isTokenRestricted?.(token));
+                    const warned = warnedRestricted.has(
+                      token.address?.toLowerCase(),
+                    );
+                    if (warned) {
+                      return (
+                        <div key={`${token.symbol}-${index}`}>
+                          <div className="flex flex-col gap-1 bg-warning-200 px-6 py-2">
+                            <div className="flex items-center justify-between opacity-50 pointer-events-none">
+                              <div className="flex items-center gap-2">
+                                <TokenLogo src={token.logo} size={24} />
+                                <TokenSymbol
+                                  className="text-subText"
+                                  symbol={token.symbol}
+                                  maxWidth={120}
+                                />
+                                <p className="text-xs text-[#6C7284]">
+                                  {token.name}
+                                </p>
+                              </div>
+                              <Button
+                                disabled
+                                className="h-fit rounded-full !bg-accent px-3 py-2 font-normal !text-[#222222] !cursor-not-allowed"
+                              >
+                                {i18n._("Import")}
+                              </Button>
+                            </div>
+                            <p className="text-xs font-medium text-warning">
+                              {i18n._(
+                                "This token is not available in your jurisdiction",
+                              )}
+                            </p>
+                          </div>
+                        </div>
+                      );
+                    }
+
                     return (
                       <div
                         key={`${token.symbol}-${index}`}
-                        className="px-6 py-1"
+                        className="flex items-center justify-between px-6 py-2 text-red hover:bg-[#0f0f0f]"
                       >
-                        <div className="flex flex-col gap-1 rounded-xl bg-warning-200 px-3 py-2">
-                          <div className="flex items-center justify-between opacity-50 pointer-events-none">
-                            <div className="flex items-center gap-2">
-                              <TokenLogo src={token.logo} size={24} />
-                              <TokenSymbol
-                                className="ml-2 text-subText"
-                                symbol={token.symbol}
-                                maxWidth={120}
-                              />
-                              <p className="text-xs text-[#6C7284]">
-                                {token.name}
-                              </p>
-                            </div>
-                            <Button
-                              disabled
-                              className="rounded-full !bg-accent font-normal !text-[#222222] px-3 py-[6px] h-fit !cursor-not-allowed"
-                            >
-                              {i18n._("Import")}
-                            </Button>
-                          </div>
-                          <p className="text-xs font-medium text-warning">
-                            {i18n._(
-                              "This token is not available in your jurisdiction",
-                            )}
-                          </p>
+                        <div className="flex items-center gap-2">
+                          <TokenLogo src={token.logo} size={24} />
+                          <TokenSymbol
+                            className="text-subText"
+                            symbol={token.symbol}
+                            maxWidth={120}
+                          />
+                          <p className="text-xs text-[#6C7284]">{token.name}</p>
                         </div>
+                        <Button
+                          className="h-fit rounded-full !bg-accent px-3 py-2 font-normal !text-[#222222] hover:brightness-75"
+                          onClick={() => {
+                            if (restricted) {
+                              setWarnedRestricted((prev) =>
+                                new Set(prev).add(token.address?.toLowerCase()),
+                              );
+                              return;
+                            }
+                            handleImportToken(token);
+                          }}
+                        >
+                          {i18n._("Import")}
+                        </Button>
                       </div>
                     );
-                  }
+                  })}
 
-                  return (
-                    <div
-                      key={`${token.symbol}-${index}`}
-                      className="flex items-center justify-between py-2 px-6 text-red"
-                    >
-                      <div className="flex items-center gap-2">
-                        <TokenLogo src={token.logo} size={24} />
-                        <TokenSymbol
-                          className="ml-2 text-subText"
-                          symbol={token.symbol}
-                          maxWidth={120}
-                        />
-                        <p className="text-xs text-[#6C7284]">{token.name}</p>
-                      </div>
-                      <Button
-                        className="rounded-full !bg-accent font-normal !text-[#222222] px-3 py-[6px] h-fit hover:brightness-75"
-                        onClick={() => {
-                          if (restricted) {
-                            setWarnedRestricted((prev) =>
-                              new Set(prev).add(token.address?.toLowerCase()),
-                            );
-                            return;
-                          }
-                          handleImportToken(token);
-                        }}
-                      >
-                        {i18n._("Import")}
-                      </Button>
-                    </div>
-                  );
-                })}
+                {isLoading || isPending ? (
+                  <TokenLoader />
+                ) : filteredTokens?.length > 0 && !unImportedTokens.length ? (
+                  <div className="flex-1 min-h-0">
+                    <AutoSizer>
+                      {({ height, width }) => (
+                        <List
+                          className="token-virtual-list"
+                          ref={listRef}
+                          height={height}
+                          width={width}
+                          itemCount={filteredTokens.length}
+                          itemSize={getItemSize}
+                          estimatedItemSize={TOKEN_ROW_HEIGHT}
+                          itemData={tokenListData}
+                          overscanCount={5}
+                        >
+                          {TokenRow}
+                        </List>
+                      )}
+                    </AutoSizer>
+                  </div>
+                ) : !unImportedTokens.length ||
+                  (tabSelected === TOKEN_TAB.IMPORTED &&
+                    !importedTokens.length) ? (
+                  <div className="p-4 text-center text-sm font-medium text-subText">
+                    {i18n._("No results found.")}
+                  </div>
+                ) : (
+                  <></>
+                )}
+              </>
+            )}
 
-              {isLoading || isPending ? (
-                <TokenLoader />
-              ) : filteredTokens?.length > 0 && !unImportedTokens.length ? (
+            {modalTabSelected === MODAL_TAB.POSITIONS &&
+              onSelectLiquiditySource && (
                 <div className="flex-1 min-h-0">
-                  <AutoSizer>
-                    {({ height, width }) => (
-                      <List
-                        ref={listRef}
-                        height={height}
-                        width={width}
-                        itemCount={filteredTokens.length}
-                        itemSize={getItemSize}
-                        estimatedItemSize={TOKEN_ROW_HEIGHT}
-                        itemData={tokenListData}
-                        overscanCount={5}
-                      >
-                        {TokenRow}
-                      </List>
-                    )}
-                  </AutoSizer>
+                  <UserPositions
+                    search={searchTerm}
+                    chainId={chainId}
+                    account={account}
+                    positionId={positionId}
+                    poolAddress={poolAddress}
+                    excludePositionIds={excludePositionIds}
+                    filterExchanges={filterExchanges}
+                    filterChains={filterChains}
+                    variant={variant}
+                    onConnectWallet={onConnectWallet}
+                    onSelectLiquiditySource={onSelectLiquiditySource}
+                    onClose={onClose}
+                    initialSlippage={initialSlippage}
+                  />
                 </div>
-              ) : !unImportedTokens.length ||
-                (tabSelected === TOKEN_TAB.IMPORTED &&
-                  !importedTokens.length) ? (
-                <div className="text-center text-[#6C7284] font-medium mt-4">
-                  {i18n._("No results found.")}
-                </div>
-              ) : (
-                <></>
               )}
-            </>
+          </div>
+
+          {message && (
+            <div className="px-6">
+              <div className="rounded-md bg-warning-200 px-4 py-3 text-xs text-warning transition-all duration-300 ease-in-out">
+                {message}
+              </div>
+            </div>
           )}
 
-          {modalTabSelected === MODAL_TAB.POSITIONS &&
-            onSelectLiquiditySource && (
-              <div className="flex-1 min-h-0">
-                <UserPositions
-                  search={searchTerm}
-                  chainId={chainId}
-                  account={account}
-                  positionId={positionId}
-                  poolAddress={poolAddress}
-                  excludePositionIds={excludePositionIds}
-                  filterExchanges={filterExchanges}
-                  filterChains={filterChains}
-                  variant={variant}
-                  onConnectWallet={onConnectWallet}
-                  onSelectLiquiditySource={onSelectLiquiditySource}
-                  onClose={onClose}
-                  initialSlippage={initialSlippage}
-                />
+          {mode === TOKEN_SELECT_MODE.ADD &&
+            modalTabSelected === MODAL_TAB.TOKENS && (
+              <div className="flex gap-3 px-6">
+                <Button
+                  variant="outline"
+                  className="flex-1 !bg-transparent text-subText border-subText rounded-full hover:text-accent hover:border-accent"
+                  onClick={onClose}
+                >
+                  {i18n._("Cancel")}
+                </Button>
+                <Button
+                  className="flex-1 !bg-accent text-black rounded-full hover:text-black hover:brightness-110"
+                  disabled={!modalTokensIn.length}
+                  onClick={handleSaveSelected}
+                >
+                  {i18n._("Save")}
+                </Button>
               </div>
             )}
         </div>
-
-        {message && (
-          <div
-            className={`text-warning bg-warning-200 py-3 px-4 mt-2 text-xs mx-6 rounded-md transition-all ease-in-out duration-300`}
-          >
-            {message}
-          </div>
-        )}
-
-        {mode === TOKEN_SELECT_MODE.ADD &&
-          modalTabSelected === MODAL_TAB.TOKENS && (
-            <div className="flex space-x-4 rounded-lg px-4">
-              <Button
-                variant="outline"
-                className="flex-1 !bg-transparent text-subText border-subText rounded-full hover:text-accent hover:border-accent"
-                onClick={onClose}
-              >
-                {i18n._("Cancel")}
-              </Button>
-              <Button
-                className="flex-1 !bg-accent text-black rounded-full hover:text-black hover:brightness-110"
-                disabled={!modalTokensIn.length}
-                onClick={handleSaveSelected}
-              >
-                {i18n._("Save")}
-              </Button>
-            </div>
-          )}
       </div>
     </div>
   );
@@ -1072,31 +1070,33 @@ const TokenFeature = memo(function TokenFeature({
 
   return (
     <>
-      <div className="px-6 pb-3 flex gap-4 border-b border-[#505050]">
-        <div
-          className={`text-sm cursor-pointer ${tabSelected === TOKEN_TAB.ALL ? "text-accent" : ""}`}
-          onClick={() => setTabSelected(TOKEN_TAB.ALL)}
-        >
-          {i18n._("All")}
-        </div>
-        <div
-          className={`text-sm cursor-pointer ${tabSelected === TOKEN_TAB.IMPORTED ? "text-accent" : ""}`}
-          onClick={() => setTabSelected(TOKEN_TAB.IMPORTED)}
-        >
-          {i18n._("Imported")}
+      <div className="border-b border-[#505050]">
+        <div className="flex gap-4 px-6 pb-3">
+          <div
+            className={`text-sm hover:brightness-75 font-medium cursor-pointer ${tabSelected === TOKEN_TAB.ALL ? "text-accent" : ""}`}
+            onClick={() => setTabSelected(TOKEN_TAB.ALL)}
+          >
+            {i18n._("All")}
+          </div>
+          <div
+            className={`text-sm hover:brightness-75 font-medium cursor-pointer ${tabSelected === TOKEN_TAB.IMPORTED ? "text-accent" : ""}`}
+            onClick={() => setTabSelected(TOKEN_TAB.IMPORTED)}
+          >
+            {i18n._("Imported")}
+          </div>
         </div>
       </div>
 
       {tabSelected === TOKEN_TAB.IMPORTED && importedTokens.length ? (
-        <div className="flex items-center justify-between px-6 !mt-0 py-[10px]">
+        <div className="flex items-center justify-between px-6 py-2">
           <span className="text-xs text-icon">
             {i18n._("{count} Custom Tokens", { count: importedTokens.length })}
           </span>
           <Button
-            className="rounded-full !text-icon flex items-center gap-2 text-xs px-[10px] py-[5px] h-fit font-normal !bg-[#a9a9a933]"
+            className="flex h-fit items-center gap-2 rounded-full !bg-[#a9a9a933] px-3 py-1 text-xs font-normal !text-icon"
             onClick={handleRemoveAllImportedToken}
           >
-            <TrashIcon className="w-[13px] h-[13px]" />
+            <TrashIcon className="h-3 w-3" />
             {i18n._("Clear All")}
           </Button>
         </div>

--- a/packages/token-selector/src/UserPositions/index.tsx
+++ b/packages/token-selector/src/UserPositions/index.tsx
@@ -46,41 +46,54 @@ const listDexesWithVersion = [
 export const earnSupportedExchanges = enumToArrayOfValues(Exchange);
 
 /** Skeleton row for token list loading state - matches TokenRow layout */
-const TokenSkeletonRow = () => (
-  <div className="flex items-center justify-between py-2 px-6">
-    {/* Left side: Token logo + symbol + name */}
-    <div className="flex items-center space-x-3">
-      {/* Token logo (24x24) */}
-      <Skeleton className="!rounded-full" style={{ width: 24, height: 24 }} />
-      <div className="flex flex-col gap-1">
-        {/* Token symbol */}
-        <Skeleton style={{ width: 60, height: 16 }} />
-        {/* Token name */}
-        <Skeleton style={{ width: 80, height: 12 }} />
+const tokenSkeletonWidths = [
+  { symbol: 64, name: 112, balance: 48 },
+  { symbol: 80, name: 132, balance: 40 },
+  { symbol: 72, name: 96, balance: 56 },
+  { symbol: 88, name: 124, balance: 44 },
+] as const;
+
+export const TokenSkeletonRow = ({ index = 0 }: { index?: number }) => {
+  const widths = tokenSkeletonWidths[index % tokenSkeletonWidths.length];
+
+  return (
+    <div className="flex items-center justify-between px-6 py-2">
+      <div className="flex items-center gap-3">
+        <div className="h-6 w-6 shrink-0 rounded-full bg-icon-200" />
+        <div className="flex flex-col gap-1">
+          <div
+            className="h-4 rounded bg-icon-200"
+            style={{ width: widths.symbol }}
+          />
+          <div
+            className="h-4 rounded bg-icon-200"
+            style={{ width: widths.name }}
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <div
+          className="h-4 rounded bg-icon-200"
+          style={{ width: widths.balance }}
+        />
+        <div className="h-5 w-5 rounded-full bg-icon-200" />
       </div>
     </div>
-    {/* Right side: balance + info icon */}
-    <div className="flex items-center gap-2">
-      {/* Balance */}
-      <Skeleton style={{ width: 50, height: 16 }} />
-      {/* Info icon placeholder */}
-      <Skeleton className="!rounded-full" style={{ width: 18, height: 18 }} />
-    </div>
-  </div>
-);
+  );
+};
 
 /** Skeleton loader showing multiple placeholder rows */
-export const TokenLoader = ({ rows = 6 }: { rows?: number }) => (
-  <div className="flex flex-col">
+export const TokenLoader = ({ rows = 9 }: { rows?: number }) => (
+  <div className="flex animate-pulse flex-col">
     {Array.from({ length: rows }).map((_, index) => (
-      <TokenSkeletonRow key={index} />
+      <TokenSkeletonRow key={index} index={index} />
     ))}
   </div>
 );
 
 /** Skeleton row for position list loading state - matches PositionRow layout */
 const PositionSkeletonRow = () => (
-  <div className="flex flex-col py-3 px-[26px] gap-2">
+  <div className="flex flex-col gap-2 px-6 py-3">
     {/* Row 1: Token logos + pair name + fee badge | value */}
     <div className="flex items-center justify-between w-full">
       <div className="flex gap-2 items-center">
@@ -88,17 +101,17 @@ const PositionSkeletonRow = () => (
           {/* Token 0 logo */}
           <Skeleton
             className="!rounded-full"
-            style={{ width: 26, height: 26 }}
+            style={{ width: 24, height: 24 }}
           />
           {/* Token 1 logo */}
           <Skeleton
             className="!rounded-full"
-            style={{ width: 26, height: 26, marginLeft: -8 }}
+            style={{ width: 24, height: 24, marginLeft: -8 }}
           />
           {/* Chain logo */}
           <Skeleton
             className="!rounded-full relative top-1"
-            style={{ width: 14, height: 14, marginLeft: -6 }}
+            style={{ width: 16, height: 16, marginLeft: -8 }}
           />
         </div>
         {/* Token pair name (e.g., "ETH/USDC") */}
@@ -197,7 +210,7 @@ const PositionRow = memo(function PositionRow({
   return (
     <div style={style}>
       <div
-        className="flex flex-col py-3 px-[26px] gap-2 cursor-pointer hover:bg-[#31cb9e33]"
+        className="flex h-full cursor-pointer flex-col gap-2 px-6 py-3 hover:bg-[#31cb9e33]"
         onClick={() => {
           const isUniV2 = Univ2EarnDex.safeParse(
             position.pool.protocol.type,
@@ -233,7 +246,7 @@ const PositionRow = memo(function PositionRow({
               <TokenLogo
                 src={position.chain.logo}
                 size={14}
-                className="ml-[-6px] border-[2px] border-transparent relative top-1"
+                className="relative top-1 -ml-2 border-[2px] border-transparent"
               />
             </div>
             <span>
@@ -241,7 +254,7 @@ const PositionRow = memo(function PositionRow({
               {position.pool.tokenAmounts[1]?.token.symbol || ""}
             </span>
             {position.pool.fees?.length > 0 && (
-              <div className="rounded-full text-sm bg-[#ffffff14] text-subText px-[10px] py-1">
+              <div className="rounded-full bg-[#ffffff14] px-3 py-1 text-sm text-subText">
                 {formatDisplayNumber(position.pool.fees[0], {
                   significantDigits: 4,
                 })}
@@ -267,18 +280,18 @@ const PositionRow = memo(function PositionRow({
             {!isUniv2 && (
               <span className="text-subText text-xs">#{position.tokenId}</span>
             )}
-            <div className="text-[#027BC7] bg-[#ffffff0a] rounded-full px-[10px] py-1 flex gap-1 text-sm">
+            <div className="flex gap-1 rounded-full bg-[#ffffff0a] px-3 py-1 text-sm text-[#027BC7]">
               {shortenAddress(position.pool.address, 4)}
               {copied !== position.tokenId.toString() ? (
                 <IconCopy
-                  className="w-[14px] h-[14px] text-[#027BC7] hover:brightness-125 relative top-[3px] cursor-pointer"
+                  className="relative top-1 h-4 w-4 cursor-pointer text-[#027BC7] hover:brightness-125"
                   onClick={(e) => {
                     e.stopPropagation();
                     onCopy(position);
                   }}
                 />
               ) : (
-                <CircleCheckBig className="w-[14px] h-[14px] text-accent relative top-1" />
+                <CircleCheckBig className="relative top-1 h-4 w-4 text-accent" />
               )}
             </div>
           </div>
@@ -433,7 +446,7 @@ const UserPositions = ({
 
   if (!account)
     return (
-      <div className="flex flex-col items-center justify-center gap-3 text-subText font-medium h-[260px] relative mx-6">
+      <div className="relative mx-6 flex h-[260px] flex-col items-center justify-center gap-3 font-medium text-subText">
         <IconPositionConnectWallet />
         {i18n._("No positions found. Connect your wallet first.")}
         {onConnectWallet && (
@@ -454,6 +467,7 @@ const UserPositions = ({
       <AutoSizer>
         {({ height, width }) => (
           <List
+            className="token-virtual-list"
             height={height}
             width={width}
             itemCount={itemCount}

--- a/packages/token-selector/src/styles.css
+++ b/packages/token-selector/src/styles.css
@@ -2,8 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
+:is(.ks-token-selector, kyber-portal.ks-ui-style) {
+  --ks-lw-text: #ffffff;
+  --ks-lw-subText: #979797;
+  --ks-lw-icons: #a9a9a9;
+  --ks-lw-layer1: #1c1c1c;
+  --ks-lw-layer2: #313131;
+  --ks-lw-interactive: #292929;
+  --ks-lw-stroke: #313131;
+  --ks-lw-accent: #31cb9e;
+  --ks-lw-warning: #ff9901;
+  --ks-lw-error: #ff537b;
+  --ks-lw-success: #189470;
+  --ks-lw-textRevert: #333333;
+  --ks-lw-borderRadius: 20px;
+}
+
 @layer components {
-  .token-scroll-container::-webkit-scrollbar {
+  .token-virtual-list {
+    scrollbar-width: none;
+  }
+
+  .token-virtual-list::-webkit-scrollbar {
     display: none;
   }
 }

--- a/packages/ui/src/components/token-symbol.tsx
+++ b/packages/ui/src/components/token-symbol.tsx
@@ -1,7 +1,5 @@
 import { cn } from '@kyber/utils/tailwind-helpers';
 
-import { MouseoverTooltip } from '@/components/Tooltip';
-
 export default function TokenSymbol({
   symbol,
   maxWidth = 140,
@@ -12,10 +10,8 @@ export default function TokenSymbol({
   className?: string;
 }) {
   return (
-    <MouseoverTooltip className="w-fit" text={symbol} placement="top" width="fit-content">
-      <p className={cn('truncate ks-ui-style', className)} style={{ maxWidth }}>
-        {symbol}
-      </p>
-    </MouseoverTooltip>
+    <p className={cn('truncate ks-ui-style', className)} style={{ maxWidth }} title={symbol}>
+      {symbol}
+    </p>
   );
 }


### PR DESCRIPTION
## Summary
- reorganize the token selector into consistent header and list sections with full-width interactive rows
- keep token detail views at a stable height and guard unsupported network metadata
- scope selector theme styles to its modal portals and use calmer deterministic list skeletons
- replace the shared token symbol hover popover with a native title tooltip