### PR TITLE
feat(earn): require NFT permit/approve for univ3 on pancake zap widget

### DIFF
--- a/packages/pancake-liquidity-widgets/package.json
+++ b/packages/pancake-liquidity-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyberswap/pancake-liquidity-widgets",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
@@ -106,7 +106,7 @@ export default function Content({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)) as string;
     },
-    [walletClient]
+    [walletClient],
   );
 
   const {
@@ -116,7 +116,7 @@ export default function Content({
   } = usePermitNft({
     nftManagerContract,
     tokenId: positionId,
-    spender: zapInfo?.routerPermitAddress,
+    spender: zapInfo?.routerAddress,
     account,
     chainId,
     signTypedData,
@@ -124,7 +124,7 @@ export default function Content({
 
   const isPancakeInfinityCL = isForkFrom(
     poolType,
-    CoreProtocol.PancakeInfinityCL
+    CoreProtocol.PancakeInfinityCL,
   );
   // ZapRouter v2 keeps the legacy flow (only Pancake Infinity CL positions need
   // NFT authorization); v3 requires it for every concentrated-liquidity position.
@@ -132,7 +132,7 @@ export default function Content({
     zapInfo?.routerAddress?.toLowerCase() ===
     "0x0e97c887b61ccd952a53578b04763e7134429e05";
   const requiresNftAuth = Boolean(
-    positionId && (!isZapV2 || isPancakeInfinityCL)
+    positionId && (!isZapV2 || isPancakeInfinityCL),
   );
 
   const canPermit =
@@ -148,43 +148,43 @@ export default function Content({
         : amountsIn
             .split(",")
             .map((amount, index) =>
-              parseUnits(amount || "0", tokensIn[index]?.decimals).toString()
+              parseUnits(amount || "0", tokensIn[index]?.decimals).toString(),
             ),
-    [tokensIn, amountsIn]
+    [tokensIn, amountsIn],
   );
 
   const { loading, approvalStates, addressToApprove, approve } = useApprovals(
     amountsInWei,
     tokensIn.map((token) => token?.address || ""),
-    zapInfo?.routerAddress || ""
+    zapInfo?.routerAddress || "",
   );
 
   const notApprove = useMemo(
     () =>
       tokensIn.find(
         (item) =>
-          approvalStates[item?.address || ""] === APPROVAL_STATE.NOT_APPROVED
+          approvalStates[item?.address || ""] === APPROVAL_STATE.NOT_APPROVED,
       ),
-    [approvalStates, tokensIn]
+    [approvalStates, tokensIn],
   );
 
   const pi = useMemo(() => {
     const aggregatorSwapInfo = zapInfo?.zapDetails.actions.find(
-      (item) => item.type === ZapAction.AGGREGATOR_SWAP
+      (item) => item.type === ZapAction.AGGREGATOR_SWAP,
     ) as AggregatorSwapAction | undefined;
 
     const poolSwapInfo = zapInfo?.zapDetails.actions.find(
-      (item) => item.type === ZapAction.POOL_SWAP
+      (item) => item.type === ZapAction.POOL_SWAP,
     ) as PoolSwapAction | null;
 
     const feeInfo = zapInfo?.zapDetails.actions.find(
-      (item) => item.type === ZapAction.PROTOCOL_FEE
+      (item) => item.type === ZapAction.PROTOCOL_FEE,
     ) as ProtocolFeeAction | undefined;
 
     const piRes = getPriceImpact(
       zapInfo?.zapDetails.priceImpact,
       ImpactType.ZAP,
-      feeInfo
+      feeInfo,
     );
 
     const aggregatorSwapPi =
@@ -231,7 +231,7 @@ export default function Content({
       !addressToApprove &&
       !error &&
       !zapLoading &&
-      !loading
+      !loading,
   );
 
   const onPermitNft = () => {
@@ -239,7 +239,7 @@ export default function Content({
     const date = new Date();
     date.setMinutes(date.getMinutes() + (ttl || 20));
     signPermitNft(Math.floor(date.getTime() / 1000)).finally(() =>
-      setClickedLoading(false)
+      setClickedLoading(false),
     );
   };
 
@@ -283,7 +283,7 @@ export default function Content({
       zapLoading ||
       !!error ||
       Object.values(approvalStates).some(
-        (item) => item === APPROVAL_STATE.PENDING
+        (item) => item === APPROVAL_STATE.PENDING,
       ) ||
       (pi.piVeryHigh && !degenMode),
     [
@@ -298,7 +298,7 @@ export default function Content({
       pi.piVeryHigh,
       requiresNftAuth,
       zapLoading,
-    ]
+    ],
   );
 
   const hanldeClick = () => {
@@ -311,7 +311,7 @@ export default function Content({
         const date = new Date();
         date.setMinutes(date.getMinutes() + (ttl || 20));
         signPermitNft(Math.floor(date.getTime() / 1000)).finally(() =>
-          setClickedLoading(false)
+          setClickedLoading(false),
         );
       } else {
         approveNft().finally(() => setClickedLoading(false));
@@ -358,7 +358,7 @@ export default function Content({
         BigInt(pool.sqrtRatioX96 || 0),
         pool.token0.decimals,
         pool.token1.decimals,
-        revertPrice
+        revertPrice,
       )
     : undefined;
 
@@ -383,7 +383,7 @@ export default function Content({
         setTick,
       });
     },
-    [currentPoolPrice, pool, revertPrice, setTick]
+    [currentPoolPrice, pool, revertPrice, setTick],
   );
 
   useEffect(() => {
@@ -501,11 +501,11 @@ export default function Content({
                     if (!pool) return;
                     setTick(
                       Type.PriceLower,
-                      revertPrice ? pool.maxTick : pool.minTick
+                      revertPrice ? pool.maxTick : pool.minTick,
                     );
                     setTick(
                       Type.PriceUpper,
-                      revertPrice ? pool.minTick : pool.maxTick
+                      revertPrice ? pool.minTick : pool.maxTick,
                     );
                   }}
                 >
@@ -529,7 +529,9 @@ export default function Content({
             disabled={clickedApprove || permitState === PermitNftState.SIGNING}
             onClick={onPermitNft}
           >
-            {permitState === PermitNftState.SIGNING ? "Signing..." : "Permit NFT"}
+            {permitState === PermitNftState.SIGNING
+              ? "Signing..."
+              : "Permit NFT"}
           </button>
         ) : (
           <button className="pcs-outline-btn flex-1" onClick={onDismiss}>
@@ -559,7 +561,7 @@ export default function Content({
             style={
               !disabled &&
               Object.values(approvalStates).some(
-                (item) => item !== APPROVAL_STATE.NOT_APPROVED
+                (item) => item !== APPROVAL_STATE.NOT_APPROVED,
               )
                 ? {
                     background:

--- a/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
@@ -18,6 +18,7 @@ import {
   PI_LEVEL,
   correctPrice,
   getPriceImpact,
+  isForkFrom,
 } from "@/utils";
 import {
   ZapAction,
@@ -31,6 +32,7 @@ import ErrorIcon from "@/assets/error.svg";
 import {
   MAX_ZAP_IN_TOKENS,
   POSITION_MANAGER_CONTRACT,
+  CoreProtocol,
 } from "@/constants";
 import { sqrtToPrice } from "@kyber/utils/uniswapv3";
 import { usePermitNft, PermitNftState } from "@kyber/hooks";
@@ -120,9 +122,23 @@ export default function Content({
     signTypedData,
   });
 
+  const isPancakeInfinityCL = isForkFrom(
+    poolType,
+    CoreProtocol.PancakeInfinityCL
+  );
+  // ZapRouter v2 keeps the legacy flow (only Pancake Infinity CL positions need
+  // NFT authorization); v3 requires it for every concentrated-liquidity position.
+  const isZapV2 =
+    zapInfo?.routerAddress?.toLowerCase() ===
+    "0x0e97c887b61ccd952a53578b04763e7134429e05";
+  const requiresNftAuth = Boolean(
+    positionId && (!isZapV2 || isPancakeInfinityCL)
+  );
+
   const canPermit =
-    permitState === PermitNftState.READY_TO_SIGN ||
-    permitState === PermitNftState.SIGNING;
+    !isZapV2 &&
+    (permitState === PermitNftState.READY_TO_SIGN ||
+      permitState === PermitNftState.SIGNING);
   const nftAuthorized = nftApproved || permitState === PermitNftState.SIGNED;
 
   const amountsInWei: string[] = useMemo(
@@ -209,7 +225,7 @@ export default function Content({
   }, [zapInfo]);
 
   const isInNftApprovalStep = Boolean(
-    positionId &&
+    requiresNftAuth &&
       !nftAuthorized &&
       !notApprove &&
       !addressToApprove &&
@@ -238,7 +254,7 @@ export default function Content({
     if (loading) return "Checking Allowance";
     if (addressToApprove || pendingTxNft) return "Approving";
     if (notApprove) return `Approve ${notApprove.symbol}`;
-    if (positionId && !nftAuthorized)
+    if (requiresNftAuth && !nftAuthorized)
       return canPermit ? "Permit NFT" : "Approve NFT";
     if (pi.piVeryHigh) return "Zap anyway";
 
@@ -252,14 +268,14 @@ export default function Content({
     notApprove,
     pendingTxNft,
     pi.piVeryHigh,
-    positionId,
+    requiresNftAuth,
     zapLoading,
   ]);
 
   const disabled = useMemo(
     () =>
       clickedApprove ||
-      (positionId &&
+      (requiresNftAuth &&
         (pendingTxNft ||
           isChecking ||
           permitState === PermitNftState.SIGNING)) ||
@@ -280,7 +296,7 @@ export default function Content({
       pendingTxNft,
       permitState,
       pi.piVeryHigh,
-      positionId,
+      requiresNftAuth,
       zapLoading,
     ]
   );
@@ -289,7 +305,7 @@ export default function Content({
     if (notApprove) {
       setClickedLoading(true);
       approve(notApprove.address).finally(() => setClickedLoading(false));
-    } else if (positionId && !nftAuthorized) {
+    } else if (requiresNftAuth && !nftAuthorized) {
       setClickedLoading(true);
       if (canPermit) {
         const date = new Date();

--- a/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
@@ -18,7 +18,6 @@ import {
   PI_LEVEL,
   correctPrice,
   getPriceImpact,
-  isForkFrom,
 } from "@/utils";
 import {
   ZapAction,
@@ -32,9 +31,9 @@ import ErrorIcon from "@/assets/error.svg";
 import {
   MAX_ZAP_IN_TOKENS,
   POSITION_MANAGER_CONTRACT,
-  CoreProtocol,
 } from "@/constants";
 import { sqrtToPrice } from "@kyber/utils/uniswapv3";
+import { usePermitNft, PermitNftState } from "@kyber/hooks";
 import { useNftApproval } from "@/hooks/useNftApproval";
 
 export default function Content({
@@ -72,7 +71,7 @@ export default function Content({
     onOpenTokenSelectModal,
     poolType,
   } = useWidgetInfo();
-  const { account, chainId } = useWeb3Provider();
+  const { account, chainId, walletClient } = useWeb3Provider();
 
   const [clickedApprove, setClickedLoading] = useState(false);
   const [snapshotState, setSnapshotState] = useState<ZapState | null>(null);
@@ -94,10 +93,37 @@ export default function Content({
     spender: zapInfo?.routerAddress,
   });
 
-  const isPancakeInfinityCL = isForkFrom(
-    poolType,
-    CoreProtocol.PancakeInfinityCL
+  const signTypedData = useCallback(
+    async (signer: string, typedData: string): Promise<string> => {
+      if (!walletClient) throw new Error("Wallet not connected");
+      // usePermitNft builds the EIP-712 payload as a raw JSON string; viem's
+      // typed request schema doesn't cover eth_signTypedData_v4 with that shape.
+      return (await walletClient.request({
+        method: "eth_signTypedData_v4",
+        params: [signer as `0x${string}`, typedData],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)) as string;
+    },
+    [walletClient]
   );
+
+  const {
+    permitState,
+    signPermitNft,
+    permitData: permitResult,
+  } = usePermitNft({
+    nftManagerContract,
+    tokenId: positionId,
+    spender: zapInfo?.routerPermitAddress,
+    account,
+    chainId,
+    signTypedData,
+  });
+
+  const canPermit =
+    permitState === PermitNftState.READY_TO_SIGN ||
+    permitState === PermitNftState.SIGNING;
+  const nftAuthorized = nftApproved || permitState === PermitNftState.SIGNED;
 
   const amountsInWei: string[] = useMemo(
     () =>
@@ -182,22 +208,47 @@ export default function Content({
     return { piVeryHigh, piHigh };
   }, [zapInfo]);
 
+  const isInNftApprovalStep = Boolean(
+    positionId &&
+      !nftAuthorized &&
+      !notApprove &&
+      !addressToApprove &&
+      !error &&
+      !zapLoading &&
+      !loading
+  );
+
+  const onPermitNft = () => {
+    setClickedLoading(true);
+    const date = new Date();
+    date.setMinutes(date.getMinutes() + (ttl || 20));
+    signPermitNft(Math.floor(date.getTime() / 1000)).finally(() =>
+      setClickedLoading(false)
+    );
+  };
+
+  const onApproveNft = () => {
+    setClickedLoading(true);
+    approveNft().finally(() => setClickedLoading(false));
+  };
+
   const btnText = useMemo(() => {
     if (error) return error;
     if (zapLoading) return "Loading...";
     if (loading) return "Checking Allowance";
     if (addressToApprove || pendingTxNft) return "Approving";
     if (notApprove) return `Approve ${notApprove.symbol}`;
-    if (isPancakeInfinityCL && positionId && !nftApproved) return "Approve NFT";
+    if (positionId && !nftAuthorized)
+      return canPermit ? "Permit NFT" : "Approve NFT";
     if (pi.piVeryHigh) return "Zap anyway";
 
     return "Preview";
   }, [
     addressToApprove,
     error,
-    isPancakeInfinityCL,
     loading,
-    nftApproved,
+    nftAuthorized,
+    canPermit,
     notApprove,
     pendingTxNft,
     pi.piVeryHigh,
@@ -208,7 +259,10 @@ export default function Content({
   const disabled = useMemo(
     () =>
       clickedApprove ||
-      (isPancakeInfinityCL && positionId && (pendingTxNft || isChecking)) ||
+      (positionId &&
+        (pendingTxNft ||
+          isChecking ||
+          permitState === PermitNftState.SIGNING)) ||
       loading ||
       zapLoading ||
       !!error ||
@@ -222,9 +276,9 @@ export default function Content({
       degenMode,
       error,
       isChecking,
-      isPancakeInfinityCL,
       loading,
       pendingTxNft,
+      permitState,
       pi.piVeryHigh,
       positionId,
       zapLoading,
@@ -235,9 +289,17 @@ export default function Content({
     if (notApprove) {
       setClickedLoading(true);
       approve(notApprove.address).finally(() => setClickedLoading(false));
-    } else if (isPancakeInfinityCL && positionId && !nftApproved) {
+    } else if (positionId && !nftAuthorized) {
       setClickedLoading(true);
-      approveNft().finally(() => setClickedLoading(false));
+      if (canPermit) {
+        const date = new Date();
+        date.setMinutes(date.getMinutes() + (ttl || 20));
+        signPermitNft(Math.floor(date.getTime() / 1000)).finally(() =>
+          setClickedLoading(false)
+        );
+      } else {
+        approveNft().finally(() => setClickedLoading(false));
+      }
     } else if (
       pool &&
       amountsIn &&
@@ -263,6 +325,7 @@ export default function Content({
         slippage,
         tickUpper,
         tickLower,
+        permitData: permitResult?.permitData,
       });
       onTogglePreview?.(true);
     }
@@ -444,13 +507,33 @@ export default function Content({
       </div>
 
       <div className="flex gap-6 p-6">
-        <button className="pcs-outline-btn flex-1" onClick={onDismiss}>
-          Cancel
-        </button>
+        {isInNftApprovalStep && canPermit ? (
+          <button
+            className="pcs-primary-btn flex-1"
+            disabled={clickedApprove || permitState === PermitNftState.SIGNING}
+            onClick={onPermitNft}
+          >
+            {permitState === PermitNftState.SIGNING ? "Signing..." : "Permit NFT"}
+          </button>
+        ) : (
+          <button className="pcs-outline-btn flex-1" onClick={onDismiss}>
+            Cancel
+          </button>
+        )}
 
         {!account ? (
           <button className="pcs-primary-btn flex-1" onClick={onConnectWallet}>
             Connect Wallet
+          </button>
+        ) : isInNftApprovalStep ? (
+          <button
+            className={
+              canPermit ? "pcs-outline-btn flex-1" : "pcs-primary-btn flex-1"
+            }
+            disabled={clickedApprove || !!pendingTxNft || isChecking}
+            onClick={onApproveNft}
+          >
+            {pendingTxNft ? "Approving..." : "Approve NFT"}
           </button>
         ) : (
           <button

--- a/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Content/index.tsx
@@ -137,8 +137,7 @@ export default function Content({
 
   const canPermit =
     !isZapV2 &&
-    (permitState === PermitNftState.READY_TO_SIGN ||
-      permitState === PermitNftState.SIGNING);
+    (permitState != PermitNftState.SIGNED);
   const nftAuthorized = nftApproved || permitState === PermitNftState.SIGNED;
 
   const amountsInWei: string[] = useMemo(
@@ -146,10 +145,10 @@ export default function Content({
       !amountsIn
         ? []
         : amountsIn
-            .split(",")
-            .map((amount, index) =>
-              parseUnits(amount || "0", tokensIn[index]?.decimals).toString(),
-            ),
+          .split(",")
+          .map((amount, index) =>
+            parseUnits(amount || "0", tokensIn[index]?.decimals).toString(),
+          ),
     [tokensIn, amountsIn],
   );
 
@@ -226,12 +225,12 @@ export default function Content({
 
   const isInNftApprovalStep = Boolean(
     requiresNftAuth &&
-      !nftAuthorized &&
-      !notApprove &&
-      !addressToApprove &&
-      !error &&
-      !zapLoading &&
-      !loading,
+    !nftAuthorized &&
+    !notApprove &&
+    !addressToApprove &&
+    !error &&
+    !zapLoading &&
+    !loading,
   );
 
   const onPermitNft = () => {
@@ -355,11 +354,11 @@ export default function Content({
 
   const currentPoolPrice = pool
     ? sqrtToPrice(
-        BigInt(pool.sqrtRatioX96 || 0),
-        pool.token0.decimals,
-        pool.token1.decimals,
-        revertPrice,
-      )
+      BigInt(pool.sqrtRatioX96 || 0),
+      pool.token0.decimals,
+      pool.token1.decimals,
+      revertPrice,
+    )
     : undefined;
 
   const selectPriceRange = useCallback(
@@ -443,9 +442,8 @@ export default function Content({
           ))}
 
           <div
-            className={`mt-4 text-primary cursor-pointer w-fit text-sm ${
-              tokensIn.length >= MAX_ZAP_IN_TOKENS ? "opacity-50" : ""
-            }`}
+            className={`mt-4 text-primary cursor-pointer w-fit text-sm ${tokensIn.length >= MAX_ZAP_IN_TOKENS ? "opacity-50" : ""
+              }`}
             onClick={() =>
               tokensIn.length < MAX_ZAP_IN_TOKENS && onOpenTokenSelectModal()
             }
@@ -560,24 +558,24 @@ export default function Content({
             onClick={hanldeClick}
             style={
               !disabled &&
-              Object.values(approvalStates).some(
-                (item) => item !== APPROVAL_STATE.NOT_APPROVED,
-              )
+                Object.values(approvalStates).some(
+                  (item) => item !== APPROVAL_STATE.NOT_APPROVED,
+                )
                 ? {
-                    background:
-                      pi.piVeryHigh && degenMode
-                        ? theme.error
-                        : pi.piHigh
-                          ? theme.warning
-                          : undefined,
-                    border:
-                      pi.piVeryHigh && degenMode
-                        ? `1px solid ${theme.error}`
-                        : pi.piHigh
-                          ? theme.warning
-                          : undefined,
-                    color: pi.piVeryHigh && degenMode ? "fff" : undefined,
-                  }
+                  background:
+                    pi.piVeryHigh && degenMode
+                      ? theme.error
+                      : pi.piHigh
+                        ? theme.warning
+                        : undefined,
+                  border:
+                    pi.piVeryHigh && degenMode
+                      ? `1px solid ${theme.error}`
+                      : pi.piHigh
+                        ? theme.warning
+                        : undefined,
+                  color: pi.piVeryHigh && degenMode ? "fff" : undefined,
+                }
                 : {}
             }
           >

--- a/packages/pancake-liquidity-widgets/src/components/Preview/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Preview/index.tsx
@@ -60,6 +60,7 @@ export interface ZapState {
   slippage: number;
   tickLower: number;
   tickUpper: number;
+  permitData?: string;
 }
 
 export interface PreviewProps {
@@ -79,6 +80,7 @@ export default function Preview({
     slippage,
     tickLower,
     tickUpper,
+    permitData,
   },
   onDismiss,
   onTxSubmit,
@@ -238,6 +240,9 @@ export default function Preview({
         route: zapInfo.route,
         deadline,
         source,
+        ...(positionId && permitData
+          ? { permits: { [positionId]: permitData } }
+          : {}),
       }),
     })
       .then((res) => res.json())
@@ -273,7 +278,16 @@ export default function Preview({
           }
         }
       });
-  }, [account, chainId, deadline, publicClient, source, zapInfo.route]);
+  }, [
+    account,
+    chainId,
+    deadline,
+    publicClient,
+    source,
+    zapInfo.route,
+    permitData,
+    positionId,
+  ]);
 
   const handleClick = async () => {
     if (!publicClient || !account || !walletClient) {
@@ -292,6 +306,9 @@ export default function Preview({
         route: zapInfo.route,
         deadline,
         source,
+        ...(positionId && permitData
+          ? { permits: { [positionId]: permitData } }
+          : {}),
       }),
     })
       .then((res) => res.json())

--- a/packages/pancake-liquidity-widgets/src/types/zapInTypes.ts
+++ b/packages/pancake-liquidity-widgets/src/types/zapInTypes.ts
@@ -130,6 +130,7 @@ export interface ZapRouteDetail {
   };
   route: string;
   routerAddress: string;
+  routerPermitAddress?: string;
   gas: string;
   gasUsd: string;
 }

--- a/packages/pancake-liquidity-widgets/src/types/zapInTypes.ts
+++ b/packages/pancake-liquidity-widgets/src/types/zapInTypes.ts
@@ -130,7 +130,6 @@ export interface ZapRouteDetail {
   };
   route: string;
   routerAddress: string;
-  routerPermitAddress?: string;
   gas: string;
   gasUsd: string;
 }


### PR DESCRIPTION
Extend the NFT authorization step to univ3 (PancakeSwapV3) increase liquidity and add an off-chain permit path (usePermitNft) next to the on-chain approve, matching the main liquidity widget. Gating keys off positionId instead of the pancake-infinity-only check; the approval step shows Permit NFT + Approve NFT side by side. Permit stays dormant until the backend returns routerPermitAddress for pancake pools.