### PR TITLE
fix(cross-chain): prevent stale quote execution

### DIFF
--- a/apps/kyberswap-interface/src/components/Web3Provider/SolanaProvider.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/SolanaProvider.tsx
@@ -5,8 +5,8 @@ import { ConnectionProvider, WalletProvider, useConnection, useWallet } from '@s
 import { ComponentProps, FC, ReactNode, createContext, useContext, useEffect, useState } from 'react'
 
 import { SOLANA_RPC } from 'constants/env'
-import { SOLANA_NATIVE } from 'pages/CrossChainSwap/constants'
 import { SolanaConnectModalProvider } from 'pages/CrossChainSwap/provider/SolanaConnectModalProvider'
+import { SOLANA_NATIVE } from 'pages/CrossChainSwap/utils'
 
 interface SolanaProviderProps {
   children: ReactNode

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/AcrossAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/AcrossAdapter.ts
@@ -34,10 +34,9 @@ import {
   SwapStatus,
 } from 'pages/CrossChainSwap/adapters/BaseSwapAdapter'
 import { isEvmChain } from 'pages/CrossChainSwap/adapters/types'
-import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/constants'
 import type { SolanaToken } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
 import { Quote } from 'pages/CrossChainSwap/registry'
-import { isNativeToken, isWrappedToken } from 'pages/CrossChainSwap/utils'
+import { CROSS_CHAIN_FEE_RECEIVER, isNativeToken, isWrappedToken } from 'pages/CrossChainSwap/utils'
 
 const API_URL = 'https://app.across.to/api/suggested-fees'
 

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BungeeAdapter/index.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/BungeeAdapter/index.ts
@@ -16,9 +16,8 @@ import {
 import { getBungeeQuote, getBungeeStatus } from 'pages/CrossChainSwap/adapters/BungeeAdapter/api'
 import { type SocketQuoteParams, type SocketQuoteResult } from 'pages/CrossChainSwap/adapters/BungeeAdapter/types'
 import { getSocketTxRoute, normalizeSocketStatus } from 'pages/CrossChainSwap/adapters/BungeeAdapter/utils'
-import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/constants'
 import { Quote } from 'pages/CrossChainSwap/registry'
-import { isWrappedToken } from 'pages/CrossChainSwap/utils'
+import { CROSS_CHAIN_FEE_RECEIVER, isWrappedToken } from 'pages/CrossChainSwap/utils'
 
 export class BungeeAdapter extends BaseSwapAdapter {
   constructor() {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/DebridgeAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/DebridgeAdapter.ts
@@ -17,9 +17,9 @@ import {
   QuoteParams,
   SwapStatus,
 } from 'pages/CrossChainSwap/adapters/BaseSwapAdapter'
-import { CROSS_CHAIN_FEE_RECEIVER, CROSS_CHAIN_FEE_RECEIVER_SOLANA } from 'pages/CrossChainSwap/constants'
 import type { SolanaToken } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
 import { Quote } from 'pages/CrossChainSwap/registry'
+import { CROSS_CHAIN_FEE_RECEIVER, CROSS_CHAIN_FEE_RECEIVER_SOLANA } from 'pages/CrossChainSwap/utils'
 
 const DEBRIDGE_API = 'https://dln.debridge.finance/v1.0/dln/order'
 const DEBRIDGE_STATS_API = 'https://stats-api.dln.trade/api'

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/LifiAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/LifiAdapter.ts
@@ -6,8 +6,8 @@ import { WalletClient, formatUnits } from 'viem'
 
 import { ZERO_ADDRESS } from 'constants/index'
 import { MAINNET_NETWORKS } from 'constants/networks'
-import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/constants'
 import type { SolanaToken } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
+import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/utils'
 import { toBigIntSafe } from 'utils/bigint'
 
 import { Quote } from '../registry'

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/MayanAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/MayanAdapter.ts
@@ -15,8 +15,8 @@ import { WalletClient, formatUnits, parseUnits } from 'viem'
 
 import { wagmiConfig } from 'components/Web3Provider'
 import { ZERO_ADDRESS } from 'constants/index'
-import { CROSS_CHAIN_FEE_RECEIVER, CROSS_CHAIN_FEE_RECEIVER_SOLANA } from 'pages/CrossChainSwap/constants'
 import type { SolanaToken } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
+import { CROSS_CHAIN_FEE_RECEIVER, CROSS_CHAIN_FEE_RECEIVER_SOLANA } from 'pages/CrossChainSwap/utils'
 
 import { Quote } from '../registry'
 import {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/NearIntentsAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/NearIntentsAdapter.ts
@@ -14,9 +14,9 @@ import { Connection, PublicKey, SystemProgram, Transaction } from '@solana/web3.
 import { WalletClient, formatUnits } from 'viem'
 
 import { ZERO_ADDRESS } from 'constants/index'
-import { BTC_DEFAULT_RECEIVER, CROSS_CHAIN_FEE_RECEIVER, SOLANA_NATIVE } from 'pages/CrossChainSwap/constants'
 import { saveMyNearWalletPendingTransaction } from 'pages/CrossChainSwap/hooks/useRestoreMyNearWalletPendingTransaction'
 import type { SolanaToken } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
+import { BTC_DEFAULT_RECEIVER, CROSS_CHAIN_FEE_RECEIVER, SOLANA_NATIVE } from 'pages/CrossChainSwap/utils'
 
 import { Quote } from '../registry'
 import {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/OptimexAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/OptimexAdapter.ts
@@ -2,7 +2,7 @@ import { ChainId, Currency } from '@kyberswap/ks-sdk-core'
 import { WalletClient, formatUnits } from 'viem'
 
 import { ZERO_ADDRESS } from 'constants/index'
-import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/constants'
+import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/utils'
 
 import { Quote } from '../registry'
 import {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/OrbiterAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/OrbiterAdapter.ts
@@ -8,8 +8,8 @@ import { WalletClient, formatUnits } from 'viem'
 import { wagmiConfig } from 'components/Web3Provider'
 import { ZERO_ADDRESS } from 'constants/index'
 import { MAINNET_NETWORKS } from 'constants/networks'
-import { CROSS_CHAIN_FEE_RECEIVER, CROSS_CHAIN_FEE_RECEIVER_SOLANA } from 'pages/CrossChainSwap/constants'
 import type { SolanaToken } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
+import { CROSS_CHAIN_FEE_RECEIVER, CROSS_CHAIN_FEE_RECEIVER_SOLANA } from 'pages/CrossChainSwap/utils'
 
 import { Quote } from '../registry'
 import {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/RelayAdapter/index.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/RelayAdapter/index.ts
@@ -43,9 +43,9 @@ import {
   QuoteParams,
   SwapStatus,
 } from 'pages/CrossChainSwap/adapters/BaseSwapAdapter'
-import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/constants'
 import type { SolanaToken } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
 import { Quote } from 'pages/CrossChainSwap/registry'
+import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/utils'
 
 const SolanaChainId = 792703809
 

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
@@ -15,8 +15,8 @@ import {
   QuoteParams,
   SwapStatus,
 } from 'pages/CrossChainSwap/adapters/BaseSwapAdapter'
-import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/constants'
 import { Quote } from 'pages/CrossChainSwap/registry'
+import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/utils'
 
 const symbiosisClient = axios.create({
   baseURL: 'https://api.symbiosis.finance/crosschain/v2',

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/XYFinanceAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/XYFinanceAdapter.ts
@@ -4,7 +4,7 @@ import { WalletClient, formatUnits } from 'viem'
 
 import { wagmiConfig } from 'components/Web3Provider'
 import { ETHER_ADDRESS } from 'constants/index'
-import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/constants'
+import { CROSS_CHAIN_FEE_RECEIVER } from 'pages/CrossChainSwap/utils'
 
 import { Quote } from '../registry'
 import {

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/ConfirmationPopup.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/ConfirmationPopup.tsx
@@ -27,7 +27,7 @@ import { QuoteProviderName } from 'pages/CrossChainSwap/components/QuoteProvider
 import { Summary } from 'pages/CrossChainSwap/components/Summary'
 import { useCrossChainSwap } from 'pages/CrossChainSwap/hooks/useCrossChainSwap'
 import { useRestoreMyNearWalletPendingTransaction } from 'pages/CrossChainSwap/hooks/useRestoreMyNearWalletPendingTransaction'
-import { getChainName } from 'pages/CrossChainSwap/utils'
+import { getChainName, isQuoteExecutable } from 'pages/CrossChainSwap/utils'
 import { useCrossChainTransactions } from 'state/crossChainSwap'
 import { CloseIcon, ExternalLink } from 'theme'
 import { shortenHash } from 'utils/address'
@@ -146,7 +146,17 @@ export const ConfirmationPopup = ({ isOpen, onDismiss }: { isOpen: boolean; onDi
   const amount = inputAmount?.toExact() || formatUnits(BigInt(amountInWei), currencyIn.decimals)
 
   const handleSwap = async () => {
-    if (isEvmChain(fromChainId) && !walletClient) return
+    if (isEvmChain(fromChainId) && !walletClient) {
+      setTxError(t`The route is outdated. Please refresh and try again.`)
+      return
+    }
+
+    const executionSender = isEvmChain(fromChainId) ? walletClient?.account.address : sender
+    if (!isQuoteExecutable(selectedQuote, executionSender, receiver)) {
+      setTxError(t`The route is outdated. Please refresh and try again.`)
+      return
+    }
+
     const adaptedWallet = adaptRelaySolanaWallet(
       solanaAddress?.toString() || '1nc1nerator11111111111111111111111111111111',
       792703809, //chain id that Relay uses to identify solana

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/ConfirmationPopup.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/ConfirmationPopup.tsx
@@ -27,6 +27,7 @@ import { QuoteProviderName } from 'pages/CrossChainSwap/components/QuoteProvider
 import { Summary } from 'pages/CrossChainSwap/components/Summary'
 import { useCrossChainSwap } from 'pages/CrossChainSwap/hooks/useCrossChainSwap'
 import { useRestoreMyNearWalletPendingTransaction } from 'pages/CrossChainSwap/hooks/useRestoreMyNearWalletPendingTransaction'
+import type { Quote } from 'pages/CrossChainSwap/registry'
 import { getChainName, isQuoteExecutable } from 'pages/CrossChainSwap/utils'
 import { useCrossChainTransactions } from 'state/crossChainSwap'
 import { CloseIcon, ExternalLink } from 'theme'
@@ -75,22 +76,18 @@ const TokenBoxInfo = ({
   )
 }
 
-export const ConfirmationPopup = ({ isOpen, onDismiss }: { isOpen: boolean; onDismiss: () => void }) => {
+type ConfirmationPopupProps = {
+  quote: Quote | null
+  isOpen: boolean
+  onDismiss?: () => void
+}
+
+export const ConfirmationPopup = ({ quote: selectedQuote, isOpen, onDismiss }: ConfirmationPopupProps) => {
   const { crossChainMixpanelHandler } = useCrossChainMixpanel()
   const { trackingHandler } = useTracking()
   const { data: walletClient } = useGatedWalletClient()
-  const {
-    selectedQuote,
-    currencyIn,
-    currencyOut,
-    amountInWei,
-    fromChainId,
-    toChainId,
-    warning,
-    recipient,
-    sender,
-    receiver,
-  } = useCrossChainSwap()
+  const { currencyIn, currencyOut, amountInWei, fromChainId, toChainId, warning, recipient, sender, receiver } =
+    useCrossChainSwap()
 
   const [searchParams] = useSearchParams()
   const [submittingTx, setSubmittingTx] = useState(false)
@@ -323,7 +320,7 @@ export const ConfirmationPopup = ({ isOpen, onDismiss }: { isOpen: boolean; onDi
 
   const dismiss = () => {
     setSubmittingTx(false)
-    onDismiss()
+    onDismiss?.()
     setTxHash('')
     setSubmittingTx(false)
     setTxError('')

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
@@ -21,6 +21,7 @@ import { useCrossChainApproval } from 'pages/CrossChainSwap/hooks/useCrossChainA
 import { useCrossChainSwap } from 'pages/CrossChainSwap/hooks/useCrossChainSwap'
 import { useNearBalances } from 'pages/CrossChainSwap/hooks/useNearBalances'
 import { useSolanaConnectModal } from 'pages/CrossChainSwap/provider/SolanaConnectModalProvider'
+import { isQuoteExecutable } from 'pages/CrossChainSwap/utils'
 import { useWalletModalToggle } from 'state/application/hooks'
 import { useCurrencyBalance } from 'state/wallet/hooks'
 import { getTokenAddress } from 'utils/tokenInfo'
@@ -38,6 +39,8 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
     allLoading,
     selectedQuote,
     recipient,
+    sender,
+    receiver,
   } = useCrossChainSwap()
   const { account, chainId } = useActiveWeb3React()
   const { trackingHandler } = useTracking()
@@ -74,6 +77,7 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
     })
 
   const isFindingRoute = loading || (allLoading && !selectedQuote)
+  const isSelectedQuoteExecutable = isQuoteExecutable(selectedQuote, isFromEvm ? account : sender, receiver)
 
   // Restricted-token check applies only to EVM sides (the restricted list is keyed by EVM chainId).
   const restrictedCurrency =
@@ -100,6 +104,8 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
   }
 
   const checkAllowanceAndOpenPreview = async () => {
+    if (!isSelectedQuoteExecutable) return
+
     const hasSufficientAllowance = await revalidateAllowance()
     if (!hasSufficientAllowance) return
 
@@ -220,6 +226,13 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
     if (!recipient) {
       return {
         label: t`Enter Recipient`,
+        disabled: true,
+      }
+    }
+
+    if (!isSelectedQuoteExecutable) {
+      return {
+        label: <Dots>{t`Refreshing route`}</Dots>,
         disabled: true,
       }
     }

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
@@ -2,6 +2,7 @@ import { ChainId, Currency, CurrencyAmount } from '@kyberswap/ks-sdk-core'
 import { t } from '@lingui/macro'
 import { useWalletSelector } from '@near-wallet-selector/react-hook'
 import { useWallet } from '@solana/wallet-adapter-react'
+import { useState } from 'react'
 
 import { ButtonPrimary } from 'components/Button'
 import Dots from 'components/Dots'
@@ -21,6 +22,7 @@ import { useCrossChainApproval } from 'pages/CrossChainSwap/hooks/useCrossChainA
 import { useCrossChainSwap } from 'pages/CrossChainSwap/hooks/useCrossChainSwap'
 import { useNearBalances } from 'pages/CrossChainSwap/hooks/useNearBalances'
 import { useSolanaConnectModal } from 'pages/CrossChainSwap/provider/SolanaConnectModalProvider'
+import type { Quote } from 'pages/CrossChainSwap/registry'
 import { isQuoteExecutable } from 'pages/CrossChainSwap/utils'
 import { useWalletModalToggle } from 'state/application/hooks'
 import { useCurrencyBalance } from 'state/wallet/hooks'
@@ -44,6 +46,7 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
   } = useCrossChainSwap()
   const { account, chainId } = useActiveWeb3React()
   const { trackingHandler } = useTracking()
+  const [reviewQuote, setReviewQuote] = useState<Quote | null>(null)
 
   const isFromEvm = isEvmChain(fromChainId)
   const isFromNear = fromChainId === NonEvmChain.Near
@@ -91,6 +94,9 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
       : undefined
 
   const openPreview = () => {
+    if (!selectedQuote) return
+
+    setReviewQuote(selectedQuote)
     setShowPreview(true)
     trackingHandler(TRACKING_EVENT_TYPE.CC_REVIEW_OPENED, {
       from_token: currencyIn?.symbol,
@@ -256,9 +262,11 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
     <>
       {termAndPolicyModal}
       <ConfirmationPopup
+        quote={reviewQuote}
         isOpen={showPreview}
         onDismiss={() => {
           setShowPreview(false)
+          setReviewQuote(null)
         }}
       />
       <ButtonPrimary

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TokenLogoWithChain.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TokenLogoWithChain.tsx
@@ -1,5 +1,6 @@
-import { ChainId, Currency as EvmCurrency } from '@kyberswap/ks-sdk-core'
+import { ChainId } from '@kyberswap/ks-sdk-core'
 
+import UnknownToken from 'assets/svg/kyber/unknown-token.svg'
 import { Chain, Currency } from 'pages/CrossChainSwap/adapters'
 import { isEvmChain } from 'pages/CrossChainSwap/adapters/types'
 import { getNetworkInfo } from 'pages/CrossChainSwap/utils'
@@ -11,7 +12,7 @@ export const TokenLogoWithChain = ({
   size = 16,
   chainLogoStyle = {},
 }: {
-  currency?: Currency
+  currency?: Currency & Partial<{ isNative: boolean; logoURI: string; logo: string }>
   chainId: Chain
   size?: number
   chainLogoStyle?: React.CSSProperties
@@ -20,16 +21,14 @@ export const TokenLogoWithChain = ({
     <div className="relative mr-1 flex">
       {isEvmChain(chainId) ? (
         <img
-          src={
-            (currency as EvmCurrency)?.isNative ? getNativeTokenLogo(chainId as ChainId) : (currency as any)?.logoURI
-          }
+          src={(currency?.isNative ? getNativeTokenLogo(chainId as ChainId) : currency?.logoURI) || UnknownToken}
           width={size}
           height={size}
           className="rounded-full"
           alt={currency?.symbol}
         />
       ) : (
-        <img src={(currency as any)?.logo} width={size} height={size} className="rounded-full" alt={currency?.symbol} />
+        <img src={currency?.logo} width={size} height={size} className="rounded-full" alt={currency?.symbol} />
       )}
       <img
         src={getNetworkInfo(chainId).icon}

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TransactionHistory.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/TransactionHistory.tsx
@@ -26,8 +26,7 @@ import {
   isProcessingTransactionStatus,
   useTransactionHistory,
 } from 'pages/CrossChainSwap/hooks/useTransactionHistory'
-import { normalizeAdapterName } from 'pages/CrossChainSwap/registry'
-import { getChainName } from 'pages/CrossChainSwap/utils'
+import { getChainName, normalizeAdapterName } from 'pages/CrossChainSwap/utils'
 import { ExternalLinkIcon, MEDIA_WIDTHS } from 'theme'
 import { shortenHash } from 'utils/address'
 import { cn } from 'utils/cn'

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/constants.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/constants.ts
@@ -1,6 +1,0 @@
-export const CROSS_CHAIN_FEE_RECEIVER = '0x0891617fe27647731d6f1e764092b2f9f06130A0'
-export const CROSS_CHAIN_FEE_RECEIVER_SOLANA = 'D6tN4c5vpMqh4eFdHBUCEo7QLiw6DQy8f4NwqABZuJEf'
-
-// Use a fake address when the user wallet is not connected. Signing with this address will be rejected.
-export const BTC_DEFAULT_RECEIVER = 'bc1qmzgkj3hznt8heh4vp33v2cr2mvsyhc3lmfzz9p'
-export const SOLANA_NATIVE = '11111111111111111111111111111111'

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
@@ -466,6 +466,7 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
   const disable = !fromChainId || !toChainId || !currencyIn || !currencyOut || !inputAmount || inputAmount === '0'
 
   const abortControllerRef = useRef(new AbortController())
+  const requestIdRef = useRef(0)
 
   const evmWalletAddress = walletClient?.data?.account?.address
 
@@ -490,11 +491,12 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
   const getQuote = useCallback(async () => {
     if (showPreview) return
     if (disable) {
+      requestIdRef.current += 1
+      abortControllerRef.current.abort()
       setQuotes([])
       setSelectedAdapter(null)
       setLoading(false)
       setAllLoading(false)
-      abortControllerRef.current.abort()
       return
     }
 
@@ -503,6 +505,7 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
     const requestIsReadOnly = (isFromEvm && !evmWalletAddress) || (isToEvm && !recipient && !evmWalletAddress)
 
     abortControllerRef.current.abort()
+    const requestId = ++requestIdRef.current
     // Create a new controller for this request
     abortControllerRef.current = new AbortController()
 
@@ -728,6 +731,8 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
 
         // Set up soft timeout to enable swap button after SOFT_TIMEOUT_MS if we have at least 1 quote
         softTimeoutTimer = setTimeout(() => {
+          if (signal.aborted) return
+
           if (quotes.length > 0) {
             console.log(
               `[Soft Timeout] ${SOFT_TIMEOUT_MS}ms reached with ${quotes.length} quote(s). Enabling swap button while continuing to collect quotes.`,
@@ -766,6 +771,7 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
 
           const { done, value } = await reader.read()
 
+          if (signal.aborted) throw new Error('Cancelled')
           if (done) break
 
           buffer += decoder.decode(value, { stream: true })
@@ -1018,14 +1024,16 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
         nearTokens,
         publicKey: btcPublicKey || '',
       })
-    } catch (e) {
-      console.error('Error getting quotes:', e)
-      if ((e as Error).message !== 'Cancelled') {
+    } catch (error) {
+      if ((error as Error).message !== 'Cancelled') {
+        console.error('Error getting quotes:', error)
         setQuotes([])
       }
     } finally {
-      setLoading(false)
-      setAllLoading(false)
+      if (requestIdRef.current === requestId) {
+        setLoading(false)
+        setAllLoading(false)
+      }
     }
   }, [
     sender,

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
@@ -28,17 +28,19 @@ import {
 } from 'pages/CrossChainSwap/adapters'
 import { adaptRelaySolanaWallet } from 'pages/CrossChainSwap/adapters/RelayAdapter/relaySolanaWallet'
 import { isEvmChain, isNonEvmChain } from 'pages/CrossChainSwap/adapters/types'
-import {
-  BTC_DEFAULT_RECEIVER,
-  CROSS_CHAIN_FEE_RECEIVER,
-  CROSS_CHAIN_FEE_RECEIVER_SOLANA,
-  SOLANA_NATIVE,
-} from 'pages/CrossChainSwap/constants'
 import { CrossChainSwapFactory } from 'pages/CrossChainSwap/factory'
 import { type NearToken, useNearTokens } from 'pages/CrossChainSwap/hooks/useNearTokens'
 import { type SolanaToken, useSolanaTokens } from 'pages/CrossChainSwap/hooks/useSolanaTokens'
 import { CrossChainSwapAdapterRegistry, Quote } from 'pages/CrossChainSwap/registry'
-import { NEAR_STABLE_COINS, SOLANA_STABLE_COINS, isCanonicalPair } from 'pages/CrossChainSwap/utils'
+import {
+  BTC_DEFAULT_RECEIVER,
+  CROSS_CHAIN_FEE_RECEIVER,
+  CROSS_CHAIN_FEE_RECEIVER_SOLANA,
+  NEAR_STABLE_COINS,
+  SOLANA_NATIVE,
+  SOLANA_STABLE_COINS,
+  isCanonicalPair,
+} from 'pages/CrossChainSwap/utils'
 import { useAppSelector } from 'state/hooks'
 import { useUserSlippageTolerance } from 'state/user/hooks'
 
@@ -465,21 +467,25 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
 
   const abortControllerRef = useRef(new AbortController())
 
-  const sender = isFromSolana
-    ? solanaAddress?.toString() || CROSS_CHAIN_FEE_RECEIVER_SOLANA
-    : isFromBitcoin
-    ? btcAddress || BTC_DEFAULT_RECEIVER
-    : isFromNear
-    ? signedAccountId || ZERO_ADDRESS
-    : walletClient?.data?.account?.address || CROSS_CHAIN_FEE_RECEIVER
+  const evmWalletAddress = walletClient?.data?.account?.address
 
-  const receiver = isToSolana
-    ? recipient || solanaAddress?.toString() || CROSS_CHAIN_FEE_RECEIVER_SOLANA
-    : isToBitcoin
-    ? recipient || BTC_DEFAULT_RECEIVER
-    : isToNear
-    ? recipient || signedAccountId || ZERO_ADDRESS
-    : recipient || walletClient?.data?.account?.address || CROSS_CHAIN_FEE_RECEIVER
+  const resolveAddress = (chain: Chain | undefined, role: 'sender' | 'receiver') => {
+    const recipientAddress = role === 'receiver' ? recipient : undefined
+
+    switch (chain) {
+      case NonEvmChain.Solana:
+        return recipientAddress || solanaAddress?.toString() || CROSS_CHAIN_FEE_RECEIVER_SOLANA
+      case NonEvmChain.Bitcoin:
+        return recipientAddress || (role === 'sender' ? btcAddress : undefined) || BTC_DEFAULT_RECEIVER
+      case NonEvmChain.Near:
+        return recipientAddress || signedAccountId || ZERO_ADDRESS
+      default:
+        return recipientAddress || evmWalletAddress || CROSS_CHAIN_FEE_RECEIVER
+    }
+  }
+
+  const sender = resolveAddress(fromChainId, 'sender')
+  const receiver = resolveAddress(toChainId, 'receiver')
 
   const getQuote = useCallback(async () => {
     if (showPreview) return
@@ -491,6 +497,11 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
       abortControllerRef.current.abort()
       return
     }
+
+    // Keep placeholder quotes visible, but never allow that request snapshot
+    // to become executable after the wallet state resolves.
+    const requestIsReadOnly = (isFromEvm && !evmWalletAddress) || (isToEvm && !recipient && !evmWalletAddress)
+
     abortControllerRef.current.abort()
     // Create a new controller for this request
     abortControllerRef.current = new AbortController()
@@ -619,7 +630,11 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
 
             if (signal.aborted) throw new Error('Cancelled')
 
-            quotes.push({ adapter: kyberswapAdapter, quote })
+            quotes.push({
+              adapter: kyberswapAdapter,
+              quote,
+              isReadOnly: requestIsReadOnly,
+            })
             setQuotes(quotes)
             setLoading(false)
 
@@ -853,7 +868,11 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
                     platformFeePercent: data.platformFeePercent,
                   }
 
-                  quotes.push({ adapter, quote: normalizedQuote })
+                  quotes.push({
+                    adapter,
+                    quote: normalizedQuote,
+                    isReadOnly: requestIsReadOnly,
+                  })
 
                   const sortedQuotes = [...quotes].sort((a, b) => {
                     const netA = getNetOutputAmount(a.quote)
@@ -937,7 +956,11 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
             // Check for cancellation after getting quote
             if (signal.aborted) throw new Error('Cancelled')
 
-            fallbackQuotes.push({ adapter, quote })
+            fallbackQuotes.push({
+              adapter,
+              quote,
+              isReadOnly: requestIsReadOnly,
+            })
             const sortedQuotes = [...fallbackQuotes].sort((a, b) => {
               const netA = getNetOutputAmount(a.quote)
               const netB = getNetOutputAmount(b.quote)
@@ -1007,6 +1030,8 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
   }, [
     sender,
     receiver,
+    recipient,
+    evmWalletAddress,
     isFromEvm,
     isToEvm,
     btcPublicKey,

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useSolanaTokens.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useSolanaTokens.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import SolanaIcon from 'assets/images/SOL.png'
-import { SOLANA_NATIVE } from 'pages/CrossChainSwap/constants'
+import { SOLANA_NATIVE } from 'pages/CrossChainSwap/utils'
 
 const cached: Record<string, SolanaToken> = {}
 const cachedByQuery: Record<string, SolanaToken[]> = {}

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/index.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/index.tsx
@@ -84,7 +84,7 @@ const CrossChainSwapForm = ({ onQuoteChange }: CrossChainSwapProps) => {
 
     const timeout = setTimeout(() => {
       getQuote()
-    }, 3000)
+    }, 300)
 
     return () => clearTimeout(timeout)
   }, [disable, getQuote, showPreview])

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/index.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/index.tsx
@@ -84,7 +84,7 @@ const CrossChainSwapForm = ({ onQuoteChange }: CrossChainSwapProps) => {
 
     const timeout = setTimeout(() => {
       getQuote()
-    }, 300)
+    }, 3000)
 
     return () => clearTimeout(timeout)
   }, [disable, getQuote, showPreview])

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/registry.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/registry.ts
@@ -1,10 +1,10 @@
-import { NormalizedQuote, SwapProvider } from './adapters'
-
-export const normalizeAdapterName = (name: string) => name.toLowerCase().replace(/\s+/g, '')
+import type { NormalizedQuote, SwapProvider } from 'pages/CrossChainSwap/adapters'
+import { normalizeAdapterName } from 'pages/CrossChainSwap/utils'
 
 export interface Quote {
   adapter: SwapProvider
   quote: NormalizedQuote
+  isReadOnly: boolean
 }
 
 export class CrossChainSwapAdapterRegistry {
@@ -26,42 +26,4 @@ export class CrossChainSwapAdapterRegistry {
   getAllAdapters(): SwapProvider[] {
     return Array.from(new Set(this.adapters.values()))
   }
-
-  // get quotes from all adapters and sort them by output amount
-  // async getQuotes(params: QuoteParams | NearQuoteParams): Promise<Quote[]> {
-  //   const quotes: { adapter: SwapProvider; quote: NormalizedQuote }[] = []
-  //
-  //   const adapters =
-  //     params.fromChain === params.toChain && isEvmChain(params.fromChain)
-  //       ? ([this.getAdapter('KyberSwap')] as SwapProvider[])
-  //       : this.getAllAdapters().filter(
-  //           adapter =>
-  //             adapter.getSupportedChains().includes(params.fromChain) &&
-  //             adapter.getSupportedChains().includes(params.toChain),
-  //         )
-  //
-  //   console.log(
-  //     'Available adapters',
-  //     params,
-  //     adapters.map(ad => ad.getName()),
-  //   )
-  //   // Get quotes from all compatible adapters
-  //   const quotePromises = adapters.map(async adapter => {
-  //     try {
-  //       const quote = await adapter.getQuote(params)
-  //       quotes.push({ adapter, quote })
-  //     } catch (err) {
-  //       console.error(`Failed to get quote from ${adapter.getName()}:`, err)
-  //     }
-  //   })
-  //
-  //   await Promise.all(quotePromises)
-  //
-  //   if (quotes.length === 0) {
-  //     throw new Error('No valid quotes found for the requested swap')
-  //   }
-  //
-  //   quotes.sort((a, b) => (a.quote.outputAmount < b.quote.outputAmount ? 1 : -1))
-  //   return quotes
-  // }
 }

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/utils.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/utils.ts
@@ -1,7 +1,23 @@
 import { ChainId, WETH } from '@kyberswap/ks-sdk-core'
 
 import { NETWORKS_INFO } from 'constants/networks'
-import { Chain, Currency, NonEvmChain, NonEvmChainInfo, isEvmChain } from 'pages/CrossChainSwap/adapters/types'
+import {
+  type Chain,
+  type Currency,
+  NonEvmChain,
+  NonEvmChainInfo,
+  isEvmChain,
+} from 'pages/CrossChainSwap/adapters/types'
+import type { Quote } from 'pages/CrossChainSwap/registry'
+
+export const CROSS_CHAIN_FEE_RECEIVER = '0x0891617fe27647731d6f1e764092b2f9f06130A0'
+export const CROSS_CHAIN_FEE_RECEIVER_SOLANA = 'D6tN4c5vpMqh4eFdHBUCEo7QLiw6DQy8f4NwqABZuJEf'
+
+// Use a fake address when the user wallet is not connected. Signing with this address will be rejected.
+export const BTC_DEFAULT_RECEIVER = 'bc1qmzgkj3hznt8heh4vp33v2cr2mvsyhc3lmfzz9p'
+export const SOLANA_NATIVE = '11111111111111111111111111111111'
+
+export const normalizeAdapterName = (name: string) => name.toLowerCase().replace(/\s+/g, '')
 
 export const getNetworkInfo = (chain: Chain) => {
   if (isEvmChain(chain))
@@ -82,3 +98,12 @@ export const getChainName = (chainId: ChainId | NonEvmChain) => {
   if (isEvmChain(chainId)) return NETWORKS_INFO[chainId as ChainId].name
   return NonEvmChainInfo[chainId as NonEvmChain].name
 }
+
+const areAddressesEqual = (first: string | undefined, second: string | undefined, ignoreCase: boolean) =>
+  !!first && !!second && (ignoreCase ? first.toLowerCase() === second.toLowerCase() : first === second)
+
+export const isQuoteExecutable = (quote: Quote | null, sender?: string, receiver?: string) =>
+  !!quote &&
+  !quote.isReadOnly &&
+  areAddressesEqual(quote.quote.quoteParams.sender, sender, isEvmChain(quote.quote.quoteParams.fromChain)) &&
+  areAddressesEqual(quote.quote.quoteParams.recipient, receiver, isEvmChain(quote.quote.quoteParams.toChain))


### PR DESCRIPTION
## Summary

- Mark placeholder-address quotes as read-only and validate sender and receiver before Review and broadcast.
- Refresh quotes quickly after wallet or recipient changes and prevent stale requests from overriding current loading state.
- Snapshot the selected quote for the confirmation flow so live quote updates cannot change the reviewed route.
- Consolidate CrossChainSwap helpers and constants in the shared utility module.