### PR TITLE
fix(token-prices): resolve wrapped native token from SDK

### DIFF
--- a/apps/kyberswap-interface/src/state/tokenPrices/hooks.ts
+++ b/apps/kyberswap-interface/src/state/tokenPrices/hooks.ts
@@ -1,5 +1,5 @@
-import { NATIVE_TOKEN_ADDRESS, NETWORKS_INFO as SCHEMA_NETWORKS_INFO, ChainId as SchemaChainId } from '@kyber/schema'
-import { ChainId } from '@kyberswap/ks-sdk-core'
+import { NATIVE_TOKEN_ADDRESS } from '@kyber/schema'
+import { ChainId, Token, WETH } from '@kyberswap/ks-sdk-core'
 import { useQueryClient } from '@tanstack/react-query'
 import debounce from 'lodash.debounce'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -48,10 +48,7 @@ export const useTokenPricesWithLoading = (
     .map(x => x.toLowerCase())
     .join(',')
 
-  const wrappedNativeAddress = useMemo(
-    () => SCHEMA_NETWORKS_INFO[chainId as unknown as SchemaChainId]?.wrappedToken.address?.toLowerCase(),
-    [chainId],
-  )
+  const wrappedNativeAddress = useMemo(() => (WETH[chainId] as Token | undefined)?.address?.toLowerCase(), [chainId])
 
   const tokenList = useMemo(() => {
     const list = addressKeys.split(',').filter(Boolean)


### PR DESCRIPTION
## Summary
- Resolve wrapped native token addresses through the SDK `WETH` map.
- Restore native-token USD balance prices on app-supported chains missing from `@kyber/schema`, including Robinhood.

## Root cause
The token price API prices the wrapped-native address, while the token selector represents native ETH with the `0xEeee...` placeholder. `useTokenPrices` aliases that placeholder to the wrapped-native token, but it previously looked up the address in `@kyber/schema` by casting the SDK `ChainId` to `SchemaChainId`.

`@kyber/schema` only covers a subset of the chains supported by the Interface and does not include Robinhood (4663). The lookup therefore returned no wrapped-native address, the API was queried only with the native placeholder, and the USD balance price resolved to zero.

## Why use SDK WETH
- `useTokenPrices` receives `ChainId` from `@kyberswap/ks-sdk-core`, so `WETH` uses the same chain domain.
- The SDK `WETH` map covers every chain currently supported by the Interface (24/24), including Robinhood.
- `WETH` is the purpose-specific source of truth for wrapped-native addresses and removes the unsafe cross-package chain cast.

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/state/tokenPrices/hooks.ts`
- `git diff --check`
