### PR TITLE
fix(earn): hide zero Active APR on pool detail

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
@@ -137,13 +137,12 @@ const AprHistoryChart = ({ chainId, poolAddress, positionId, programs, currentAp
   const latestAprPoint = chartData[chartData.length - 1]
   const activeApr = currentApr?.activeApr ?? latestAprPoint?.activeApr
   const totalApr = currentApr?.totalApr ?? latestAprPoint?.totalApr
-  const hasActiveApr = activeApr !== undefined
-  const showActiveApr = !isPositionChart && hasActiveApr
+  const showActiveApr = !isPositionChart && !!activeApr
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="flex min-h-12 flex-col gap-1">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex min-h-12 flex-col justify-center gap-1">
           {showActiveApr && totalApr !== undefined && (
             <div className="flex items-baseline gap-1">
               <span className="text-sm text-subText">APR</span>

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningApr.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningApr.tsx
@@ -28,7 +28,7 @@ const PoolEarningApr = () => {
     }
   }, [pool])
 
-  const hasActiveApr = aprSummary?.activeApr !== undefined
+  const hasActiveApr = !!aprSummary.activeApr
 
   return (
     <HStack className="flex-wrap items-stretch gap-3">

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolHeader.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolHeader.tsx
@@ -43,7 +43,7 @@ const PoolHeaderPage = () => {
 
   const isFarming = Boolean(pool.programs?.includes('eg') || pool.programs?.includes('lm'))
   const poolStats = pool.poolStats
-  const hasActiveApr = poolStats?.activeApr !== undefined
+  const hasActiveApr = !!poolStats?.activeApr
   const bonusApr = poolStats?.bonusApr || 0
   const activeTotal = hasActiveApr ? (poolStats?.activeApr || 0) + bonusApr : undefined
 


### PR DESCRIPTION
Treat a zero active APR the same as a missing one so the pool detail page stops rendering an "Active APR 0%" row, and vertically center the APR header block that the removed row leaves half empty.