### PR TITLE
fix(cross-chain): select token chain within form

### DIFF
--- a/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/kyberswap-interface/src/components/CurrencyInputPanel/index.tsx
@@ -47,7 +47,7 @@ export const CurrencySelect = forwardRef<
         selected ? 'border border-transparent text-subText' : 'border border-border-primary text-primary',
         !selected && 'shadow-[0px_6px_10px_rgba(0,0,0,0.075)]',
         isDisable ? 'cursor-default' : 'cursor-pointer',
-        !isDisable && 'hover:brightness-125 focus:brightness-125',
+        !isDisable && 'hover:brightness-110 focus:brightness-110',
         className,
       )}
     >

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -96,6 +96,8 @@ interface TokenSelectorContentProps {
   onShowTokenInfo?: (token: Token) => void
   /** Show the discovery tab bar (Trending / New / …). Off for surfaces that want a plain search + list (cross-chain). */
   showDiscoveryTabs?: boolean
+  /** Select a different chain in the owning form instead of switching the connected app/wallet chain. */
+  onSelectChain?: (chainId: ChainId) => void
 }
 
 const NoResult = ({ message }: { message?: ReactNode }) => {
@@ -173,6 +175,7 @@ export const TokenSelectorContent = ({
   trackingSource,
   onShowTokenInfo,
   showDiscoveryTabs = true,
+  onSelectChain,
 }: TokenSelectorContentProps) => {
   const { chainId: web3ChainId, account } = useActiveWeb3React()
   const anchorChainId = customChainId || web3ChainId
@@ -562,8 +565,16 @@ export const TokenSelectorContent = ({
         notifyRestrictedToken(resolved)
         return
       }
-      // Picking a token on another chain asks the user to switch first.
+      // Cross-chain forms own their chain state, so update that form and select immediately without
+      // switching the connected app/wallet chain. Other surfaces keep the existing confirm flow.
       if (resolved.chainId !== anchorChainId) {
+        if (onSelectChain) {
+          trackTokenSelected(resolved, true, selectionMethod)
+          onSelectChain(resolved.chainId)
+          onCurrencySelect?.(resolved)
+          onDismiss?.()
+          return
+        }
         pendingSelectMethodRef.current = selectionMethod
         setSwitchChainToken(resolved)
         return
@@ -580,6 +591,7 @@ export const TokenSelectorContent = ({
       isTokenRestricted,
       notifyRestrictedToken,
       trackTokenSelected,
+      onSelectChain,
     ],
   )
 

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/index.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/index.tsx
@@ -32,6 +32,8 @@ interface TokenSelectorModalProps {
   trackingSource?: string
   /** Show the discovery tab bar (Trending / New / …). Off for a plain search + list (cross-chain). */
   showDiscoveryTabs?: boolean
+  /** Select a different chain in the owning form instead of switching the connected app/wallet chain. */
+  onSelectChain?: (chainId: ChainId) => void
 }
 
 enum TokenSelectorModalView {
@@ -53,6 +55,7 @@ const TokenSelectorModal = ({
   customChainId,
   trackingSource,
   showDiscoveryTabs,
+  onSelectChain,
 }: TokenSelectorModalProps) => {
   const [modalView, setModalView] = useState<TokenSelectorModalView>(TokenSelectorModalView.search)
   // A cross-chain token confirmed from the import flow, pending its Switch-Chain confirm.
@@ -88,13 +91,19 @@ const TokenSelectorModal = ({
       // directly, so its Switch-Chain confirm is shown here, after the import, rather than before it).
       // Row selections arrive already on the right chain, so this branch no-ops for them.
       if (picked.chainId !== anchorChainId) {
+        if (onSelectChain) {
+          onSelectChain(picked.chainId)
+          onCurrencySelect?.(picked)
+          onDismiss?.()
+          return
+        }
         setSwitchChainToken(picked)
         return
       }
       onCurrencySelect?.(picked)
       onDismiss?.()
     },
-    [onDismiss, onCurrencySelect, isTokenRestricted, notifyRestrictedToken, anchorChainId],
+    [onDismiss, onCurrencySelect, isTokenRestricted, notifyRestrictedToken, anchorChainId, onSelectChain],
   )
 
   // for token import view
@@ -166,6 +175,7 @@ const TokenSelectorModal = ({
             trackingSource={trackingSource}
             onShowTokenInfo={setTokenToShowInfo}
             showDiscoveryTabs={showDiscoveryTabs}
+            onSelectChain={onSelectChain}
           />
         </div>
         {modalView === TokenSelectorModalView.importToken && importToken && !tokenToShowInfo ? (

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TokenPanel.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TokenPanel.tsx
@@ -344,6 +344,7 @@ export const TokenPanel = ({
           customChainId={selectedChain as ChainId}
           trackingSource="cross_chain"
           showDiscoveryTabs={false}
+          onSelectChain={onSelectNetwork}
         />
       ) : (
         <TokenSelectorNonEvmModal


### PR DESCRIPTION
## Summary
- switch the owning cross-chain form network when selecting an RPC token from another chain without changing the connected wallet chain
- keep the existing switch-chain confirmation for other token selector surfaces and soften currency selector hover feedback