### PR TITLE
fix(earn): load zap widget stylesheets eagerly, keep their JS lazy

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useCompounding.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useCompounding.tsx
@@ -2,6 +2,10 @@
 // enum, so taking it from the source keeps the exact same values without dragging the widget in with it.
 import { PoolType as CompoundingPoolType } from '@kyber/schema'
 import type { ChainId as CompoundingChainId, SupportedLocale } from '@kyberswap/compounding-widget'
+// Eager, not with the lazy JS below: the widget's status dialog is styled by utilities scoped under the
+// widget's own root class, which ship only in this stylesheet (the app's eager @kyber/ui styles use a
+// different scope and don't reach it). This widget's scope is its own, so nothing else supplies it.
+import '@kyberswap/compounding-widget/dist/style.css'
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import { Suspense, lazy, useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -21,15 +25,11 @@ import { useKyberSwapConfig, useNotify, useWalletModalToggle } from 'state/appli
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { TRANSACTION_TYPE } from 'state/transactions/type'
 
-// The widget only renders inside the modal below, so keep it out of every /earn route chunk that calls this
-// hook and load it — with its stylesheet — when the modal actually mounts.
-const CompoundingWidget = lazy(async () => {
-  const [widget] = await Promise.all([
-    import('@kyberswap/compounding-widget'),
-    import('@kyberswap/compounding-widget/dist/style.css'),
-  ])
-  return { default: widget.CompoundingWidget }
-})
+// The widget only renders inside the modal below, so lazy-load its JS to keep it out of every /earn route
+// chunk that calls this hook.
+const CompoundingWidget = lazy(() =>
+  import('@kyberswap/compounding-widget').then(widget => ({ default: widget.CompoundingWidget })),
+)
 
 interface CompoundingPureParams {
   poolAddress: string

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapCreatePoolWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapCreatePoolWidget.tsx
@@ -1,4 +1,9 @@
 import { POOL_CATEGORY, Token } from '@kyber/schema'
+// Eager, not with the lazy JS below: each widget's status dialog is styled by utilities scoped under the
+// widget's own root class, which ship only in these stylesheets (the app's eager @kyber/ui styles use a
+// different scope and don't reach them). They must be present whenever the widgets can open.
+import '@kyberswap/liquidity-widgets/dist/style.css'
+import '@kyberswap/zap-create-widgets/dist/style.css'
 import { Suspense, lazy, useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -18,23 +23,15 @@ import { useTransactionAdder } from 'state/transactions/hooks'
 import { TRANSACTION_TYPE } from 'state/transactions/type'
 import { friendlyError } from 'utils/errorMessage'
 
-// Both widgets only render inside the modal below, so keep them out of every /earn route chunk that calls
-// this hook and load whichever the flow needs when the modal actually mounts.
-const ZapWidget = lazy(async () => {
-  const [widget] = await Promise.all([
-    import('@kyberswap/zap-create-widgets'),
-    import('@kyberswap/zap-create-widgets/dist/style.css'),
-  ])
-  return { default: widget.ZapCreateWidget }
-})
+// Both widgets only render inside the modal below, so lazy-load their JS to keep them out of every /earn
+// route chunk that calls this hook.
+const ZapWidget = lazy(() =>
+  import('@kyberswap/zap-create-widgets').then(widget => ({ default: widget.ZapCreateWidget })),
+)
 
-const LiquidityWidget = lazy(async () => {
-  const [widget] = await Promise.all([
-    import('@kyberswap/liquidity-widgets'),
-    import('@kyberswap/liquidity-widgets/dist/style.css'),
-  ])
-  return { default: widget.LiquidityWidget }
-})
+const LiquidityWidget = lazy(() =>
+  import('@kyberswap/liquidity-widgets').then(widget => ({ default: widget.LiquidityWidget })),
+)
 
 type CreateConfig = {
   chainId: number

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapInWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapInWidget.tsx
@@ -5,6 +5,11 @@ import type {
   ChainId as ZapInChainId,
   PoolType as ZapInPoolType,
 } from '@kyberswap/liquidity-widgets'
+// The stylesheet loads eagerly, not with the lazy JS below: the widget's transaction-status dialog is styled
+// by utilities scoped under the widget's own root class (`.ks-lw-style`), which ship only in this stylesheet
+// — the app's eager @kyber/ui styles use a different scope (`.ks-ui-style`) and don't reach it. It must be
+// present whenever the widget can open, independent of its lazy JS chunk.
+import '@kyberswap/liquidity-widgets/dist/style.css'
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -38,16 +43,9 @@ import { Address } from 'utils/viem'
 import { signTypedDataRaw } from 'utils/walletClient'
 
 // Every /earn route calls this hook to get its Zap button, but the widget itself only renders inside the
-// modal below — so importing it at module scope made each of those routes download ~760KB gz of widget for
-// UI most visitors never open. Load it, and its stylesheet, only when the modal actually mounts. The types
-// above are erased at build time, so nothing else here pulls the package back into the route chunk.
-const ZapIn = lazy(async () => {
-  const [widget] = await Promise.all([
-    import('@kyberswap/liquidity-widgets'),
-    import('@kyberswap/liquidity-widgets/dist/style.css'),
-  ])
-  return { default: widget.LiquidityWidget }
-})
+// modal below — so lazy-loading its ~760KB gz JS keeps it off routes whose visitors never open it. The
+// types above are erased at build time, so nothing else here pulls the package back into the route chunk.
+const ZapIn = lazy(() => import('@kyberswap/liquidity-widgets').then(widget => ({ default: widget.LiquidityWidget })))
 
 interface AddLiquidityPureParams {
   poolAddress: string

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
@@ -3,6 +3,10 @@
 import { PoolType as ZapMigrationDex } from '@kyber/schema'
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import type { OnSuccessProps, SupportedLocale, ChainId as ZapMigrationChainId } from '@kyberswap/zap-migration-widgets'
+// Eager, not with the lazy JS below: the widget's status dialog is styled by utilities scoped under the
+// widget's own root class, which ship only in this stylesheet (the app's eager @kyber/ui styles use a
+// different scope and don't reach it). This widget's scope is its own, so nothing else supplies it.
+import '@kyberswap/zap-migration-widgets/dist/style.css'
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePreviousDistinct } from 'react-use'
@@ -34,15 +38,11 @@ import { friendlyError } from 'utils/errorMessage'
 import { Address } from 'utils/viem'
 import { signTypedDataRaw } from 'utils/walletClient'
 
-// The widget only renders inside the modal below, so keep it out of every /earn route chunk that calls this
-// hook and load it — with its stylesheet — when the modal actually mounts.
-const ZapMigration = lazy(async () => {
-  const [widget] = await Promise.all([
-    import('@kyberswap/zap-migration-widgets'),
-    import('@kyberswap/zap-migration-widgets/dist/style.css'),
-  ])
-  return { default: widget.ZapMigration }
-})
+// The widget only renders inside the modal below, so lazy-load its JS to keep it out of every /earn route
+// chunk that calls this hook.
+const ZapMigration = lazy(() =>
+  import('@kyberswap/zap-migration-widgets').then(widget => ({ default: widget.ZapMigration })),
+)
 
 interface MigrateLiquidityPureParams {
   from: {

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapOutWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapOutWidget.tsx
@@ -3,6 +3,10 @@
 import { PoolType as ZapOutDex } from '@kyber/schema'
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import type { OnSuccessProps, ChainId as ZapOutChainId } from '@kyberswap/zap-out-widgets'
+// Eager, not with the lazy JS below: the widget's status dialog is styled by utilities scoped under the
+// widget's own root class, which ship only in this stylesheet (the app's eager @kyber/ui styles use a
+// different scope and don't reach it). It must be present whenever the widget can open.
+import '@kyberswap/zap-out-widgets/dist/style.css'
 import { Suspense, lazy, useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -64,15 +68,9 @@ const zapOutDexMapping: Record<Exchange, ZapOutDex> = {
   [Exchange.DEX_AERODROMECL3]: ZapOutDex.DEX_AERODROMECL3,
 }
 
-// The widget only renders inside the modal below, so keep it out of every /earn route chunk that calls this
-// hook and load it — with its stylesheet — when the modal actually mounts.
-const ZapOut = lazy(async () => {
-  const [widget] = await Promise.all([
-    import('@kyberswap/zap-out-widgets'),
-    import('@kyberswap/zap-out-widgets/dist/style.css'),
-  ])
-  return { default: widget.ZapOut }
-})
+// The widget only renders inside the modal below, so lazy-load its JS to keep it out of every /earn route
+// chunk that calls this hook.
+const ZapOut = lazy(() => import('@kyberswap/zap-out-widgets').then(widget => ({ default: widget.ZapOut })))
 
 const useZapOutWidget = (
   onRefreshPosition?: (props: CheckClosedPositionParams) => void,


### PR DESCRIPTION
## Summary

Each Earn zap widget's transaction-status dialog is styled by Tailwind utilities scoped under **that widget's own root class** (`.ks-lw-style` for zap-in/out/create, `.ks-lw-migration-style` for migration, `.ks-cw-style` for compounding), which ship only in the widget's own stylesheet. The app's eagerly-loaded `@kyber/ui` styles use a **different scope** (`.ks-ui-style`) and don't reach the dialog.

Previously each widget's stylesheet was imported at module scope (eager), so on any /earn route every widget's CSS was co-present and every dialog was styled. The perf change (#3284) moved the stylesheet into the lazy `import()` alongside the widget JS, so a widget opened in isolation only loaded its own CSS — leaving its status dialog unstyled until another **same-scope** widget's CSS happened to load first (e.g. opening zap-out, then zap-in works; opening zap-in directly is broken). zap-migration and compounding have unique scopes, so nothing rescues them.

This restores the eager stylesheet imports (module scope) while keeping the widget **JS** lazy behind `React.lazy` — so the ~760KB-gz-per-widget JS still loads on demand, but the much smaller stylesheets are always present on the /earn routes.

Affects all five zap hooks: `useZapInWidget`, `useZapOutWidget`, `useZapMigrationWidget`, `useCompounding`, `useZapCreatePoolWidget`.

## Verification

Confirmed via computed styles that a `.ks-lw-style`-scoped dialog element gets `max-width: none` / transparent background with only the app's `.ks-ui-style` styles present — i.e. the app CSS does not reach it. Please smoke-test on a preview deploy: open **zap-in directly** (without opening zap-out first) and confirm the "Waiting for confirmation" status dialog renders with its card/width, and repeat for zap-migration and compounding.
