### PR TITLE
feat(swap): display ERC8056 input with multiplier

### DIFF
--- a/apps/kyberswap-interface/src/components/Announcement/Popups/TransactionPopup.tsx
+++ b/apps/kyberswap-interface/src/components/Announcement/Popups/TransactionPopup.tsx
@@ -32,9 +32,11 @@ const summary1Token = (txs: TransactionDetails) => {
 }
 
 const summary2Token = (txs: TransactionDetails, withType = true) => {
-  const { tokenAmountIn, tokenSymbolIn, tokenAmountOut, tokenSymbolOut } = (txs.extraInfo ||
-    {}) as TransactionExtraInfo2Token
-  return `${withType ? txs.type : ''} ${tokenAmountIn} ${tokenSymbolIn} to ${tokenAmountOut} ${tokenSymbolOut}`
+  const { tokenAmountIn, tokenAmountInDisplay, tokenSymbolIn, tokenAmountOut, tokenAmountOutDisplay, tokenSymbolOut } =
+    (txs.extraInfo || {}) as TransactionExtraInfo2Token
+  return `${withType ? txs.type : ''} ${tokenAmountInDisplay || tokenAmountIn} ${tokenSymbolIn} to ${
+    tokenAmountOutDisplay || tokenAmountOut
+  } ${tokenSymbolOut}`
 }
 
 const summaryApprove = (txs: TransactionDetails) => {

--- a/apps/kyberswap-interface/src/components/SwapForm/ERC8056Info.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/ERC8056Info.tsx
@@ -27,6 +27,8 @@ export const useERC8056SwapInfo = ({
   const displayBalanceOut = useERC8056DisplayBalance(outputInfo, balanceOut)
 
   return {
+    inputInfo,
+    outputInfo,
     input: {
       balanceText:
         displayBalanceIn && inputInfo.enabled && (inputInfo.isLoading || inputInfo.isScaled)

--- a/apps/kyberswap-interface/src/components/SwapForm/InputCurrencyPanel.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/InputCurrencyPanel.tsx
@@ -18,12 +18,14 @@ type Props = {
   highlightToken?: boolean
   onChangeCurrencyIn: (c: Currency) => void
   setTypedValue: (v: string) => void
+  onUserInput: (v: string) => void
   customChainId?: ChainId
 }
 const InputCurrencyPanel: React.FC<Props> = ({
   wrapType,
   typedValue,
   setTypedValue,
+  onUserInput,
   currencyIn,
   currencyOut,
   balanceIn,
@@ -60,7 +62,7 @@ const InputCurrencyPanel: React.FC<Props> = ({
       value={typedValue}
       positionMax="top"
       currency={currencyIn}
-      onUserInput={setTypedValue}
+      onUserInput={onUserInput}
       onMax={handleMaxInput}
       onHalf={handleHalfInput}
       onCurrencySelect={onChangeCurrencyIn}

--- a/apps/kyberswap-interface/src/components/SwapForm/SwapFormContext.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/SwapFormContext.tsx
@@ -6,6 +6,7 @@ type SwapFormContextProps = {
   slippage: number
   routeSummary: DetailedRouteSummary | undefined
   typedValue: string
+  displayTypedValue: string
   recipient: string | null
   isAdvancedMode: boolean
 }

--- a/apps/kyberswap-interface/src/components/SwapForm/SwapModal/SwapBrief.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/SwapModal/SwapBrief.tsx
@@ -34,7 +34,7 @@ export default function SwapBrief({
   currencyOut,
 }: Props) {
   const { chainId } = useActiveWeb3React()
-  const { typedValue } = useSwapFormContext()
+  const { displayTypedValue } = useSwapFormContext()
 
   const renderOutputAmount = () => {
     if (isLoading) {
@@ -71,7 +71,7 @@ export default function SwapBrief({
           <Trans>Input Amount</Trans>
         </span>
         <div className="flex w-full items-center justify-between gap-2">
-          <span className="min-w-0 flex-1 truncate text-2xl font-medium">{typedValue}</span>
+          <span className="min-w-0 flex-1 truncate text-2xl font-medium">{displayTypedValue}</span>
           <div className="flex min-w-fit items-center gap-2">
             <span className="text-sm font-medium text-subText">
               ~{formatDisplayNumber(amountInUsd, { style: 'currency', significantDigits: 4 })}

--- a/apps/kyberswap-interface/src/components/SwapForm/SwapModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/SwapModal/index.tsx
@@ -49,12 +49,12 @@ const SwapModal: React.FC<Props> = props => {
     txHash: '',
   })
 
-  const { routeSummary } = useSwapFormContext()
+  const { routeSummary, displayTypedValue } = useSwapFormContext()
   const currencyIn = routeSummary?.parsedAmountIn?.currency
   const currencyOut = routeSummary?.parsedAmountOut?.currency
 
   const amountOut = currencyOut && CurrencyAmount.fromRawAmount(currencyOut, buildResult?.data?.amountOut || '0')
-  const amountInDisplay = routeSummary?.parsedAmountIn?.toSignificant(6)
+  const amountInDisplay = displayTypedValue || routeSummary?.parsedAmountIn?.toSignificant(6)
   const symbolIn = getCurrencyDisplaySymbol(currencyIn)
   const amountOutDisplay = amountOut?.toSignificant(6)
   const symbolOut = getCurrencyDisplaySymbol(currencyOut)
@@ -96,7 +96,7 @@ const SwapModal: React.FC<Props> = props => {
       from_token: currencyIn?.symbol,
       to_token: currencyOut?.symbol,
       pair: currencyIn?.symbol && currencyOut?.symbol ? `${currencyIn.symbol}/${currencyOut.symbol}` : undefined,
-      amount_in: routeSummary?.parsedAmountIn?.toSignificant(6),
+      amount_in: displayTypedValue || routeSummary?.parsedAmountIn?.toSignificant(6),
       amount_in_usd: routeSummary?.amountInUsd ? Number(routeSummary.amountInUsd) : undefined,
       error_type: isUserRejected ? 'user_rejected' : 'tx_failed',
       error_message: error,

--- a/apps/kyberswap-interface/src/components/SwapForm/index.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/index.tsx
@@ -28,6 +28,7 @@ import { TutorialIds } from 'components/Tutorial/TutorialSwap/constant'
 import { SAFE_APP_CLIENT_ID } from 'constants/index'
 import { useActiveWeb3React } from 'hooks'
 import useDebounce from 'hooks/useDebounce'
+import { getERC8056RawTypedValue, useERC8056DisplayTypedValue } from 'hooks/useERC8056Token'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
 import { useNotify } from 'state/application/hooks'
@@ -164,6 +165,13 @@ const SwapForm: React.FC<SwapFormProps> = props => {
 
   const parsedAmount = useParsedAmount(currencyIn, typedValue)
   const erc8056Info = useERC8056SwapInfo({ chainId, currencyIn, currencyOut, balanceIn, balanceOut })
+  const displayTypedValue = useERC8056DisplayTypedValue(erc8056Info.inputInfo, typedValue)
+  const handleUserInput = useCallback(
+    (value: string) => {
+      updateInputAmount(Field.INPUT, getERC8056RawTypedValue(erc8056Info.inputInfo, value))
+    },
+    [erc8056Info.inputInfo, updateInputAmount],
+  )
 
   const {
     wrapType,
@@ -248,6 +256,7 @@ const SwapForm: React.FC<SwapFormProps> = props => {
       slippage={slippage}
       routeSummary={routeSummary}
       typedValue={typedValue}
+      displayTypedValue={displayTypedValue}
       recipient={recipient}
       isAdvancedMode={isDegenMode}
     >
@@ -259,8 +268,9 @@ const SwapForm: React.FC<SwapFormProps> = props => {
             <div className="flex flex-col gap-2">
               <InputCurrencyPanel
                 wrapType={wrapType}
-                typedValue={typedValue}
+                typedValue={displayTypedValue}
                 setTypedValue={onUserInput}
+                onUserInput={handleUserInput}
                 currencyIn={currencyIn}
                 currencyOut={currencyOut}
                 balanceIn={balanceIn}

--- a/apps/kyberswap-interface/src/components/WalletPopup/Transactions/TransactionItem.tsx
+++ b/apps/kyberswap-interface/src/components/WalletPopup/Transactions/TransactionItem.tsx
@@ -52,8 +52,16 @@ const Description1Token = (transaction: TransactionDetails) => {
 
 const Description2Token = (transaction: TransactionDetails) => {
   const { extraInfo = {}, type, chainId } = transaction
-  const { tokenAmountIn, tokenAmountOut, tokenSymbolIn, tokenSymbolOut, tokenAddressIn, tokenAddressOut } =
-    extraInfo as TransactionExtraInfo2Token
+  const {
+    tokenAmountIn,
+    tokenAmountInDisplay,
+    tokenAmountOut,
+    tokenAmountOutDisplay,
+    tokenSymbolIn,
+    tokenSymbolOut,
+    tokenAddressIn,
+    tokenAddressOut,
+  } = extraInfo as TransactionExtraInfo2Token
 
   const signTokenOut = ![
     TRANSACTION_TYPE.CLASSIC_ADD_LIQUIDITY,
@@ -75,14 +83,14 @@ const Description2Token = (transaction: TransactionDetails) => {
       <DeltaTokenAmount
         tokenAddress={tokenAddressOut}
         symbol={tokenSymbolOut}
-        amount={tokenAmountOut}
+        amount={tokenAmountOutDisplay || tokenAmountOut}
         plus={signTokenOut}
         logoURL={tokenAddressOut === ETHER_ADDRESS ? getNativeTokenLogo(chainId) : undefined}
       />
       <DeltaTokenAmount
         tokenAddress={tokenAddressIn}
         symbol={tokenSymbolIn}
-        amount={tokenAmountIn}
+        amount={tokenAmountInDisplay || tokenAmountIn}
         plus={signTokenIn}
         logoURL={tokenAddressIn === ETHER_ADDRESS ? getNativeTokenLogo(chainId) : undefined}
       />

--- a/apps/kyberswap-interface/src/hooks/useERC8056Token.ts
+++ b/apps/kyberswap-interface/src/hooks/useERC8056Token.ts
@@ -1,8 +1,10 @@
-import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
+import { ChainId, Currency, CurrencyAmount, Fraction } from '@kyberswap/ks-sdk-core'
+import JSBI from 'jsbi'
 import { useMemo } from 'react'
 import { useReadContract } from 'wagmi'
 
 import { useReadingContract } from 'hooks/useContract'
+import { parseFraction } from 'utils/numbers'
 import { parseAbi } from 'utils/viem'
 
 const UI_MULTIPLIER_SCALE = 10n ** 18n
@@ -73,4 +75,45 @@ export const useERC8056DisplayBalance = (
     const uiBalance = (BigInt(rawBalance.quotient.toString()) * info.multiplier) / UI_MULTIPLIER_SCALE
     return CurrencyAmount.fromRawAmount(rawBalance.currency, uiBalance.toString())
   }, [info.multiplier, rawBalance])
+}
+
+const trimTrailingZero = (value: string) => value.replace(/\.?0+$/, '') || '0'
+
+const formatFractionValue = (value: Fraction) => trimTrailingZero(value.toFixed(18))
+
+const getERC8056DisplayTypedValueByMultiplier = (multiplier: bigint | undefined, rawTypedValue: string): string => {
+  if (!rawTypedValue || !multiplier) return rawTypedValue
+  return formatFractionValue(
+    parseFraction(rawTypedValue)
+      .multiply(JSBI.BigInt(multiplier.toString()))
+      .divide(JSBI.BigInt(UI_MULTIPLIER_SCALE.toString())),
+  )
+}
+
+const getERC8056RawTypedValueByMultiplier = (multiplier: bigint | undefined, displayTypedValue: string): string => {
+  if (!displayTypedValue || !multiplier) return displayTypedValue
+  return formatFractionValue(
+    parseFraction(displayTypedValue)
+      .multiply(JSBI.BigInt(UI_MULTIPLIER_SCALE.toString()))
+      .divide(JSBI.BigInt(multiplier.toString())),
+  )
+}
+
+export const getERC8056DisplayTypedValue = (info: ERC8056TokenInfo, rawTypedValue: string): string =>
+  getERC8056DisplayTypedValueByMultiplier(info.multiplier, rawTypedValue)
+
+export const getERC8056RawTypedValue = (info: ERC8056TokenInfo, displayTypedValue: string): string =>
+  getERC8056RawTypedValueByMultiplier(info.multiplier, displayTypedValue)
+
+export const useERC8056DisplayTypedValue = (info: ERC8056TokenInfo, rawTypedValue: string): string => {
+  const multiplier = info.multiplier
+  return useMemo(() => getERC8056DisplayTypedValueByMultiplier(multiplier, rawTypedValue), [multiplier, rawTypedValue])
+}
+
+export const useERC8056RawTypedValue = (info: ERC8056TokenInfo, displayTypedValue: string): string => {
+  const multiplier = info.multiplier
+  return useMemo(
+    () => getERC8056RawTypedValueByMultiplier(multiplier, displayTypedValue),
+    [multiplier, displayTypedValue],
+  )
 }

--- a/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
+++ b/apps/kyberswap-interface/src/hooks/useSwapCallbackV3.ts
@@ -6,6 +6,7 @@ import { getTipLinkAttribution } from 'components/TipLinkGeneratorModal/shared'
 import { ETHER_ADDRESS } from 'constants/index'
 import { useActiveWeb3React, useWeb3React } from 'hooks'
 import useENS from 'hooks/useENS'
+import { useERC8056DisplayBalance, useERC8056TokenInfo } from 'hooks/useERC8056Token'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { TRANSACTION_TYPE, TransactionExtraInfo2Token } from 'state/transactions/type'
 import { useUserSlippageTolerance } from 'state/user/hooks'
@@ -22,9 +23,11 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
   const { connector, isSmartConnector } = useWeb3React()
   const walletKey = connector?.name
 
-  const { recipient: recipientAddressOrName, routeSummary } = useSwapFormContext()
+  const { recipient: recipientAddressOrName, routeSummary, displayTypedValue } = useSwapFormContext()
   const { parsedAmountIn: inputAmount, parsedAmountOut: outputAmount, priceImpact } = routeSummary || {}
   const isSmartSettlement = routeSummary?.isSmartSettlement
+  const outputInfo = useERC8056TokenInfo(outputAmount?.currency, chainId)
+  const displayOutputAmount = useERC8056DisplayBalance(outputInfo, outputAmount)?.toSignificant(6)
 
   const [allowedSlippage] = useUserSlippageTolerance()
   const [searchParams] = useSearchParams()
@@ -62,6 +65,8 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
       extraInfo: {
         tokenAmountIn: inputAmountStr,
         tokenAmountOut: outputAmountStr,
+        tokenAmountInDisplay: displayTypedValue || inputAmountStr,
+        tokenAmountOutDisplay: displayOutputAmount,
         tokenSymbolIn: inputSymbol,
         tokenSymbolOut: outputSymbol,
         tokenAddressIn: inputAddress,
@@ -110,6 +115,8 @@ const useSwapCallbackV3 = (isPermitSwap?: boolean) => {
     recipientAddressOrName,
     routeSummary,
     searchParams,
+    displayTypedValue,
+    displayOutputAmount,
   ])
 
   const handleSwapResponse = useCallback(

--- a/apps/kyberswap-interface/src/state/transactions/type.ts
+++ b/apps/kyberswap-interface/src/state/transactions/type.ts
@@ -23,6 +23,8 @@ export type TransactionExtraInfo2Token = {
   tokenSymbolOut: string
   tokenAmountIn: string
   tokenAmountOut: string
+  tokenAmountInDisplay?: string
+  tokenAmountOutDisplay?: string
 
   tokenLogoURLIn?: string
   tokenLogoURLOut?: string


### PR DESCRIPTION
## Summary
- Display ERC8056 swap input and confirm amounts via uiMultiplier while keeping raw amounts for route, approval, and transaction flow
- Route Max/Half and user typing through a raw/display boundary so the swap state stays unchanged
- Preserve ERC8056 balance label scaling and related swap UI copy