### PR TITLE
fix(earn): stop clipping the claim threshold control

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/components/RewardsFilterSetting.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/RewardsFilterSetting.tsx
@@ -28,7 +28,6 @@ export const RewardsFilterSetting = ({
 
   const thresholdDisplayValue = formatThresholdValue(thresholdValue)
   const isExpanded = statusExpanded || thresholdExpanded
-  const expandedHeight = statusExpanded ? 48 : thresholdExpanded ? 90 : 0
 
   return (
     <div className="flex flex-col">
@@ -82,23 +81,26 @@ export const RewardsFilterSetting = ({
 
       <div
         className={cn(
-          'flex flex-col gap-3 overflow-hidden transition-[height,padding] duration-200 ease-in-out',
-          isExpanded ? 'pt-3 max-sm:min-h-fit' : 'pt-0',
+          'grid transition-[grid-template-rows,padding] duration-200 ease-in-out',
+          isExpanded ? 'grid-rows-[1fr] pt-3' : 'grid-rows-[0fr] pt-0',
         )}
-        style={{ height: isExpanded ? `${expandedHeight}px` : '0' }}
       >
-        {statusExpanded && <PositionStatusControl value={positionStatus} onChange={onPositionStatusChange} />}
-        {thresholdExpanded && (
-          <>
-            <span className="text-xs text-subText">
-              <Trans>
-                Only position with rewards above this estimated value will be included in the claim. Others will remain
-                unclaimed.
-              </Trans>
-            </span>
-            <ClaimThresholdControl value={thresholdValue} onChange={onThresholdChange} />
-          </>
-        )}
+        <div className="min-h-0 overflow-hidden">
+          <div className="flex flex-col gap-3 pb-px">
+            {statusExpanded && <PositionStatusControl value={positionStatus} onChange={onPositionStatusChange} />}
+            {thresholdExpanded && (
+              <>
+                <span className="text-xs text-subText">
+                  <Trans>
+                    Only position with rewards above this estimated value will be included in the claim. Others will
+                    remain unclaimed.
+                  </Trans>
+                </span>
+                <ClaimThresholdControl value={thresholdValue} onChange={onThresholdChange} />
+              </>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
The rewards filter panel animated open to a hardcoded pixel height (90px for the threshold section). With border-box sizing the 12px top padding came out of that budget, leaving a 78px content box for 80px of content, so flexbox squeezed the control to 34px and parked its bottom border exactly on the overflow-hidden edge. Any sub-pixel rounding — browser zoom off 100%, a description that wraps to a third line — pushed the border out of view.

Animate a 0fr/1fr grid row instead so the panel measures its own content, and pad one pixel below the control so rounding eats padding rather than the border.