### PR TITLE
feat(earn): flag the EG share left out of every aggregate

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/Landing/PoolItem.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/Landing/PoolItem.tsx
@@ -7,6 +7,7 @@ import TokenLogo from 'components/TokenLogo'
 import { NETWORKS_INFO } from 'hooks/useChainsConfig'
 import { PoolRow, Tag } from 'pages/Earns/Landing/styles'
 import AprDetailTooltip from 'pages/Earns/components/AprDetailTooltip'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import useSmartExitWidget from 'pages/Earns/hooks/useSmartExitWidget'
 import useZapInWidget from 'pages/Earns/hooks/useZapInWidget'
 import useZapMigrationWidget from 'pages/Earns/hooks/useZapMigrationWidget'
@@ -65,8 +66,9 @@ const PoolItem = ({ pool, rowIndex = 0 }: { pool: EarnPool; rowIndex?: number })
       </div>
 
       <div className="flex items-center gap-1">
-        <span className="text-primary">
+        <span className="whitespace-nowrap text-primary">
           {formatAprNumber(egCalculating ? excludeEg(pool.allApr, pool.kemEGApr) : pool.allApr)}%
+          {egCalculating && <EgCalculatingMarker compact />}
         </span>
         {isFarming ? (
           <AprDetailTooltip

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/EstimatedPositionApr.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/EstimatedPositionApr.tsx
@@ -9,6 +9,7 @@ import { HStack, Stack } from 'components/Stack'
 import { MouseoverTooltip } from 'components/Tooltip'
 import useDebounce from 'hooks/useDebounce'
 import EgCalculating from 'pages/Earns/components/EgCalculating'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import { isEgCalculating } from 'pages/Earns/utils/egCalculating'
 import { ExternalLink } from 'theme/components'
 
@@ -127,8 +128,9 @@ const EstimatedPositionApr = ({
               <Skeleton width={48} height={17} />
             </div>
           ) : (
-            <span className="text-sm font-medium text-primary">
+            <span className="whitespace-nowrap text-sm font-medium text-primary">
               {!aprValues ? '--' : aprValues.totalApr === 0 ? '~0%' : `${formatAprNumber(aprValues.totalApr)}%`}
+              {egCalculating && !!aprValues && <EgCalculatingMarker />}
             </span>
           )}
         </HStack>

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/Information/InformationTab.tsx
@@ -7,6 +7,7 @@ import AprHistoryChart from 'pages/Earns/PoolDetail/components/AprHistoryChart'
 import TopMetricsStrip, { type TopMetricItem } from 'pages/Earns/PoolDetail/components/TopMetricsStrip'
 import { getParsedRewardAmount } from 'pages/Earns/PoolDetail/components/utils'
 import { usePoolDetailContext } from 'pages/Earns/PoolDetail/context'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import { ProgramType } from 'pages/Earns/types/pool'
 import { excludeEg, hasEgProgram, isEgCalculating } from 'pages/Earns/utils/egCalculating'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
@@ -63,7 +64,10 @@ const InformationTab = () => {
 
   const rewardsValue = (
     <HStack className="items-center gap-1">
-      <span className="font-medium text-text">{formatUsd(rewards24hUsd)}</span>
+      <span className="whitespace-nowrap font-medium text-text">
+        {formatUsd(rewards24hUsd)}
+        {egCalculating && <EgCalculatingMarker />}
+      </span>
       <BagIcon height={18} width={18} />
     </HStack>
   )

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/AprHistoryChart.tsx
@@ -17,6 +17,7 @@ import {
   getUniqueDateAxisTicks,
 } from 'pages/Earns/PoolDetail/Information/utils'
 import PoolChartState, { PoolChartWrapper } from 'pages/Earns/PoolDetail/components/PoolChartState'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import { ProgramType } from 'pages/Earns/types'
 import { excludeEg } from 'pages/Earns/utils/egCalculating'
 import { MEDIA_WIDTHS } from 'theme'
@@ -162,7 +163,10 @@ const AprHistoryChart = ({
           {showActiveApr && totalApr !== undefined && (
             <div className="flex items-baseline gap-1">
               <span className="text-sm text-subText">APR</span>
-              <span className="text-sm font-medium text-blue">{formatAprValue(totalApr)}</span>
+              <span className="whitespace-nowrap text-sm font-medium text-blue">
+                {formatAprValue(totalApr)}
+                {egCalculating && <EgCalculatingMarker />}
+              </span>
             </div>
           )}
 
@@ -171,7 +175,10 @@ const AprHistoryChart = ({
               <span className="text-base font-medium text-text">Active APR</span>
               <div className="flex items-center gap-1">
                 <FarmingMarker programs={programs} />
-                <span className="text-xl font-medium leading-none text-primary">{formatAprValue(activeApr)}</span>
+                <span className="whitespace-nowrap text-xl font-medium leading-none text-primary">
+                  {formatAprValue(activeApr)}
+                  {egCalculating && <EgCalculatingMarker />}
+                </span>
               </div>
               <span className="text-sm text-subText">(Earning Per Active TVL)</span>
             </div>
@@ -180,7 +187,10 @@ const AprHistoryChart = ({
               <span className="text-base font-medium text-text">APR</span>
               <div className="flex items-center gap-1">
                 <FarmingMarker programs={programs} />
-                <span className="text-xl font-medium leading-none text-blue">{formatAprValue(totalApr)}</span>
+                <span className="whitespace-nowrap text-xl font-medium leading-none text-blue">
+                  {formatAprValue(totalApr)}
+                  {egCalculating && <EgCalculatingMarker />}
+                </span>
               </div>
               <span className="text-sm text-subText">
                 {isPositionChart ? '(Earning Per Position Liquidity)' : '(Earning Per Total TVL)'}

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningApr.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/components/PoolEarningApr.tsx
@@ -4,6 +4,7 @@ import InfoHelper from 'components/InfoHelper'
 import { HStack, Stack } from 'components/Stack'
 import { formatAprValue } from 'pages/Earns/PoolDetail/components/AprHistoryChart'
 import { usePoolDetailContext } from 'pages/Earns/PoolDetail/context'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import { excludeEg, hasEgProgram, isEgCalculating } from 'pages/Earns/utils/egCalculating'
 
 const PoolEarningApr = () => {
@@ -47,7 +48,10 @@ const PoolEarningApr = () => {
             <InfoHelper text="Earning Per Total TVL" size={14} placement="top" />
           </HStack>
           <Stack className="rounded-xl bg-blue/[0.12] px-3 py-1">
-            <span className="text-2xl font-semibold text-blue">{formatAprValue(aprSummary.totalApr)}</span>
+            <span className="whitespace-nowrap text-2xl font-semibold text-blue">
+              {formatAprValue(aprSummary.totalApr)}
+              {egCalculating && <EgCalculatingMarker compact />}
+            </span>
           </Stack>
         </Stack>
 
@@ -60,7 +64,10 @@ const PoolEarningApr = () => {
           </HStack>
           <HStack className="items-baseline gap-2">
             <span className="text-sm text-subText">Rewards</span>
-            <span className="font-medium text-text">{formatAprValue(aprSummary.rewardApr)}</span>
+            <span className="whitespace-nowrap font-medium text-text">
+              {formatAprValue(aprSummary.rewardApr)}
+              {egCalculating && <EgCalculatingMarker compact />}
+            </span>
           </HStack>
         </Stack>
       </HStack>
@@ -73,7 +80,10 @@ const PoolEarningApr = () => {
               <InfoHelper text="Earning Per Active TVL" size={14} placement="top" />
             </HStack>
             <Stack className="rounded-xl bg-primary-12 px-3 py-1">
-              <span className="text-2xl font-semibold text-primary">{formatAprValue(aprSummary.activeApr)}</span>
+              <span className="whitespace-nowrap text-2xl font-semibold text-primary">
+                {formatAprValue(aprSummary.activeApr)}
+                {egCalculating && <EgCalculatingMarker compact />}
+              </span>
             </Stack>
           </Stack>
 
@@ -86,7 +96,10 @@ const PoolEarningApr = () => {
             </HStack>
             <HStack className="items-baseline gap-2">
               <span className="text-sm text-subText">Rewards</span>
-              <span className="font-medium text-text">{formatAprValue(aprSummary.activeRewardApr)}</span>
+              <span className="whitespace-nowrap font-medium text-text">
+                {formatAprValue(aprSummary.activeRewardApr)}
+                {egCalculating && <EgCalculatingMarker compact />}
+              </span>
             </HStack>
           </Stack>
         </HStack>

--- a/apps/kyberswap-interface/src/pages/Earns/PositionDetail/InformationTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PositionDetail/InformationTab.tsx
@@ -45,6 +45,7 @@ import {
   VerticalDivider,
 } from 'pages/Earns/PositionDetail/styles'
 import AnimatedNumber from 'pages/Earns/components/AnimatedNumber'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import PositionSkeleton from 'pages/Earns/components/PositionSkeleton'
 import RewardSyncing from 'pages/Earns/components/RewardSyncing'
 import { SmartExit } from 'pages/Earns/components/SmartExit'
@@ -276,6 +277,7 @@ const InformationTab = () => {
                       )}
                     >
                       <AnimatedNumber value={`${formatAprNum(totalApr)}%`} />
+                      {egCalculating && <EgCalculatingMarker />}
                     </span>
                     {position?.status !== PositionStatus.CLOSED && shareBtn(12, [ShareOption.TOTAL_APR])}
                   </div>
@@ -302,7 +304,9 @@ const InformationTab = () => {
                   >
                     <div className="flex cursor-pointer items-center gap-4">
                       <span className="text-[14px] text-subText">{t`Rewards`}</span>
-                      <span className="text-[14px] text-text">{formatAprNum(rewardApr)}%</span>
+                      <span className="whitespace-nowrap text-[14px] text-text">
+                        {formatAprNum(rewardApr)}%{egCalculating && <EgCalculatingMarker />}
+                      </span>
                     </div>
                   </PositionAprTooltip>
                 )}

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/MigrationModal.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/MigrationModal.tsx
@@ -18,6 +18,7 @@ import {
   SymbolText,
 } from 'pages/Earns/PoolExplorer/styles'
 import AprDetailTooltip from 'pages/Earns/components/AprDetailTooltip'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import { EarnPool, ParsedPosition, ProgramType, SuggestedPool } from 'pages/Earns/types'
 import { excludeEg, hasEgProgram, isEgCalculating } from 'pages/Earns/utils/egCalculating'
 import { MEDIA_WIDTHS } from 'theme'
@@ -87,7 +88,7 @@ export default function MigrationModal({
                       <FeeTier>{formatDisplayNumber(pool.feeTier, { significantDigits: 4 })}%</FeeTier>
                     </div>
                     <Apr value={allApr}>
-                      {formatAprNumber(allApr)}%{' '}
+                      {formatAprNumber(allApr)}%{egCalculating && <EgCalculatingMarker compact />}{' '}
                       {isFarming ? (
                         <AprDetailTooltip
                           feeApr={pool.lpApr}
@@ -153,7 +154,9 @@ export default function MigrationModal({
                         </SymbolText>
                       </div>
                       <div className="flex items-center gap-0.5">
-                        <Apr value={allApr}>{formatAprNumber(allApr)}%</Apr>
+                        <Apr value={allApr}>
+                          {formatAprNumber(allApr)}%{egCalculating && <EgCalculatingMarker compact />}
+                        </Apr>
                         {isFarming ? (
                           <AprDetailTooltip
                             feeApr={pool.lpApr}

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/PositionRowItem.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/PositionRowItem.tsx
@@ -27,6 +27,7 @@ import {
 } from 'pages/Earns/UserPositions/styles'
 import AnimatedNumber from 'pages/Earns/components/AnimatedNumber'
 import AprDetailTooltip from 'pages/Earns/components/AprDetailTooltip'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import PositionSkeleton from 'pages/Earns/components/PositionSkeleton'
 import RewardSyncing from 'pages/Earns/components/RewardSyncing'
 import { EARN_DEXES, LIMIT_TEXT_STYLES } from 'pages/Earns/constants'
@@ -314,8 +315,9 @@ export default function PositionRowItem({
                 merklApr={bonusApr}
                 egCalculating={egCalculating}
               >
-                <span className="text-primary">
+                <span className="whitespace-nowrap text-primary">
                   <AnimatedNumber value={`${formatAprNumber(totalApr)}%`} />
+                  {egCalculating && <EgCalculatingMarker compact />}
                 </span>
               </AprDetailTooltip>
             ) : (

--- a/apps/kyberswap-interface/src/pages/Earns/components/EgCalculatingMarker.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/EgCalculatingMarker.tsx
@@ -1,0 +1,22 @@
+import { t } from '@lingui/macro'
+
+import Dots from 'components/Dots'
+import { cn } from 'utils/cn'
+
+type Props = {
+  className?: string
+  /** Shortens the label for cells too narrow to fit the full word. */
+  compact?: boolean
+}
+
+/**
+ * Rides on an aggregate that had its EG share left out, flagging the missing part without pushing
+ * the figure itself out of the way.
+ */
+const EgCalculatingMarker = ({ className, compact }: Props) => (
+  <sup className={cn('ml-0.5 whitespace-nowrap text-[10px] font-normal text-subText', className)}>
+    <Dots>{compact ? t`+EG calc` : t`+EG calculating`}</Dots>
+  </sup>
+)
+
+export default EgCalculatingMarker

--- a/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/PoolAprInfo.tsx
@@ -7,6 +7,7 @@ import { ReactComponent as FarmingLmIcon } from 'assets/svg/kyber/kemLm.svg'
 import { HStack, Stack } from 'components/Stack'
 import { MouseoverTooltipDesktopOnly } from 'components/Tooltip'
 import EgCalculating from 'pages/Earns/components/EgCalculating'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import { ParsedEarnPool, ProgramType } from 'pages/Earns/types'
 import { excludeEg, hasEgProgram, isEgCalculating } from 'pages/Earns/utils/egCalculating'
 import { ExternalLink } from 'theme/components'
@@ -96,7 +97,10 @@ const PoolAprInfo = ({ pool }: { pool: ParsedEarnPool }) => {
           width="fit-content"
           text={<AprTooltipContent pool={pool} type="active" egCalculating={egCalculating} />}
         >
-          <span className="text-primary">{formatAprNumber((activeApr || 0) + (pool.bonusApr || 0))}%</span>
+          <span className="whitespace-nowrap text-primary">
+            {formatAprNumber((activeApr || 0) + (pool.bonusApr || 0))}%
+            {egCalculating && <EgCalculatingMarker compact />}
+          </span>
         </MouseoverTooltipDesktopOnly>
       ) : (
         <MouseoverTooltipDesktopOnly
@@ -104,7 +108,9 @@ const PoolAprInfo = ({ pool }: { pool: ParsedEarnPool }) => {
           width="fit-content"
           text={<AprTooltipContent pool={pool} type="total" egCalculating={egCalculating} />}
         >
-          <span className="text-blue">{formatAprNumber(allApr)}%</span>
+          <span className="whitespace-nowrap text-blue">
+            {formatAprNumber(allApr)}%{egCalculating && <EgCalculatingMarker compact />}
+          </span>
         </MouseoverTooltipDesktopOnly>
       )}
 

--- a/apps/kyberswap-interface/src/pages/Earns/components/PoolRewardsInfo.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/PoolRewardsInfo.tsx
@@ -9,6 +9,7 @@ import { getParsedRewardAmount } from 'pages/Earns/PoolDetail/components/utils'
 import { Badge } from 'pages/Earns/PoolExplorer/styles'
 import useFilter from 'pages/Earns/PoolExplorer/useFilter'
 import EgCalculating from 'pages/Earns/components/EgCalculating'
+import EgCalculatingMarker from 'pages/Earns/components/EgCalculatingMarker'
 import { EarnPool } from 'pages/Earns/types'
 import { hasEgProgram, isEgCalculating } from 'pages/Earns/utils/egCalculating'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
@@ -191,7 +192,10 @@ const PoolRewardsInfo = ({ pool, showEstimate = true }: Props) => {
           width="fit-content"
           placement="left"
         >
-          <span>{formatDisplayNumber(totalRewards, { style: 'currency', significantDigits: 4 })}</span>
+          <span className="whitespace-nowrap">
+            {formatDisplayNumber(totalRewards, { style: 'currency', significantDigits: 4 })}
+            {egCalculating && <EgCalculatingMarker compact />}
+          </span>
         </MouseoverTooltipDesktopOnly>
       ) : (
         <span>{formatDisplayNumber(totalRewards, { style: 'currency', significantDigits: 4 })}</span>

--- a/packages/liquidity-widgets/src/components/Content/PoolStat.tsx
+++ b/packages/liquidity-widgets/src/components/Content/PoolStat.tsx
@@ -3,9 +3,10 @@ import { useState } from 'react';
 import { Trans } from '@lingui/macro';
 
 import { DEXES_INFO, NETWORKS_INFO, PoolType, defaultToken, dexMapping, univ2Types } from '@kyber/schema';
-import { MouseoverTooltip, ShareModal, ShareType } from '@kyber/ui';
+import { Calculating, MouseoverTooltip, ShareModal, ShareType } from '@kyber/ui';
 import { Skeleton } from '@kyber/ui';
 import { shortenAddress } from '@kyber/utils/crypto';
+import { isEgCalculating } from '@kyber/utils/egCalculating';
 import { formatAprNumber, formatDisplayNumber } from '@kyber/utils/number';
 import { cn } from '@kyber/utils/tailwind-helpers';
 
@@ -39,8 +40,13 @@ export default function PoolStat() {
       : Number((BigInt(position.liquidity) * 10000n) / BigInt(position.totalSupply)) / 100;
 
   const poolStat = initializing ? null : pool?.stats;
+  // The APR leaves the EG share out while it is unreliable, and says so through the marker.
+  const egCalculating = isEgCalculating(chainId, !!poolStat?.kemEGApr24h);
   const poolApr =
-    (poolStat?.apr24h || 0) + (poolStat?.kemEGApr24h || 0) + (poolStat?.kemLMApr24h || 0) + (poolStat?.bonusApr || 0);
+    (poolStat?.apr24h || 0) +
+    (egCalculating ? 0 : poolStat?.kemEGApr24h || 0) +
+    (poolStat?.kemLMApr24h || 0) +
+    (poolStat?.bonusApr || 0);
   const isFarming = initializing ? false : pool?.isFarming || false;
   const isFarmingLm = initializing ? false : pool?.isFarmingLm || false;
 
@@ -169,7 +175,13 @@ export default function PoolStat() {
                           <Trans>LP Fees: {formatAprNumber(poolStat?.apr24h || 0)}%</Trans>
                         </div>
                         <div>
-                          <Trans>EG Sharing Reward: {formatAprNumber(poolStat?.kemEGApr24h || 0)}%</Trans>
+                          {egCalculating ? (
+                            <>
+                              <Trans>EG Sharing Reward:</Trans> <Calculating />
+                            </>
+                          ) : (
+                            <Trans>EG Sharing Reward: {formatAprNumber(poolStat?.kemEGApr24h || 0)}%</Trans>
+                          )}
                         </div>
                         {poolStat?.kemLMApr24h ? (
                           <div>
@@ -201,7 +213,14 @@ export default function PoolStat() {
                   </MouseoverTooltip>
                 )}
 
-                {formatAprNumber(poolApr) + '%'}
+                <span className="whitespace-nowrap">
+                  {formatAprNumber(poolApr) + '%'}
+                  {egCalculating && (
+                    <sup className="ml-0.5 text-[10px] font-normal text-subText">
+                      <Calculating label="+EG calc" />
+                    </sup>
+                  )}
+                </span>
                 <div
                   className="flex items-center justify-center cursor-pointer w-6 h-6 rounded-full text-primary bg-primary-200"
                   onClick={() => setOpenShare(true)}

--- a/packages/liquidity-widgets/src/components/PositionApr.tsx
+++ b/packages/liquidity-widgets/src/components/PositionApr.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro';
 
-import { MouseoverTooltip, Skeleton } from '@kyber/ui';
+import { Calculating, MouseoverTooltip, Skeleton } from '@kyber/ui';
+import { isEgCalculating } from '@kyber/utils/egCalculating';
 import { formatAprNumber } from '@kyber/utils/number';
 
 import { useEstimatedPositionApr } from '@/hooks/useEstimatedPositionApr';
@@ -22,6 +23,10 @@ export const PositionApr = () => {
     enabled: pool?.isFarming,
   });
 
+  // The estimate leaves the EG share out while it is unreliable, and says so through the marker.
+  const egCalculating = isEgCalculating(chainId, pool?.isFarming);
+  const totalApr = data ? (egCalculating ? Math.max(data.totalApr - data.egApr, 0) : data.totalApr) : 0;
+
   const tooltipContent = !route ? (
     <div>
       <Trans>Input an amount to calculate.</Trans>
@@ -36,7 +41,13 @@ export const PositionApr = () => {
         <Trans>LP Fees: {formatAprNumber(data.feeApr)}%</Trans>
       </div>
       <div>
-        <Trans>EG Sharing Reward: {formatAprNumber(data.egApr)}%</Trans>
+        {egCalculating ? (
+          <>
+            <Trans>EG Sharing Reward:</Trans> <Calculating />
+          </>
+        ) : (
+          <Trans>EG Sharing Reward: {formatAprNumber(data.egApr)}%</Trans>
+        )}
       </div>
       <div>
         <Trans>LM Reward: {formatAprNumber(data.lmApr)}%</Trans>
@@ -71,8 +82,13 @@ export const PositionApr = () => {
         {loading && !data ? (
           <Skeleton className="w-16 h-5" />
         ) : (
-          <p className="text-accent">
-            {!data ? '--' : data.totalApr === 0 ? '~0%' : `${formatAprNumber(data.totalApr)}%`}
+          <p className="text-accent whitespace-nowrap">
+            {!data ? '--' : totalApr === 0 ? '~0%' : `${formatAprNumber(totalApr)}%`}
+            {egCalculating && !!data && (
+              <sup className="ml-0.5 text-[10px] font-normal text-subText">
+                <Calculating label="+EG calculating" />
+              </sup>
+            )}
           </p>
         )}
       </div>

--- a/packages/ui/src/components/calculating.tsx
+++ b/packages/ui/src/components/calculating.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const DOT_INTERVAL_MS = 420;
+
+/**
+ * Stands in for a figure the backend cannot report yet. The trailing dots cycle to read as work in
+ * progress; they sit in a fixed-width slot so the label does not jitter as they grow.
+ */
+export const Calculating = ({ className, label = 'Calculating' }: { className?: string; label?: string }) => {
+  const [dotCount, setDotCount] = useState(1);
+
+  useEffect(() => {
+    const timer = setInterval(() => setDotCount(count => (count % 3) + 1), DOT_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <span className={className} style={{ whiteSpace: 'nowrap' }}>
+      {label}
+      <span style={{ display: 'inline-block', width: '1em', textAlign: 'left' }}>{'.'.repeat(dotCount)}</span>
+    </span>
+  );
+};
+
+export default Calculating;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,6 +22,7 @@ export { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 export { Skeleton } from '@/components/ui/skeleton';
 export { default as Tooltip, MouseoverTooltip } from '@/components/Tooltip';
 export { InfoHelper } from '@/components/info-helper';
+export { Calculating } from '@/components/calculating';
 export { default as TokenLogo } from '@/components/token-logo';
 export { Portal } from '@/portal';
 export { default as Loader } from '@/components/loader';

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,24 +11,60 @@
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
-      "crypto": ["src/crypto/index.ts"],
-      "crypto/*": ["src/crypto/*"],
-      "dist/crypto": ["src/crypto/index.ts"],
-      "dist/crypto/*": ["src/crypto/*"],
-      "dist/error": ["src/error.ts"],
-      "dist/liquidity": ["src/liquidity/index.ts"],
-      "dist/liquidity/*": ["src/liquidity/*"],
-      "dist/number": ["src/number.ts"],
-      "dist/services": ["src/services/index.ts"],
-      "dist/tailwind-helpers": ["src/tailwind-helpers.ts"],
-      "dist/uniswapv3": ["src/uniswapv3.ts"],
-      "error": ["src/error.ts"],
-      "liquidity": ["src/liquidity/index.ts"],
-      "liquidity/*": ["src/liquidity/*"],
-      "number": ["src/number.ts"],
-      "services": ["src/services/index.ts"],
-      "tailwind-helpers": ["src/tailwind-helpers.ts"],
-      "uniswapv3": ["src/uniswapv3.ts"]
+      "crypto": [
+        "src/crypto/index.ts"
+      ],
+      "crypto/*": [
+        "src/crypto/*"
+      ],
+      "dist/crypto": [
+        "src/crypto/index.ts"
+      ],
+      "dist/crypto/*": [
+        "src/crypto/*"
+      ],
+      "dist/error": [
+        "src/error.ts"
+      ],
+      "dist/liquidity": [
+        "src/liquidity/index.ts"
+      ],
+      "dist/liquidity/*": [
+        "src/liquidity/*"
+      ],
+      "dist/number": [
+        "src/number.ts"
+      ],
+      "dist/services": [
+        "src/services/index.ts"
+      ],
+      "dist/tailwind-helpers": [
+        "src/tailwind-helpers.ts"
+      ],
+      "dist/uniswapv3": [
+        "src/uniswapv3.ts"
+      ],
+      "error": [
+        "src/error.ts"
+      ],
+      "liquidity": [
+        "src/liquidity/index.ts"
+      ],
+      "liquidity/*": [
+        "src/liquidity/*"
+      ],
+      "number": [
+        "src/number.ts"
+      ],
+      "services": [
+        "src/services/index.ts"
+      ],
+      "tailwind-helpers": [
+        "src/tailwind-helpers.ts"
+      ],
+      "uniswapv3": [
+        "src/uniswapv3.ts"
+      ]
     }
   },
   "peerDependencies": {
@@ -39,6 +75,7 @@
     "./uniswapv3": "./src/uniswapv3.ts",
     "./crypto": "./src/crypto/index.ts",
     "./number": "./src/number.ts",
+    "./egCalculating": "./src/egCalculating.ts",
     "./error": "./src/error.ts",
     "./services": "./src/services/index.ts",
     "./liquidity/pool": "./src/liquidity/pool.ts",
@@ -52,6 +89,7 @@
     "./dist/uniswapv3": "./src/uniswapv3.ts",
     "./dist/crypto": "./src/crypto/index.ts",
     "./dist/number": "./src/number.ts",
+    "./dist/egCalculating": "./src/egCalculating.ts",
     "./dist/error": "./src/error.ts",
     "./dist/services": "./src/services/index.ts",
     "./dist/liquidity": "./src/liquidity/index.ts",

--- a/packages/utils/src/egCalculating.ts
+++ b/packages/utils/src/egCalculating.ts
@@ -1,0 +1,10 @@
+/** Chains whose FairFlow EG figures are not trustworthy, so every EG reading is masked. */
+const EG_CALCULATING_CHAINS: Array<number> = [4663]; // Robinhood
+
+/**
+ * Every EG reading and every aggregate built on one renders a "Calculating..." placeholder instead
+ * of a number, but only for pools/positions that sit on an affected chain AND take part in the EG
+ * program; everything else keeps rendering the real figures.
+ */
+export const isEgCalculating = (chainId?: number, hasEgProgram?: boolean) =>
+  chainId !== undefined && !!hasEgProgram && EG_CALCULATING_CHAINS.includes(chainId);

--- a/packages/zap-out-widgets/src/components/PoolStat.tsx
+++ b/packages/zap-out-widgets/src/components/PoolStat.tsx
@@ -1,7 +1,8 @@
 import { Trans, t } from '@lingui/macro';
 
 import { univ2Types } from '@kyber/schema';
-import { MouseoverTooltip, Skeleton } from '@kyber/ui';
+import { Calculating, MouseoverTooltip, Skeleton } from '@kyber/ui';
+import { isEgCalculating } from '@kyber/utils/egCalculating';
 import { formatAprNumber, formatDisplayNumber } from '@kyber/utils/number';
 import { cn } from '@kyber/utils/tailwind-helpers';
 
@@ -10,7 +11,7 @@ import FarmingLmIcon from '@/assets/svg/kemLm.svg';
 import { useZapOutContext } from '@/stores';
 
 export default function PoolStat() {
-  const { position, pool, poolType, positionId } = useZapOutContext(s => s);
+  const { position, pool, poolType, positionId, chainId } = useZapOutContext(s => s);
 
   const initializing = !pool || !position;
 
@@ -20,9 +21,11 @@ export default function PoolStat() {
       ? null
       : Number((BigInt(position.liquidity) * 10000n) / BigInt(position.totalSupply)) / 100;
 
+  // The APR leaves the EG share out while it is unreliable, and says so through the marker.
+  const egCalculating = isEgCalculating(chainId, !initializing && !!pool.stats.kemEGApr24h);
   const poolApr = initializing
     ? 0
-    : (pool.stats.apr24h || 0) + (pool.stats.kemEGApr24h || 0) + (pool.stats.kemLMApr24h || 0);
+    : (pool.stats.apr24h || 0) + (egCalculating ? 0 : pool.stats.kemEGApr24h || 0) + (pool.stats.kemLMApr24h || 0);
   const isFarming = initializing ? false : pool.isFarming || false;
   const isFarmingLm = initializing ? false : pool.isFarmingLm || false;
 
@@ -93,13 +96,28 @@ export default function PoolStat() {
             <Skeleton className="w-16 h-5" />
           ) : (
             <div className={`flex items-center gap-1 ${poolApr > 0 ? 'text-accent' : 'text-text'}`}>
-              {formatAprNumber(poolApr) + '%'}
+              <span className="whitespace-nowrap">
+                {formatAprNumber(poolApr) + '%'}
+                {egCalculating && (
+                  <sup className="ml-0.5 text-[10px] font-normal text-subText">
+                    <Calculating label="+EG calc" />
+                  </sup>
+                )}
+              </span>
               {isFarming ? (
                 <MouseoverTooltip
                   text={
                     <div className="flex flex-col gap-0.5">
                       <div>{t`LP Fees: ${formatAprNumber(pool.stats.apr24h)}%`}</div>
-                      <div>{t`EG Sharing Reward: ${formatAprNumber(pool.stats.kemEGApr24h)}%`}</div>
+                      <div>
+                        {egCalculating ? (
+                          <>
+                            {t`EG Sharing Reward:`} <Calculating />
+                          </>
+                        ) : (
+                          t`EG Sharing Reward: ${formatAprNumber(pool.stats.kemEGApr24h)}%`
+                        )}
+                      </div>
                       {pool.stats.kemLMApr24h > 0 && (
                         <div>{t`LM Reward: ${formatAprNumber(pool.stats.kemLMApr24h)}%`}</div>
                       )}


### PR DESCRIPTION
Follow-up to #3314. Robinhood still returns unusable FairFlow EG numbers, and aggregates already
dropped that share — but they rendered as ordinary figures, so nothing told the user a part was
missing.

## What changes

- Every aggregate that leaves EG out now carries a small `+EG calculating` superscript, shortened to
  `+EG calc` where the cell is tight (pool explorer APR/Rewards, the pool-detail APR summary, the
  My Positions APR column, the landing card, the zap widgets).
- The standalone EG readings keep their animated `Calculating...` placeholder.
- The zap-in / zap-out widgets were still showing the raw EG numbers. Their `Est. Pool APR`,
  `Est. APR` and `Est. Position APR` now leave EG out and carry the marker, and their EG tooltip
  rows read as calculating.

## Structure

- The affected-chain switch moves to `@kyber/utils/egCalculating` so the app and the embeddable
  widgets share one list — emptying it retires the whole workaround without touching a call site.
- The animated placeholder lands in `@kyber/ui` because the widgets cannot reach the app's ellipsis
  keyframes.

## Note for reviewers

This touches `packages/`, so run `pnpm build-package` after checkout.

## Verified against live Robinhood data

| Surface | Before | After |
| --- | --- | --- |
| Pool explorer APR | `4,901%` | `11.66%` + `+EG calc...` |
| Pool detail APR / Active APR | `1,445%` / `1,647%` | `15.32%` / `11.66%` + marker |
| Zap-in Est. Pool APR | `45,717%` | `350.65%` + `+EG calc...` |
| Zap-in Est. Position APR | `49,076%` | `376.84%` + marker |