### PR TITLE
fix(ui): refine empty states and earn defaults

### DIFF
--- a/apps/kyberswap-interface/src/components/Announcement/styles.tsx
+++ b/apps/kyberswap-interface/src/components/Announcement/styles.tsx
@@ -32,7 +32,7 @@ export const Badge = ({
 }: React.HTMLAttributes<HTMLDivElement> & { isOverflow: boolean }) => (
   <div
     className={cn(
-      'absolute -top-1.5 z-[1] inline-flex h-5 min-w-[20px] items-center justify-center rounded-2xl bg-primary px-1 text-center font-medium leading-none',
+      'absolute -top-1.5 z-[1] inline-flex h-5 min-w-5 items-center justify-center rounded-2xl bg-primary px-1 text-center text-sm font-semibold',
       isOverflow ? '-right-4' : '-right-2.5',
       className,
     )}

--- a/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/index.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/OrderBook/index.tsx
@@ -45,8 +45,22 @@ const SectionLabel = ({ color, label, symbol }: { color: string; label: React.Re
   </>
 )
 
-const OrderSide = ({ children, reverse }: { children: React.ReactNode; reverse?: boolean }) => {
-  return <div className={cn('max-h-[336px] overflow-y-auto', reverse && 'flex flex-col-reverse')}>{children}</div>
+const OrderSide = ({
+  children,
+  hasOrders,
+  reverse,
+}: {
+  children: React.ReactNode
+  hasOrders: boolean
+  reverse?: boolean
+}) => {
+  return (
+    <div
+      className={cn('max-h-[336px] overflow-y-auto', !hasOrders && 'min-h-[120px]', reverse && 'flex flex-col-reverse')}
+    >
+      {children}
+    </div>
+  )
 }
 
 const OrderBook = () => {
@@ -185,7 +199,7 @@ const OrderBook = () => {
       </div>
       <SectionLabel color="var(--ks-red)" label={<Trans>SELLING</Trans>} symbol={makerCurrency?.wrapped.symbol} />
 
-      <OrderSide reverse>
+      <OrderSide reverse hasOrders={visibleSellOrders.length > 0}>
         {visibleSellOrders.length > 0
           ? visibleSellOrders.map(order => (
               <OrderRow key={order.id} order={order} showInvertedRate={showInvertedRate} onTake={handleTakeOrder} />
@@ -221,7 +235,7 @@ const OrderBook = () => {
 
       <SectionLabel color="var(--ks-primary)" label={<Trans>BUYING</Trans>} symbol={makerCurrency?.wrapped.symbol} />
 
-      <OrderSide>
+      <OrderSide hasOrders={visibleBuyOrders.length > 0}>
         {visibleBuyOrders.length > 0
           ? visibleBuyOrders.map(order => (
               <OrderRow

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/LiquidityFlowsChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/LiquidityFlowsChart.tsx
@@ -92,7 +92,7 @@ const LiquidityFlowsTooltip = ({
 const LiquidityFlowsChart = ({ chainId, poolAddress }: LiquidityFlowsChartProps) => {
   const theme = useTheme()
 
-  const [window, setWindow] = useState<PoolAnalyticsWindow>('24h')
+  const [window, setWindow] = useState<PoolAnalyticsWindow>('7d')
 
   const upToSmall = useMedia(`(max-width: ${MEDIA_WIDTHS.upToSmall}px)`)
   const chartHeight = upToSmall ? 280 : 360

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/useFilter.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/useFilter.ts
@@ -1,4 +1,3 @@
-import { ChainId } from '@kyber/schema'
 import { useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import type { PoolQueryParams } from 'services/earn/types'
@@ -6,17 +5,15 @@ import type { PoolQueryParams } from 'services/earn/types'
 import { useActiveWeb3React } from 'hooks'
 import { SortBy } from 'pages/Earns/PoolExplorer'
 import { FilterTag, timings } from 'pages/Earns/PoolExplorer/Filter'
-import { EARN_CHAINS, EarnChain } from 'pages/Earns/constants'
 import { Direction } from 'pages/MarketOverview/SortIcon'
 
 export default function useFilter(setSearch?: (search: string) => void) {
   const [searchParams, setSearchParams] = useSearchParams()
-  const { account, chainId } = useActiveWeb3React()
+  const { account } = useActiveWeb3React()
 
   const filters: PoolQueryParams = useMemo(() => {
-    const fallbackChainId = EARN_CHAINS[chainId as unknown as EarnChain] ? chainId : ChainId.Ethereum
     return {
-      chainIds: searchParams.get('chainIds') ?? String(fallbackChainId),
+      chainIds: searchParams.get('chainIds') ?? '',
       page: +(searchParams.get('page') || 1),
       limit: 10,
       interval: searchParams.get('interval') || (timings[0].value as string),
@@ -28,7 +25,7 @@ export default function useFilter(setSearch?: (search: string) => void) {
       orderBy: searchParams.get('orderBy') || '',
       q: searchParams.get('q')?.trim() || '',
     }
-  }, [searchParams, account, chainId])
+  }, [searchParams, account])
 
   const updateFilters = useCallback(
     (key: keyof PoolQueryParams, value: string) => {


### PR DESCRIPTION
## Summary
- Refine the announcement badge and preserve order-book space when a side has no visible orders
- Default liquidity flows to the 7-day view and load Pool Explorer without a fallback chain filter