### PR TITLE
fix(swap): show slippage info tooltip on click

### DIFF
--- a/apps/kyberswap-interface/src/components/InfoHelper/index.tsx
+++ b/apps/kyberswap-interface/src/components/InfoHelper/index.tsx
@@ -2,7 +2,7 @@ import { Placement } from '@popperjs/core'
 import { CSSProperties, ReactNode, useCallback, useState } from 'react'
 import { Info } from 'react-feather'
 
-import Tooltip, { MouseoverTooltip } from 'components/Tooltip'
+import Tooltip, { ClickTooltip, MouseoverTooltip } from 'components/Tooltip'
 import { Z_INDEXS } from 'constants/styles'
 import { cn } from 'utils/cn'
 
@@ -19,6 +19,7 @@ export default function InfoHelper({
   zIndexTooltip = Z_INDEXS.POPOVER_CONTAINER,
   noArrow = false,
   margin = true,
+  clickOnly = false,
 }: {
   text: string | ReactNode
   size?: number
@@ -32,11 +33,45 @@ export default function InfoHelper({
   zIndexTooltip?: number
   noArrow?: boolean
   margin?: boolean
+  clickOnly?: boolean
 }) {
   const [show, setShow] = useState<boolean>(false)
 
   const open = useCallback(() => setShow(true), [setShow])
   const close = useCallback(() => setShow(false), [setShow])
+
+  const icon = (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded-[36px] border-none bg-transparent outline-none hover:opacity-70 focus:opacity-70',
+        clickOnly ? 'cursor-pointer' : 'cursor-default',
+        isActive ? 'text-textReverse' : 'text-subText',
+        className,
+      )}
+    >
+      <Info size={size || 12} color={color || 'currentcolor'} />
+    </div>
+  )
+
+  if (clickOnly) {
+    return (
+      <span
+        style={style}
+        className={cn('inline-flex items-center justify-center align-middle leading-none', margin ? 'ml-1' : 'ml-0')}
+      >
+        <ClickTooltip
+          text={text}
+          placement={placement}
+          width={width}
+          size={fontSize || size}
+          style={{ zIndex: zIndexTooltip }}
+          noArrow={noArrow}
+        >
+          {icon}
+        </ClickTooltip>
+      </span>
+    )
+  }
 
   return (
     <span
@@ -58,15 +93,7 @@ export default function InfoHelper({
         style={{ zIndex: zIndexTooltip }}
         noArrow={noArrow}
       >
-        <div
-          className={cn(
-            'flex cursor-default items-center justify-center rounded-[36px] border-none bg-transparent outline-none hover:opacity-70 focus:opacity-70',
-            isActive ? 'text-textReverse' : 'text-subText',
-            className,
-          )}
-        >
-          <Info size={size || 12} color={color || 'currentcolor'} />
-        </div>
+        {icon}
       </Tooltip>
     </span>
   )

--- a/apps/kyberswap-interface/src/components/SwapForm/SlippageSetting.tsx
+++ b/apps/kyberswap-interface/src/components/SwapForm/SlippageSetting.tsx
@@ -4,10 +4,10 @@ import { ChevronDown } from 'react-feather'
 import { useSearchParams } from 'react-router-dom'
 
 import { ErrorWarning } from 'components/ErrorWarning'
+import InfoHelper from 'components/InfoHelper'
 import SlippageControl from 'components/SlippageControl'
 import SlippageWarningNote from 'components/SlippageWarningNote'
 import { Stack } from 'components/Stack'
-import { TextDashed } from 'components/Text'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { DEFAULT_SLIPPAGES, DEFAULT_SLIPPAGES_HIGH_VOLATILITY } from 'constants/trade'
 import { useDefaultSlippageByPair, usePairCategory } from 'state/swap/hooks'
@@ -107,30 +107,31 @@ const SlippageSetting = ({ rightComponent, tooltip, slippageInfo }: Props) => {
   return (
     <div className="flex w-full flex-col">
       <div className="flex items-center justify-between gap-1 text-subText">
-        <div className="flex items-center gap-1">
-          <TextDashed fontSize={12} fontWeight={500} className="flex h-fit items-center text-subText">
-            <MouseoverTooltip
-              placement="bottom"
-              text={
-                tooltip || (
-                  <span>
-                    <Trans>
-                      During your swap if the price changes by more than this %, your transaction will revert. Read more{' '}
-                      <ExternalLink
-                        href={
-                          'https://docs.kyberswap.com/getting-started/foundational-topics/decentralized-finance/slippage'
-                        }
-                      >
-                        here ↗
-                      </ExternalLink>
-                    </Trans>
-                  </span>
-                )
-              }
-            >
-              <Trans>Max Slippage</Trans>:
-            </MouseoverTooltip>
-          </TextDashed>
+        <div className="flex items-end gap-1">
+          <span className="text-xs font-medium text-subText">
+            <Trans>Max Slippage</Trans>:
+          </span>
+          <InfoHelper
+            clickOnly
+            margin={false}
+            placement="top"
+            text={
+              tooltip || (
+                <span>
+                  <Trans>
+                    During your swap if the price changes by more than this %, your transaction will revert. Read more{' '}
+                    <ExternalLink
+                      href={
+                        'https://docs.kyberswap.com/getting-started/foundational-topics/decentralized-finance/slippage'
+                      }
+                    >
+                      here ↗
+                    </ExternalLink>
+                  </Trans>
+                </span>
+              )
+            }
+          />
           <div
             role="button"
             onClick={() => setExpanded(e => !e)}

--- a/apps/kyberswap-interface/src/components/TokenPriceChart/TokenPriceChartCanvas.tsx
+++ b/apps/kyberswap-interface/src/components/TokenPriceChart/TokenPriceChartCanvas.tsx
@@ -51,7 +51,7 @@ type TokenPriceChartCanvasProps = {
   timeFrame: TokenChartTimeFrame
 }
 
-const DEFAULT_VISIBLE_CANDLES = 60
+const DEFAULT_VISIBLE_CANDLES = 40
 const LOAD_MORE_THRESHOLD = 20
 
 const formatAxisTimeLabel = (timestamp: number, timeFrame: TokenChartTimeFrame) => {

--- a/apps/kyberswap-interface/src/components/TokenPriceChart/TokenPriceChartCanvas.tsx
+++ b/apps/kyberswap-interface/src/components/TokenPriceChart/TokenPriceChartCanvas.tsx
@@ -559,9 +559,11 @@ const TokenPriceChartCanvas = ({
       if (!chartRef.current || hasInitializedViewRef.current) return
 
       const lastCandleIndex = chartData.length - 1
+      const visibleCandleCount = Math.min(chartData.length, DEFAULT_VISIBLE_CANDLES)
+      const sidePadding = (DEFAULT_VISIBLE_CANDLES - visibleCandleCount) / 2
       chartRef.current.timeScale().setVisibleLogicalRange({
-        from: Math.max(lastCandleIndex - (DEFAULT_VISIBLE_CANDLES - 1), 0),
-        to: lastCandleIndex + 0.5,
+        from: Math.max(lastCandleIndex - (DEFAULT_VISIBLE_CANDLES - 1), 0) - sidePadding,
+        to: lastCandleIndex + sidePadding + 0.5,
       })
       hasInitializedViewRef.current = true
       setIsViewportReady(true)


### PR DESCRIPTION
## Summary
- replace the Max Slippage hover tooltip with an InfoHelper control
- add a click-only InfoHelper mode with outside-click dismissal and pointer cursor