### PR TITLE
fix(earn): make the unfinalized position placeholder reliable

### DIFF
--- a/apps/kyberswap-interface/src/index.tsx
+++ b/apps/kyberswap-interface/src/index.tsx
@@ -20,6 +20,7 @@ import Web3Provider from 'components/Web3Provider'
 import { ENV_LEVEL, ENV_TYPE, GTM_ID } from 'constants/env'
 import { useAffiliate } from 'hooks/useAffiliate'
 import App from 'pages/App'
+import UnfinalizedPositionUpdater from 'pages/Earns/components/UnfinalizedPositionUpdater'
 import store from 'state'
 import ApplicationUpdater from 'state/application/updater'
 import CustomizeDexesUpdater from 'state/customizeDexes/updater'
@@ -74,6 +75,7 @@ function Updaters() {
       <UserUpdater />
       <ApplicationUpdater />
       <TransactionUpdater />
+      <UnfinalizedPositionUpdater />
       <CustomizeDexesUpdater />
     </>
   )

--- a/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/ReviewModal/useReviewTransaction.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolDetail/AddLiquidity/components/ReviewModal/useReviewTransaction.ts
@@ -156,6 +156,29 @@ export const useReviewTransaction = ({
           tokensIn,
           dexLogoUrl: EARN_DEXES[exchange].logo,
           dex: exchange,
+          // The page only ever opens a brand-new position, so the placeholder never carries a position id.
+          unfinalizedPosition: {
+            chainId,
+            dex: exchange,
+            dexLogo: EARN_DEXES[exchange].logo,
+            pool: { address: poolAddress, fee: pool.fee },
+            token0: {
+              address: pool.token0.address,
+              symbol: pool.token0.symbol,
+              logo: pool.token0.logo || '',
+              decimals: pool.token0.decimals,
+              amount: outputTokenItems[0]?.amount || 0,
+            },
+            token1: {
+              address: pool.token1.address,
+              symbol: pool.token1.symbol,
+              logo: pool.token1.logo || '',
+              decimals: pool.token1.decimals,
+              amount: outputTokenItems[1]?.amount || 0,
+            },
+            value: Number(route.zapDetails.initialAmountUsd || 0),
+            createdAt: Date.now(),
+          },
         },
       })
       onTrackEvent?.('LIQ_ADDED', {
@@ -196,8 +219,10 @@ export const useReviewTransaction = ({
     onAddTrackedTxHash,
     onAddTransactionWithType,
     onTrackEvent,
+    outputTokenItems,
     pool,
     poolAddress,
+    route,
     tokensIn,
   ])
 

--- a/apps/kyberswap-interface/src/pages/Earns/PositionDetail/InformationTab.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PositionDetail/InformationTab.tsx
@@ -154,9 +154,11 @@ const InformationTab = () => {
   const isClosed = position?.status === PositionStatus.CLOSED
   const isOutRange = position?.status === PositionStatus.OUT_RANGE
 
-  const repositionDisabled = initialLoading || !position || isClosed
-  const increaseDisabled = initialLoading || (isUniV4 && isClosed)
-  const removeDisabled = initialLoading || isNotAccountOwner || isClosed || !position
+  // A placeholder has no indexed position behind it yet, so every action that would submit its id has to
+  // wait — the positions list already hides the same actions on an unfinalized row.
+  const repositionDisabled = initialLoading || !position || isClosed || isUnfinalized
+  const increaseDisabled = initialLoading || (isUniV4 && isClosed) || isUnfinalized
+  const removeDisabled = initialLoading || isNotAccountOwner || isClosed || !position || isUnfinalized
   const subActionDisabled = isClosed || (!isOutRange ? repositionDisabled : increaseDisabled)
 
   const isSmartExitSupported =

--- a/apps/kyberswap-interface/src/pages/Earns/PositionDetail/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PositionDetail/index.tsx
@@ -4,7 +4,7 @@ import { t } from '@lingui/macro'
 import { readContract } from '@wagmi/core'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Share2 } from 'react-feather'
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useUserPositionsQuery } from 'services/earn'
 import { useGetSmartExitOrdersQuery } from 'services/smartExit'
 
@@ -34,20 +34,27 @@ import useForceLoading from 'pages/Earns/hooks/useForceLoading'
 import useKemRewards from 'pages/Earns/hooks/useKemRewards'
 import useMerklRewards from 'pages/Earns/hooks/useMerklRewards'
 import useReduceFetchInterval from 'pages/Earns/hooks/useReduceFetchInterval'
+import useUnfinalizedPositions from 'pages/Earns/hooks/useUnfinalizedPositions'
 import useZapMigrationWidget from 'pages/Earns/hooks/useZapMigrationWidget'
 import { FeeInfo, OrderStatus, PAIR_CATEGORY, ParsedPosition, PositionStatus, SuggestedPool } from 'pages/Earns/types'
 import { getNftManagerContractAddress } from 'pages/Earns/utils'
 import { getUnclaimedFeesInfo } from 'pages/Earns/utils/fees'
 import { checkEarlyPosition, parsePosition } from 'pages/Earns/utils/position'
-import { getUnfinalizedPositions } from 'pages/Earns/utils/unfinalizedPosition'
+import {
+  getUnfinalizedPositionKeyFromPosition,
+  getUnfinalizedPositionKeyFromRoute,
+} from 'pages/Earns/utils/unfinalizedPosition'
 import { getPoolDetailUrl } from 'pages/Earns/utils/url'
 import { toString } from 'utils/numbers'
 import { type Address } from 'utils/viem'
 
+// Long enough to outlast the receipt lookup the placeholder write waits on, short enough that a zap whose
+// placeholder never lands still resolves to a real page state instead of spinning.
+const FORCE_LOADING_MAX_MS = 30_000
+
 const PositionDetail = () => {
   const firstLoading = useRef(false)
   const navigate = useNavigate()
-  const [searchParams, setSearchParams] = useSearchParams()
 
   const { account } = useActiveWeb3React()
   const { forceLoading, removeForceLoading } = useForceLoading()
@@ -95,6 +102,9 @@ const PositionDetail = () => {
   const hasActiveSmartExitOrder = !!smartExitOrders?.orders?.length && smartExitOrders.orders.length > 0
 
   const currentWalletAddress = useRef(account)
+  // Anchors the bound to mount: `removeForceLoading`'s identity changes with the URL.
+  const removeForceLoadingRef = useRef(removeForceLoading)
+  removeForceLoadingRef.current = removeForceLoading
   const [aprInterval, setAprInterval] = useState<'24h' | '7d'>('24h')
   const [feeInfoFromRpc, setFeeInfoFromRpc] = useState<FeeInfo | undefined>()
   const [shareInfo, setShareInfo] = useState<ShareModalProps | undefined>()
@@ -102,36 +112,51 @@ const PositionDetail = () => {
   const [positionOwnerAddress, setPositionOwnerAddress] = useState<string | null>(null)
 
   const loadingInterval = isFetching
-  const initialLoading = !!(forceLoading || (isLoading && !firstLoading.current))
 
-  const position: ParsedPosition | undefined = useMemo(() => {
-    const tokenId = positionId?.split('-')[1]
-    if (!userPositions || !userPositions.length) {
-      const unfinalizedPositions = getUnfinalizedPositions([], account || undefined)
-      if (unfinalizedPositions.length > 0 && Number(tokenId) === Number(unfinalizedPositions[0].tokenId))
-        return unfinalizedPositions[0]
-      return
-    }
+  const parsedPosition: ParsedPosition | undefined = useMemo(() => {
+    const positionFromApi = userPositions[0]
+    if (!positionFromApi) return undefined
 
-    const isClosedFromRpc = closedPositionsFromRpc.includes(userPositions[0].tokenId)
-
-    const parsedPosition = parsePosition({
-      position: userPositions[0],
+    return parsePosition({
+      position: positionFromApi,
       feeInfo: feeInfoFromRpc,
       nftRewardInfo: rewardInfoThisPosition,
-      isClosedFromRpc,
+      isClosedFromRpc: closedPositionsFromRpc.includes(positionFromApi.tokenId),
     })
+  }, [closedPositionsFromRpc, feeInfoFromRpc, rewardInfoThisPosition, userPositions])
 
-    const unfinalizedPositions = getUnfinalizedPositions([parsedPosition], account || undefined)
-    const matchedUnfinalized = unfinalizedPositions.find(p => Number(p.tokenId) === Number(tokenId))
+  const parsedPositions = useMemo(() => (parsedPosition ? [parsedPosition] : []), [parsedPosition])
+  const { placeholderByKey, valueUpdatingKeys } = useUnfinalizedPositions({
+    owner: account || undefined,
+    positions: parsedPositions,
+  })
 
-    if (matchedUnfinalized) {
-      if (matchedUnfinalized.isValueUpdating) return { ...parsedPosition, isValueUpdating: true }
-      return matchedUnfinalized
-    }
+  // The route carries the pool address for UniV2 pairs and `<nftManager>-<tokenId>` for NFT positions, so
+  // the cache can be addressed before the indexer has returned anything.
+  const routePositionKey = useMemo(
+    () => getUnfinalizedPositionKeyFromRoute({ chainId, dexId: exchange, positionId }),
+    [chainId, exchange, positionId],
+  )
 
-    return parsedPosition
-  }, [account, feeInfoFromRpc, userPositions, rewardInfoThisPosition, closedPositionsFromRpc, positionId])
+  // The positions query keeps serving the previously viewed position until a new set of arguments resolves,
+  // so a row that does not belong to this route is treated as not yet arrived. A row that cannot be
+  // addressed at all is trusted, since the query was already filtered by this route's position id.
+  const indexedPosition: ParsedPosition | undefined = useMemo(() => {
+    if (!parsedPosition) return undefined
+    const key = getUnfinalizedPositionKeyFromPosition(parsedPosition)
+    return key && routePositionKey && key !== routePositionKey ? undefined : parsedPosition
+  }, [parsedPosition, routePositionKey])
+
+  const position: ParsedPosition | undefined = useMemo(() => {
+    if (!routePositionKey) return indexedPosition
+    if (!indexedPosition) return placeholderByKey.get(routePositionKey)
+    // A zap into an existing position leaves the indexed row usable and only makes its value stale.
+    return valueUpdatingKeys.has(routePositionKey) ? { ...indexedPosition, isValueUpdating: true } : indexedPosition
+  }, [indexedPosition, placeholderByKey, routePositionKey, valueUpdatingKeys])
+
+  // A request in flight with nothing to show for this route means the position is still on its way, whether
+  // that is the first load or a move between two position pages; skeletons beat an empty state either way.
+  const initialLoading = !!(forceLoading || (isLoading && !firstLoading.current) || (!position && isFetching))
 
   const farmingPoolsByChain = useFarmingStablePools({ chainIds: position ? [position.chain.id] : [] })
 
@@ -251,13 +276,18 @@ const PositionDetail = () => {
     if (!account || account !== currentWalletAddress.current) navigate(APP_PATHS.EARN_POSITIONS)
   }, [account, navigate])
 
+  // `?forceLoading=true` is the hand-off from the zap flow: caching the placeholder needs the mined receipt,
+  // so the page holds its skeletons rather than flashing "No position found" in between. `position` is
+  // route-scoped, so anything rendering means the hand-off is done; the timer bounds the wait.
   useEffect(() => {
-    if (!position || !forceLoading) return
-    if (position.pool.isUniv2 ? position.positionId === positionId : position.tokenId === positionId?.split('-')[1]) {
-      removeForceLoading()
+    if (!forceLoading) return
+    if (position) {
+      removeForceLoadingRef.current()
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceLoading, position, searchParams, setSearchParams])
+    const timeout = setTimeout(() => removeForceLoadingRef.current(), FORCE_LOADING_MAX_MS)
+    return () => clearTimeout(timeout)
+  }, [forceLoading, position])
 
   const onRefreshPosition = useCallback(
     ({ tokenId, dex, poolAddress, chainId }: CheckClosedPositionParams) => {

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/TableContent.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/TableContent.tsx
@@ -26,6 +26,7 @@ import { ZapMigrationInfo } from 'pages/Earns/hooks/useZapMigrationWidget'
 import { ZapOutInfo } from 'pages/Earns/hooks/useZapOutWidget'
 import { FeeInfo, OrderStatus, ParsedPosition, PositionStatus, SuggestedPool } from 'pages/Earns/types'
 import { getUnclaimedFeesInfo } from 'pages/Earns/utils/fees'
+import { getUnfinalizedPositionKeyFromPosition } from 'pages/Earns/utils/unfinalizedPosition'
 import { useWalletModalToggle } from 'state/application/hooks'
 import { MEDIA_WIDTHS } from 'theme'
 import { cn } from 'utils/cn'
@@ -311,7 +312,7 @@ export default function TableContent({
         {account && positions && positions.length > 0
           ? positions.map((position, index) => (
               <PositionRowItem
-                key={`${position.tokenId}-${position.pool.address}-${index}`}
+                key={getUnfinalizedPositionKeyFromPosition(position) ?? position.positionId}
                 position={position}
                 index={index}
                 smartExitPosIds={smartExitPosIds}

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
@@ -38,12 +38,13 @@ import useAccountChanged from 'pages/Earns/hooks/useAccountChanged'
 import useClosedPositions from 'pages/Earns/hooks/useClosedPositions'
 import useKemRewards from 'pages/Earns/hooks/useKemRewards'
 import useSupportedDexesAndChains, { AllChainsOption } from 'pages/Earns/hooks/useSupportedDexesAndChains'
+import useUnfinalizedPositions from 'pages/Earns/hooks/useUnfinalizedPositions'
 import useZapInWidget from 'pages/Earns/hooks/useZapInWidget'
 import useZapMigrationWidget from 'pages/Earns/hooks/useZapMigrationWidget'
 import useZapOutWidget from 'pages/Earns/hooks/useZapOutWidget'
 import { ParsedPosition, PositionStatus } from 'pages/Earns/types'
 import { parsePosition } from 'pages/Earns/utils/position'
-import { getUnfinalizedPositions } from 'pages/Earns/utils/unfinalizedPosition'
+import { getUnfinalizedPositionKeyFromPosition } from 'pages/Earns/utils/unfinalizedPosition'
 import SortIcon, { Direction } from 'pages/MarketOverview/SortIcon'
 
 const UserPositions = () => {
@@ -150,31 +151,48 @@ const UserPositions = () => {
     })
   }, [feeInfoFromRpc, rewardInfo?.nfts, userPositionsData, closedPositionsFromRpc])
 
+  const { placeholders, valueUpdatingKeys } = useUnfinalizedPositions({
+    owner: account || undefined,
+    positions: parsedPositions,
+  })
+
   const filteredPositions: Array<ParsedPosition> = useMemo(() => {
-    let unfinalizedPositions: ParsedPosition[] = []
-    const valueUpdatingTokenIds: Set<number> = new Set()
+    // Placeholders belong on the first page only; the later pages would duplicate rows the API returns.
+    if (filters.page !== 1) return parsedPositions
 
-    if (filters.page && filters.page === 1) {
-      const rawUnfinalizedPositions = getUnfinalizedPositions(parsedPositions, account || undefined)
-      const filtered = rawUnfinalizedPositions.filter(
-        position =>
-          (filters.chainIds ? filters.chainIds.split(',').includes(position.chain.id.toString()) : true) &&
-          (filters.protocols ? filters.protocols.split(',').includes(position.dex.id) : true) &&
-          (filters.statuses.includes(PositionStatus.IN_RANGE) || filters.statuses.includes(PositionStatus.OUT_RANGE)),
-      )
+    const chainIds = filters.chainIds ? filters.chainIds.split(',') : []
+    const protocols = filters.protocols ? filters.protocols.split(',') : []
+    const showsOpenPositions =
+      filters.statuses.includes(PositionStatus.IN_RANGE) || filters.statuses.includes(PositionStatus.OUT_RANGE)
 
-      // Separate truly new positions from increase-liquidity positions
-      unfinalizedPositions = filtered.filter(p => !p.isValueUpdating)
-      filtered.filter(p => p.isValueUpdating).forEach(p => valueUpdatingTokenIds.add(Number(p.tokenId)))
-    }
+    const visiblePlaceholders = showsOpenPositions
+      ? placeholders.filter(
+          position =>
+            (!chainIds.length || chainIds.includes(position.chain.id.toString())) &&
+            (!protocols.length || protocols.includes(position.dex.id)),
+        )
+      : []
 
-    // Mark API positions that just had liquidity increased
-    const mergedPositions = parsedPositions.map(p =>
-      valueUpdatingTokenIds.has(Number(p.tokenId)) ? { ...p, isValueUpdating: true } : p,
-    )
+    if (!visiblePlaceholders.length && !valueUpdatingKeys.size) return parsedPositions
 
-    return [...unfinalizedPositions, ...mergedPositions]
-  }, [account, filters.chainIds, filters.page, filters.protocols, filters.statuses, parsedPositions])
+    // A zap into an existing position already has a row: flag its value instead of prepending a placeholder.
+    return [
+      ...visiblePlaceholders,
+      ...parsedPositions.map(position =>
+        valueUpdatingKeys.has(getUnfinalizedPositionKeyFromPosition(position) ?? '')
+          ? { ...position, isValueUpdating: true }
+          : position,
+      ),
+    ]
+  }, [
+    filters.chainIds,
+    filters.page,
+    filters.protocols,
+    filters.statuses,
+    parsedPositions,
+    placeholders,
+    valueUpdatingKeys,
+  ])
 
   const onSortChange = useCallback(
     (sortBy: string) => {

--- a/apps/kyberswap-interface/src/pages/Earns/components/UnfinalizedPositionUpdater.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/components/UnfinalizedPositionUpdater.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { useActiveWeb3React } from 'hooks'
+import { AppDispatch } from 'state'
+import { modifyTransaction } from 'state/transactions/actions'
+import { useAllTransactions } from 'state/transactions/hooks'
+import { TRANSACTION_TYPE, TransactionDetails, UnfinalizedPositionSnapshot } from 'state/transactions/type'
+
+/** The zap extra-infos that can carry a snapshot; only that one field is read here. */
+type ZapExtraInfo = { unfinalizedPosition?: UnfinalizedPositionSnapshot }
+
+const ZAP_IN_TRANSACTION_TYPES = [
+  TRANSACTION_TYPE.EARN_ADD_LIQUIDITY,
+  TRANSACTION_TYPE.EARN_INCREASE_LIQUIDITY,
+  TRANSACTION_TYPE.EARN_MIGRATE_LIQUIDITY,
+  TRANSACTION_TYPE.EARN_REPOSITION,
+]
+
+/**
+ * Caches the placeholder position for a zap once its transaction is mined. It works off the persisted
+ * transaction store rather than off the zap widget, so the placeholder is written whether or not the widget
+ * is still on screen — dismissing it mid-flight, navigating away, or reloading all keep working.
+ *
+ * The snapshot is cleared from the transaction afterwards, which doubles as the "already handled" marker
+ * across reloads.
+ */
+export default function UnfinalizedPositionUpdater(): null {
+  const { account } = useActiveWeb3React()
+  const dispatch = useDispatch<AppDispatch>()
+  const allTransactions = useAllTransactions(true)
+  const handledTxHashes = useRef(new Set<string>())
+
+  useEffect(() => {
+    if (!account || !allTransactions) return
+
+    const minedZaps = (Object.values(allTransactions).flat() as Array<TransactionDetails | undefined>).filter(
+      (tx): tx is TransactionDetails =>
+        !!tx &&
+        !!tx.receipt &&
+        ZAP_IN_TRANSACTION_TYPES.includes(tx.type) &&
+        !!(tx.extraInfo as ZapExtraInfo | undefined)?.unfinalizedPosition &&
+        !handledTxHashes.current.has(tx.hash),
+    )
+
+    minedZaps.forEach(async tx => {
+      handledTxHashes.current.add(tx.hash)
+
+      const snapshot = (tx.extraInfo as ZapExtraInfo | undefined)?.unfinalizedPosition
+      const clearSnapshot = () =>
+        dispatch(
+          modifyTransaction({
+            chainId: tx.chainId,
+            hash: tx.hash,
+            // Only the snapshot is dropped; the rest of the transaction's extra info is carried through, so
+            // the merged object keeps whichever Earn shape this transaction actually has.
+            extraInfo: { ...tx.extraInfo, unfinalizedPosition: undefined } as TransactionDetails['extraInfo'],
+          }),
+        )
+
+      try {
+        const { UNFINALIZED_POSITION_TTL_MS } = await import('pages/Earns/utils/unfinalizedPosition')
+
+        // A reverted zap creates no position, and a snapshot older than the cache lifetime would be pruned
+        // on the next read anyway.
+        const isWritable =
+          !!snapshot && tx.receipt?.status === 1 && Date.now() - snapshot.createdAt <= UNFINALIZED_POSITION_TTL_MS
+        if (isWritable) {
+          const { writeUnfinalizedPositionFromSnapshot } = await import('pages/Earns/utils/unfinalizedPositionWriter')
+          await writeUnfinalizedPositionFromSnapshot({ txHash: tx.hash, snapshot, owner: account })
+        }
+      } catch (error) {
+        console.error('Failed to cache unfinalized position:', error)
+      }
+      clearSnapshot()
+    })
+  }, [account, allTransactions, dispatch])
+
+  return null
+}

--- a/apps/kyberswap-interface/src/pages/Earns/constants/index.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/constants/index.ts
@@ -138,6 +138,15 @@ const defaultConfig = {
   smartExitDexType: undefined,
 }
 
+const SUPPORTED_EXCHANGES = new Set<string>(Object.values(Exchange))
+
+/**
+ * Whether the app knows this exchange. `EARN_DEXES` answers every lookup with a default entry, so an id
+ * that is not in the enum reads as an unnamed Uniswap V3 fork rather than as missing.
+ */
+export const isSupportedExchange = (exchange?: string): exchange is Exchange =>
+  !!exchange && SUPPORTED_EXCHANGES.has(exchange)
+
 // Proxy helps fallback undefined Exchange by default dex info
 export const EARN_DEXES = new Proxy(EARN_DEXES_CONFIG as any, {
   get(target, p) {

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useUnfinalizedPositions.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useUnfinalizedPositions.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
+
+import { ParsedPosition } from 'pages/Earns/types'
+import {
+  UNFINALIZED_POSITION_TTL_MS,
+  UnfinalizedPositionRecord,
+  getUnfinalizedPositionRecords,
+  pruneUnfinalizedPositions,
+  removeUnfinalizedPositions,
+  resolveUnfinalizedPositions,
+  subscribeUnfinalizedPositions,
+} from 'pages/Earns/utils/unfinalizedPosition'
+
+const EMPTY_POSITIONS: readonly ParsedPosition[] = []
+const EMPTY_RECORDS: readonly UnfinalizedPositionRecord[] = []
+const getServerSnapshot = () => EMPTY_RECORDS
+
+/**
+ * Projects the unfinalized-position cache against the indexed positions and keeps the cache pruned.
+ * Subscribing rather than reading once is what makes a zap that finishes writing after this screen mounted
+ * — the common case, since resolving the minted NFT id needs a receipt — show up without waiting for the
+ * next positions poll. Pruning runs in effects, never during render.
+ */
+const useUnfinalizedPositions = ({
+  owner,
+  positions = EMPTY_POSITIONS,
+}: {
+  owner?: string
+  positions?: readonly ParsedPosition[]
+}) => {
+  const getSnapshot = useCallback(() => getUnfinalizedPositionRecords(owner), [owner])
+  const records = useSyncExternalStore(subscribeUnfinalizedPositions, getSnapshot, getServerSnapshot)
+
+  const { placeholders, placeholderByKey, valueUpdatingKeys, staleKeys } = useMemo(
+    () => resolveUnfinalizedPositions({ records, positions, now: Date.now() }),
+    [positions, records],
+  )
+
+  useEffect(() => {
+    if (!staleKeys.length) return
+    removeUnfinalizedPositions(staleKeys, owner)
+  }, [owner, staleKeys])
+
+  // Clears entries that aged out while this screen was closed, plus any superseded cache.
+  useEffect(() => {
+    pruneUnfinalizedPositions(owner)
+  }, [owner])
+
+  // Re-runs the projection the moment the oldest entry ages out, so a placeholder cannot outlive its TTL on
+  // a screen that receives no other update.
+  useEffect(() => {
+    if (!records.length) return
+    const expiresAt = Math.min(...records.map(record => record.cachedAt + UNFINALIZED_POSITION_TTL_MS))
+    const timer = setTimeout(() => pruneUnfinalizedPositions(owner), Math.max(expiresAt - Date.now(), 0) + 50)
+    return () => clearTimeout(timer)
+  }, [owner, records])
+
+  return { placeholders, placeholderByKey, valueUpdatingKeys }
+}
+
+export default useUnfinalizedPositions

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapInWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapInWidget.tsx
@@ -23,16 +23,14 @@ import { useIsSmartAccount } from 'hooks/useIsSmartAccount'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
 import { EARN_CHAINS, EARN_DEXES, EarnChain, Exchange } from 'pages/Earns/constants'
-import { CoreProtocol } from 'pages/Earns/constants/coreProtocol'
 import { ZAPIN_DEX_MAPPING } from 'pages/Earns/constants/dexMappings'
 import useAccountChanged from 'pages/Earns/hooks/useAccountChanged'
 import { SmartExitParams } from 'pages/Earns/hooks/useSmartExitWidget'
 import useTransactionReplacement from 'pages/Earns/hooks/useTransactionReplacement'
 import { ZapMigrationInfo } from 'pages/Earns/hooks/useZapMigrationWidget'
-import { DEFAULT_PARSED_POSITION, ParsedPosition } from 'pages/Earns/types'
-import { getNftManagerContractAddress, getTokenId, submitTransaction } from 'pages/Earns/utils'
-import { getDexVersion } from 'pages/Earns/utils/position'
-import { updateUnfinalizedPosition } from 'pages/Earns/utils/unfinalizedPosition'
+import { ParsedPosition } from 'pages/Earns/types'
+import { submitTransaction } from 'pages/Earns/utils'
+import { toUnfinalizedPositionSnapshot } from 'pages/Earns/utils/unfinalizedPosition'
 import { navigateToPoolDetail, navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
 import { useKyberSwapConfig, useNotify, useWalletModalToggle } from 'state/application/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
@@ -123,9 +121,11 @@ const useZapInWidget = ({
 
   const handleNavigateToPosition = useCallback(
     async (txHash: string, chainId: number, dex: Exchange, poolId: string) => {
-      navigateToPositionAfterZap(txHash, chainId, dex, poolId, navigate)
+      // A sped-up zap confirms under a replacement hash, so resolve the minted position against the hash
+      // that actually landed — the same one the cached placeholder is keyed on.
+      navigateToPositionAfterZap(originalToCurrentHash[txHash] || txHash, chainId, dex, poolId, navigate)
     },
-    [navigate],
+    [navigate, originalToCurrentHash],
   )
 
   const handleOpenZapIn = ({ pool, positionId, initialTick }: ZapInInfo) => {
@@ -277,76 +277,8 @@ const useZapInWidget = ({
               }
             },
             onOpenZapMigration: handleOpenZapMigration,
-            onSuccess: async (data: OnSuccessProps) => {
+            onSuccess: (data: OnSuccessProps) => {
               const dex = addLiquidityPureParams.dexId
-              const isUniv2 = EARN_DEXES[dex as Exchange]?.isForkFrom === CoreProtocol.UniswapV2
-
-              const nftId =
-                data.position.positionId ||
-                (isUniv2 ? account || '' : ((await getTokenId(chainId, data.txHash, dex)) || '').toString())
-
-              const dexVersion = getDexVersion(dex)
-              const contract = getNftManagerContractAddress(dex, chainId)
-
-              updateUnfinalizedPosition(
-                {
-                  ...DEFAULT_PARSED_POSITION,
-                  positionId: !isUniv2 ? `${contract}-${nftId}` : data.position.pool.address,
-                  tokenId: !isUniv2 ? nftId : '-1',
-                  chain: {
-                    id: chainId,
-                    name: NETWORKS_INFO[chainId].name,
-                    logo: NETWORKS_INFO[chainId].icon,
-                  },
-                  dex: {
-                    id: dex,
-                    name: EARN_DEXES[dex].name,
-                    logo: data.position.dexLogo,
-                    version: dexVersion,
-                  },
-                  pool: {
-                    ...DEFAULT_PARSED_POSITION.pool,
-                    address: data.position.pool.address,
-                    fee: data.position.pool.fee,
-                    isUniv2: isUniv2,
-                  },
-                  token0: {
-                    ...DEFAULT_PARSED_POSITION.token0,
-                    address: data.position.token0.address,
-                    totalProvide: data.position.token0.amount,
-                    currentAmount: data.position.token0.amount,
-                    logo: data.position.token0.logo,
-                    symbol: data.position.token0.symbol,
-                  },
-                  token1: {
-                    ...DEFAULT_PARSED_POSITION.token1,
-                    address: data.position.token1.address,
-                    totalProvide: data.position.token1.amount,
-                    currentAmount: data.position.token1.amount,
-                    logo: data.position.token1.logo,
-                    symbol: data.position.token1.symbol,
-                  },
-                  totalValueTokens: [
-                    {
-                      address: data.position.token0.address,
-                      symbol: data.position.token0.symbol,
-                      amount: data.position.token0.amount,
-                    },
-                    {
-                      address: data.position.token1.address,
-                      symbol: data.position.token1.symbol,
-                      amount: data.position.token1.amount,
-                    },
-                  ],
-                  totalProvidedValue: data.position.value,
-                  totalValue: data.position.value,
-                  createdTime: data.position.createdAt,
-                  txHash: data.txHash,
-                  isUnfinalized: true,
-                  isValueUpdating: !!data.position.positionId,
-                },
-                account,
-              )
 
               trackingHandler(TRACKING_EVENT_TYPE.LIQ_ADD_COMPLETED, {
                 pool_pair: `${data.position.token0.symbol}/${data.position.token1.symbol}`,
@@ -370,6 +302,7 @@ const useZapInWidget = ({
                     tokensIn: Array<{ symbol: string; amount: string; logoUrl?: string }>
                     pool: string
                     dexLogo: string
+                    position?: OnSuccessProps['position']
                   }
                 | {
                     type: 'erc20_approval' | 'nft_approval' | 'nft_approval_all'
@@ -401,6 +334,7 @@ const useZapInWidget = ({
                     tokensIn: additionalInfo.tokensIn || [],
                     dexLogoUrl: additionalInfo.dexLogo,
                     dex,
+                    unfinalizedPosition: toUnfinalizedPositionSnapshot(dex, additionalInfo.position),
                   },
                 })
 

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useZapMigrationWidget.tsx
@@ -21,14 +21,11 @@ import { useActiveLocale } from 'hooks/useActiveLocale'
 import { useIsSmartAccount } from 'hooks/useIsSmartAccount'
 import useTracking, { TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { useChangeNetwork } from 'hooks/web3/useChangeNetwork'
-import { EARN_DEXES, Exchange } from 'pages/Earns/constants'
-import { CoreProtocol } from 'pages/Earns/constants/coreProtocol'
+import { Exchange } from 'pages/Earns/constants'
 import useAccountChanged from 'pages/Earns/hooks/useAccountChanged'
 import useTransactionReplacement from 'pages/Earns/hooks/useTransactionReplacement'
-import { DEFAULT_PARSED_POSITION } from 'pages/Earns/types'
-import { getNftManagerContractAddress, getTokenId, submitTransaction } from 'pages/Earns/utils'
-import { getDexVersion } from 'pages/Earns/utils/position'
-import { updateUnfinalizedPosition } from 'pages/Earns/utils/unfinalizedPosition'
+import { submitTransaction } from 'pages/Earns/utils'
+import { toUnfinalizedPositionSnapshot } from 'pages/Earns/utils/unfinalizedPosition'
 import { navigateToPoolDetail, navigateToPositionAfterZap } from 'pages/Earns/utils/zap'
 import { useKyberSwapConfig, useNotify, useWalletModalToggle } from 'state/application/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
@@ -142,9 +139,11 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
 
   const handleNavigateToPosition = useCallback(
     async (txHash: string, chainId: number, dex: Exchange, targetPoolId: string) => {
-      navigateToPositionAfterZap(txHash, chainId, dex, targetPoolId, navigate)
+      // A sped-up zap confirms under a replacement hash, so resolve the minted position against the hash
+      // that actually landed — the same one the cached placeholder is keyed on.
+      navigateToPositionAfterZap(originalToCurrentHash[txHash] || txHash, chainId, dex, targetPoolId, navigate)
     },
-    [navigate],
+    [navigate, originalToCurrentHash],
   )
 
   const handleCloseMigration = useCallback(() => {
@@ -269,6 +268,7 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
                     sourceDexLogo: string
                     destinationPool: string
                     destinationDexLogo: string
+                    position?: OnSuccessProps['position']
                   }
                 | {
                     type: 'erc20_approval' | 'nft_approval' | 'nft_approval_all'
@@ -315,6 +315,7 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
                     destinationDexLogoUrl: additionalInfo.destinationDexLogo,
                     destinationDex: destinationDex,
                     positionId: migrateLiquidityPureParams.from.positionId,
+                    unfinalizedPosition: toUnfinalizedPositionSnapshot(destinationDex, additionalInfo.position),
                   },
                 })
 
@@ -362,7 +363,7 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
             onExplorePools: () => {
               navigate(APP_PATHS.EARN_POOLS)
             },
-            onSuccess: async (data: OnSuccessProps) => {
+            onSuccess: (data: OnSuccessProps) => {
               const isReposition = migrateLiquidityPureParams.rePositionMode
               const tokenPair = `${data.position.token0.symbol}/${data.position.token1.symbol}`
               trackingHandler(
@@ -382,75 +383,6 @@ const useZapMigrationWidget = (onRefreshPosition?: () => void) => {
                         source_pool_address: migrateLiquidityPureParams.from.poolAddress,
                       }),
                 },
-              )
-
-              const dex = migrateLiquidityPureParams.to?.dexId || migrateLiquidityPureParams.from.dexId
-              const isUniv2 = EARN_DEXES[dex as Exchange]?.isForkFrom === CoreProtocol.UniswapV2
-
-              const nftId =
-                data.position.positionId ||
-                (isUniv2 ? account || '' : ((await getTokenId(chainId, data.txHash, dex)) || '').toString())
-
-              const dexVersion = getDexVersion(dex)
-              const contract = getNftManagerContractAddress(dex, chainId)
-
-              updateUnfinalizedPosition(
-                {
-                  ...DEFAULT_PARSED_POSITION,
-                  positionId: !isUniv2 ? `${contract}-${nftId}` : data.position.pool.address,
-                  tokenId: data.position.positionId || '',
-                  chain: {
-                    id: chainId,
-                    name: NETWORKS_INFO[chainId].name,
-                    logo: NETWORKS_INFO[chainId].icon,
-                  },
-                  dex: {
-                    id: dex,
-                    name: EARN_DEXES[dex].name,
-                    logo: data.position.dexLogo,
-                    version: dexVersion,
-                  },
-                  pool: {
-                    ...DEFAULT_PARSED_POSITION.pool,
-                    address: data.position.pool.address,
-                    fee: data.position.pool.fee,
-                  },
-                  token0: {
-                    ...DEFAULT_PARSED_POSITION.token0,
-                    address: data.position.token0.address,
-                    totalProvide: data.position.token0.amount,
-                    currentAmount: data.position.token0.amount,
-                    logo: data.position.token0.logo,
-                    symbol: data.position.token0.symbol,
-                  },
-                  token1: {
-                    ...DEFAULT_PARSED_POSITION.token1,
-                    address: data.position.token1.address,
-                    totalProvide: data.position.token1.amount,
-                    currentAmount: data.position.token1.amount,
-                    logo: data.position.token1.logo,
-                    symbol: data.position.token1.symbol,
-                  },
-                  totalValueTokens: [
-                    {
-                      address: data.position.token0.address,
-                      symbol: data.position.token0.symbol,
-                      amount: data.position.token0.amount,
-                    },
-                    {
-                      address: data.position.token1.address,
-                      symbol: data.position.token1.symbol,
-                      amount: data.position.token1.amount,
-                    },
-                  ],
-                  totalProvidedValue: data.position.value,
-                  totalValue: data.position.value,
-                  createdTime: data.position.createdAt,
-                  txHash: data.txHash,
-                  isUnfinalized: true,
-                  isValueUpdating: !!migrateLiquidityPureParams.to?.positionId,
-                },
-                account,
               )
             },
           }

--- a/apps/kyberswap-interface/src/pages/Earns/utils/index.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/utils/index.ts
@@ -1,13 +1,13 @@
 import { Token } from '@kyber/schema'
 import { ChainId, WETH } from '@kyberswap/ks-sdk-core'
-import { getPublicClient } from '@wagmi/core'
+import { getPublicClient, waitForTransactionReceipt } from '@wagmi/core'
 
 import { wagmiConfig } from 'components/Web3Provider'
 import { EARN_CHAINS, EARN_DEXES, EarnChain, Exchange } from 'pages/Earns/constants'
 import { CoreProtocol } from 'pages/Earns/constants/coreProtocol'
 import { sendEVMTransaction } from 'utils/sendTransaction'
 import { BlacklistedWalletError, ErrorName } from 'utils/transactionError'
-import { Hash, keccak256, toBytes } from 'utils/viem'
+import { Hash, Log, keccak256, toBytes } from 'utils/viem'
 
 type LegacyTransactionRequest = {
   from?: string
@@ -17,46 +17,109 @@ type LegacyTransactionRequest = {
   gasLimit?: string | number | bigint
 }
 
-export const getTokenId = async (chainId: number, txHash: string, exchange: Exchange) => {
-  try {
-    const publicClient = getPublicClient(wagmiConfig, { chainId })
-    if (!publicClient) return
+// A zap resolves its minted id from two places at once — the placeholder cache write and the "View
+// position" navigation — so the in-flight lookup is shared: one round trip, and both read the same id.
+// Failed lookups are evicted so a later attempt can retry, and the map is capped because a long-lived tab
+// would otherwise retain every receipt's logs.
+const receiptLogsByTx = new Map<string, Promise<readonly Log[] | undefined>>()
+const RECEIPT_CACHE_LIMIT = 32
 
-    const receipt = await publicClient.getTransactionReceipt({ hash: txHash as Hash })
-    if (!receipt || !receipt.logs) return
+// Waiting is only worth it for a zap that was just mined, where a fallback RPC may not have caught up with
+// the block yet. Callers describing an arbitrary past transaction ask for a single lookup instead, so a
+// pending or foreign-chain hash resolves to nothing immediately rather than holding a poll open.
+const RECEIPT_TIMEOUT_MS = 20_000
+const RECEIPT_POLLING_INTERVAL_MS = 2_000
+const RECEIPT_RETRY_COUNT = 3
 
-    const isUniV4 = EARN_DEXES[exchange].isForkFrom === CoreProtocol.UniswapV4
-
-    let hexTokenId
-    if (!isUniV4) {
-      const isQuickSwapV3 = exchange === Exchange.DEX_QUICKSWAPV3ALGEBRA
-      const increaseLidEventTopic = keccak256(
-        toBytes(
-          !isQuickSwapV3
-            ? 'IncreaseLiquidity(uint256,uint128,uint256,uint256)'
-            : 'IncreaseLiquidity(uint256,uint128,uint128,uint256,uint256,address)',
-        ),
-      )
-      const increaseLidLogs = receipt.logs.filter((log: any) => log.topics[0] === increaseLidEventTopic)
-      const increaseLidEvent = increaseLidLogs?.length ? increaseLidLogs[0] : undefined
-      hexTokenId = increaseLidEvent?.topics?.[1]
-    } else {
-      const transferEventTopic = keccak256(toBytes('Transfer(address,address,uint256)'))
-      const transferLogsWithTokenId = receipt.logs.filter(
-        (log: any) => log.topics[0] === transferEventTopic && log.topics.length === 4,
-      )
-      hexTokenId = !transferLogsWithTokenId.length
-        ? undefined
-        : transferLogsWithTokenId[transferLogsWithTokenId.length - 1].topics[3]
-    }
-    if (!hexTokenId) return
-    // Use BigInt to preserve precision past 2^53. Callers stringify immediately
-    // (e.g. `getTokenId(...).toString()`), so returning a numeric string is safe.
-    return BigInt(hexTokenId).toString()
-  } catch (error) {
-    console.log('getTokenId error', error)
-    return
+const readReceiptLogs = async (chainId: number, txHash: string, waitForMined: boolean) => {
+  const client = getPublicClient(wagmiConfig, { chainId })
+  if (!waitForMined) {
+    if (!client) return undefined
+    const receipt = await client.getTransactionReceipt({ hash: txHash as Hash })
+    return receipt.logs as readonly Log[]
   }
+
+  const receipt = await waitForTransactionReceipt(wagmiConfig, {
+    chainId: chainId as (typeof wagmiConfig)['chains'][number]['id'],
+    hash: txHash as Hash,
+    pollingInterval: RECEIPT_POLLING_INTERVAL_MS,
+    retryCount: RECEIPT_RETRY_COUNT,
+    timeout: RECEIPT_TIMEOUT_MS,
+  })
+  return receipt.logs as readonly Log[]
+}
+
+const getReceiptLogs = (
+  chainId: number,
+  txHash: string,
+  waitForMined: boolean,
+): Promise<readonly Log[] | undefined> => {
+  // The two modes are cached apart so a single lookup that missed cannot satisfy a caller that is willing
+  // to wait for the block to land.
+  const cacheKey = `${chainId}:${txHash.toLowerCase()}:${waitForMined ? 'wait' : 'once'}`
+  const cached = receiptLogsByTx.get(cacheKey)
+  if (cached) return cached
+
+  const pending = readReceiptLogs(chainId, txHash, waitForMined).catch(error => {
+    console.error('Failed to read transaction receipt', error)
+    receiptLogsByTx.delete(cacheKey)
+    return undefined
+  })
+
+  if (receiptLogsByTx.size >= RECEIPT_CACHE_LIMIT) {
+    const oldest = receiptLogsByTx.keys().next().value
+    if (oldest) receiptLogsByTx.delete(oldest)
+  }
+  receiptLogsByTx.set(cacheKey, pending)
+  return pending
+}
+
+const increaseLiquidityTopic = keccak256(toBytes('IncreaseLiquidity(uint256,uint128,uint256,uint256)'))
+// Algebra position managers (QuickSwap V3, Thena, Camelot V3) widen the event with actualLiquidity + pool.
+const algebraIncreaseLiquidityTopic = keccak256(
+  toBytes('IncreaseLiquidity(uint256,uint128,uint128,uint256,uint256,address)'),
+)
+const transferTopic = keccak256(toBytes('Transfer(address,address,uint256)'))
+
+/**
+ * The NFT id minted by a position-opening transaction. Pass `waitForMined` for a transaction that was just
+ * sent, to ride out an RPC that has not seen the block yet.
+ */
+export const getTokenId = async (
+  chainId: number,
+  txHash: string,
+  exchange: Exchange,
+  { waitForMined = false }: { waitForMined?: boolean } = {},
+) => {
+  const logs = await getReceiptLogs(chainId, txHash, waitForMined)
+  if (!logs) return
+
+  const { isForkFrom } = EARN_DEXES[exchange]
+  // Only the position manager mints the position NFT, so same-shaped events from the zap router, a hook or
+  // a farming contract in the same receipt are ignored. A configured address that does not match any
+  // emitter tells us nothing, so fall back to scanning the whole receipt rather than reporting no id.
+  const nftManager = getNftManagerContractAddress(exchange, chainId)?.toLowerCase()
+  const managerLogs = nftManager ? logs.filter(log => log.address.toLowerCase() === nftManager) : []
+  const nftManagerLogs = managerLogs.length ? managerLogs : logs
+
+  let hexTokenId: string | undefined
+  if (isForkFrom === CoreProtocol.UniswapV4) {
+    // V4-style managers emit no IncreaseLiquidity; the mint is the ERC-721 Transfer whose indexed tokenId
+    // is topics[3].
+    const transferLogs = nftManagerLogs.filter(log => log.topics[0] === transferTopic && log.topics.length === 4)
+    hexTokenId = transferLogs[transferLogs.length - 1]?.topics[3]
+  } else {
+    const topic =
+      isForkFrom === CoreProtocol.AlgebraV1 || isForkFrom === CoreProtocol.AlgebraV19
+        ? algebraIncreaseLiquidityTopic
+        : increaseLiquidityTopic
+    hexTokenId = nftManagerLogs.find(log => log.topics[0] === topic)?.topics[1]
+  }
+  if (!hexTokenId) return
+
+  // Use BigInt to preserve precision past 2^53. Callers stringify immediately
+  // (e.g. `getTokenId(...).toString()`), so returning a numeric string is safe.
+  return BigInt(hexTokenId).toString()
 }
 
 export const isNativeToken = (tokenAddress: string, chainId: keyof typeof WETH) =>

--- a/apps/kyberswap-interface/src/pages/Earns/utils/unfinalizedPosition.test.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/utils/unfinalizedPosition.test.ts
@@ -1,0 +1,283 @@
+import { ChainId } from '@kyberswap/ks-sdk-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Exchange } from 'pages/Earns/constants'
+import { DEFAULT_PARSED_POSITION, ParsedPosition } from 'pages/Earns/types'
+import {
+  UNFINALIZED_POSITION_TTL_MS,
+  UnfinalizedPositionInput,
+  getUnfinalizedPositionKey,
+  getUnfinalizedPositionKeyFromPosition,
+  getUnfinalizedPositionKeyFromRoute,
+  getUnfinalizedPositionRecords,
+  pruneUnfinalizedPositions,
+  resolveUnfinalizedPositions,
+  updateUnfinalizedPosition,
+} from 'pages/Earns/utils/unfinalizedPosition'
+
+const OWNER = '0x1111111111111111111111111111111111111111'
+const POOL = '0x2222222222222222222222222222222222222222'
+const NFT_DEX = Exchange.DEX_UNISWAPV3
+const UNIV2_DEX = Exchange.DEX_UNISWAPV2
+
+const createStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => void store.delete(key),
+    setItem: (key: string, value: string) => void store.set(key, value),
+  } as Storage
+}
+
+const input = (overrides: Partial<UnfinalizedPositionInput> = {}): UnfinalizedPositionInput => ({
+  chainId: ChainId.MAINNET,
+  dexId: NFT_DEX,
+  dexLogo: 'dex.png',
+  poolAddress: POOL,
+  poolFee: 0.3,
+  tokenId: '123',
+  txHash: '0xabc',
+  value: 1000,
+  createdAt: Date.now(),
+  isValueUpdating: false,
+  token0: { address: '0xaaa', symbol: 'A', logo: 'a.png', amount: 1, decimals: 6 },
+  token1: { address: '0xbbb', symbol: 'B', logo: 'b.png', amount: 2, decimals: 8 },
+  ...overrides,
+})
+
+const indexedPosition = (overrides: Partial<ParsedPosition> = {}): ParsedPosition => ({
+  ...DEFAULT_PARSED_POSITION,
+  positionId: `0xnft-123`,
+  tokenId: '123',
+  chain: { ...DEFAULT_PARSED_POSITION.chain, id: ChainId.MAINNET },
+  dex: { ...DEFAULT_PARSED_POSITION.dex, id: NFT_DEX },
+  pool: { ...DEFAULT_PARSED_POSITION.pool, address: POOL },
+  ...overrides,
+})
+
+const resolve = (positions: ParsedPosition[] = [], now = Date.now()) =>
+  resolveUnfinalizedPositions({ records: getUnfinalizedPositionRecords(OWNER), positions, now })
+
+describe('unfinalized position cache', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      localStorage: createStorage(),
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })
+  })
+
+  describe('keys', () => {
+    it('matches a cached NFT position with its indexed row', () => {
+      const cached = getUnfinalizedPositionKey({ chainId: ChainId.MAINNET, dexId: NFT_DEX, tokenId: '123' })
+      expect(getUnfinalizedPositionKeyFromPosition(indexedPosition())).toBe(cached)
+    })
+
+    it('rebuilds the key of an NFT position from its detail route', () => {
+      expect(
+        getUnfinalizedPositionKeyFromRoute({
+          chainId: String(ChainId.MAINNET),
+          dexId: NFT_DEX,
+          positionId: '0x1234567890123456789012345678901234567890-123',
+        }),
+      ).toBe(getUnfinalizedPositionKey({ chainId: ChainId.MAINNET, dexId: NFT_DEX, tokenId: '123' }))
+    })
+
+    it('rebuilds the key of a UniV2 pair from its detail route, which carries the pool address', () => {
+      expect(getUnfinalizedPositionKeyFromRoute({ chainId: ChainId.MAINNET, dexId: UNIV2_DEX, positionId: POOL })).toBe(
+        getUnfinalizedPositionKey({ chainId: ChainId.MAINNET, dexId: UNIV2_DEX, poolAddress: POOL }),
+      )
+    })
+
+    it('separates positions that share a token id across chains and dexes', () => {
+      const base = { dexId: NFT_DEX, tokenId: '123' }
+      expect(getUnfinalizedPositionKey({ ...base, chainId: ChainId.MAINNET })).not.toBe(
+        getUnfinalizedPositionKey({ ...base, chainId: ChainId.BASE }),
+      )
+      expect(getUnfinalizedPositionKey({ ...base, chainId: ChainId.MAINNET })).not.toBe(
+        getUnfinalizedPositionKey({ chainId: ChainId.MAINNET, dexId: Exchange.DEX_PANCAKESWAPV3, tokenId: '123' }),
+      )
+    })
+
+    it('keeps token ids beyond 2^53 distinct', () => {
+      const first = getUnfinalizedPositionKey({ chainId: 1, dexId: NFT_DEX, tokenId: '9007199254740993' })
+      const second = getUnfinalizedPositionKey({ chainId: 1, dexId: NFT_DEX, tokenId: '9007199254740992' })
+      expect(first).not.toBe(second)
+    })
+
+    it('refuses to address an NFT position whose token id is missing or a UniV2 placeholder id', () => {
+      expect(getUnfinalizedPositionKey({ chainId: 1, dexId: NFT_DEX, tokenId: '' })).toBeUndefined()
+      expect(getUnfinalizedPositionKey({ chainId: 1, dexId: NFT_DEX, tokenId: '0' })).toBeUndefined()
+    })
+  })
+
+  describe('writing', () => {
+    it('stores a position that can be addressed', () => {
+      expect(updateUnfinalizedPosition(input(), OWNER)).toBe(true)
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(1)
+    })
+
+    it('refuses an NFT position whose minted id could not be resolved', () => {
+      expect(updateUnfinalizedPosition(input({ tokenId: undefined }), OWNER)).toBe(false)
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(0)
+    })
+
+    it('stores a UniV2 pair, which has no token id', () => {
+      expect(updateUnfinalizedPosition(input({ dexId: UNIV2_DEX, tokenId: undefined }), OWNER)).toBe(true)
+      expect(getUnfinalizedPositionRecords(OWNER)[0].positionId).toBe(POOL)
+    })
+
+    it('ignores a write with no owner, so one wallet cannot leak into another session', () => {
+      expect(updateUnfinalizedPosition(input(), undefined)).toBe(false)
+    })
+
+    it('replaces an entry for the same position rather than duplicating it', () => {
+      updateUnfinalizedPosition(input({ value: 1000 }), OWNER)
+      updateUnfinalizedPosition(input({ value: 2000 }), OWNER)
+      const records = getUnfinalizedPositionRecords(OWNER)
+      expect(records).toHaveLength(1)
+      expect(records[0].value).toBe(2000)
+    })
+
+    it('times out from the write, so an increase on an old position still gets its full window', () => {
+      const createdAt = Date.now() - 400 * 24 * 60 * 60 * 1000
+      updateUnfinalizedPosition(input({ createdAt, isValueUpdating: true }), OWNER)
+      expect(resolve([]).placeholderByKey.size).toBe(1)
+    })
+  })
+
+  describe('reading', () => {
+    it('shows a placeholder until the indexer returns the position', () => {
+      updateUnfinalizedPosition(input(), OWNER)
+      expect(resolve([]).placeholders).toHaveLength(1)
+
+      const { placeholders, staleKeys } = resolve([indexedPosition()])
+      expect(placeholders).toHaveLength(0)
+      expect(staleKeys).toHaveLength(1)
+    })
+
+    it('does not persist indexed data back onto the cached entry', () => {
+      const createdAt = Date.now() - 60_000
+      updateUnfinalizedPosition(input({ createdAt, txHash: '0xzap', isValueUpdating: true }), OWNER)
+      resolve([indexedPosition({ totalProvidedValue: 1 })])
+
+      const [record] = getUnfinalizedPositionRecords(OWNER)
+      expect(record.createdAt).toBe(createdAt)
+      expect(record.txHash).toBe('0xzap')
+    })
+
+    it('keeps an increase-liquidity entry while the indexed value is still stale', () => {
+      updateUnfinalizedPosition(input({ value: 1000, isValueUpdating: true }), OWNER)
+      const { valueUpdatingKeys, staleKeys } = resolve([indexedPosition({ totalProvidedValue: 400 })])
+      expect(valueUpdatingKeys.size).toBe(1)
+      expect(staleKeys).toHaveLength(0)
+    })
+
+    it('drops an increase-liquidity entry once the indexed value has caught up', () => {
+      updateUnfinalizedPosition(input({ value: 1000, isValueUpdating: true }), OWNER)
+      const { valueUpdatingKeys, staleKeys } = resolve([indexedPosition({ totalProvidedValue: 1000 })])
+      expect(valueUpdatingKeys.size).toBe(0)
+      expect(staleKeys).toHaveLength(1)
+    })
+
+    it('keeps an increase-liquidity entry when the indexed value reads zero', () => {
+      updateUnfinalizedPosition(input({ value: 1000, isValueUpdating: true }), OWNER)
+      const { valueUpdatingKeys, staleKeys } = resolve([indexedPosition({ totalProvidedValue: 0 })])
+      expect(valueUpdatingKeys.size).toBe(1)
+      expect(staleKeys).toHaveLength(0)
+    })
+
+    it('addresses the right entry when several zaps are pending', () => {
+      updateUnfinalizedPosition(input({ tokenId: '111' }), OWNER)
+      updateUnfinalizedPosition(input({ tokenId: '222' }), OWNER)
+
+      const { placeholderByKey } = resolve([])
+      const firstKey = getUnfinalizedPositionKey({ chainId: ChainId.MAINNET, dexId: NFT_DEX, tokenId: '111' })
+      expect(placeholderByKey.get(firstKey as string)?.tokenId).toBe('111')
+    })
+
+    it('does not let a UniV2 row finalize an unrelated NFT entry', () => {
+      updateUnfinalizedPosition(input({ tokenId: '123' }), OWNER)
+      const univ2Row = indexedPosition({ dex: { ...DEFAULT_PARSED_POSITION.dex, id: UNIV2_DEX }, tokenId: '0' })
+      expect(resolve([univ2Row]).staleKeys).toHaveLength(0)
+    })
+
+    it('expires an entry once its window has passed', () => {
+      updateUnfinalizedPosition(input(), OWNER)
+      const { placeholders, staleKeys } = resolve([], Date.now() + UNFINALIZED_POSITION_TTL_MS + 1)
+      expect(placeholders).toHaveLength(0)
+      expect(staleKeys).toHaveLength(1)
+    })
+
+    it('renders a placeholder carrying the amounts the zap reported', () => {
+      updateUnfinalizedPosition(input(), OWNER)
+      const [placeholder] = resolve([]).placeholders
+      expect(placeholder.isUnfinalized).toBe(true)
+      expect(placeholder.token0.symbol).toBe('A')
+      expect(placeholder.token0.decimals).toBe(6)
+      expect(placeholder.totalProvidedValue).toBe(1000)
+    })
+
+    it('returns the newest zap first', () => {
+      updateUnfinalizedPosition(input({ tokenId: '111' }), OWNER)
+      updateUnfinalizedPosition(input({ tokenId: '222' }), OWNER)
+      expect(resolve([]).placeholders[0].tokenId).toBe('222')
+    })
+  })
+
+  describe('hygiene', () => {
+    const write = (raw: string) =>
+      window.localStorage.setItem(`kyber_earn_unfinalized_positions_v2_${OWNER.toLowerCase()}`, raw)
+
+    it('ignores malformed json', () => {
+      write('{oops')
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(0)
+    })
+
+    it('ignores json that is not an array', () => {
+      write('{"key":"a"}')
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(0)
+    })
+
+    it('discards entries of a foreign shape instead of rendering them', () => {
+      write(JSON.stringify([{ positionId: '0x1', tokenId: '1', chain: { id: 1 } }]))
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(0)
+      expect(() => resolve([])).not.toThrow()
+    })
+
+    it('discards entries naming a chain or dex the app does not support', () => {
+      updateUnfinalizedPosition(input(), OWNER)
+      const [record] = getUnfinalizedPositionRecords(OWNER)
+      write(JSON.stringify([{ ...record, chainId: 999_999 }]))
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(0)
+
+      write(JSON.stringify([{ ...record, dexId: 'not-a-dex' }]))
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(0)
+    })
+
+    it('returns a stable reference while storage is unchanged', () => {
+      updateUnfinalizedPosition(input(), OWNER)
+      expect(getUnfinalizedPositionRecords(OWNER)).toBe(getUnfinalizedPositionRecords(OWNER))
+    })
+
+    it('keeps each wallet in its own bucket', () => {
+      const other = '0x9999999999999999999999999999999999999999'
+      updateUnfinalizedPosition(input(), OWNER)
+      expect(getUnfinalizedPositionRecords(other)).toHaveLength(0)
+    })
+
+    it('clears entries left by a superseded cache shape', () => {
+      window.localStorage.setItem(`kyber_earn_unfinalized_positions_${OWNER.toLowerCase()}`, '[{"tokenId":"1"}]')
+      updateUnfinalizedPosition(input(), OWNER)
+      pruneUnfinalizedPositions(OWNER)
+
+      expect(window.localStorage.getItem(`kyber_earn_unfinalized_positions_${OWNER.toLowerCase()}`)).toBeNull()
+      expect(getUnfinalizedPositionRecords(OWNER)).toHaveLength(1)
+    })
+  })
+})

--- a/apps/kyberswap-interface/src/pages/Earns/utils/unfinalizedPosition.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/utils/unfinalizedPosition.ts
@@ -1,125 +1,546 @@
-import { ParsedPosition } from 'pages/Earns/types'
+import { NETWORKS_INFO, isSupportedChainId } from 'constants/networks'
+import { EARN_CHAINS, EARN_DEXES, EarnChain, Exchange, isSupportedExchange } from 'pages/Earns/constants'
+import { CoreProtocol } from 'pages/Earns/constants/coreProtocol'
+import { DEFAULT_PARSED_POSITION, ParsedPosition } from 'pages/Earns/types'
+import { getNftManagerContractAddress } from 'pages/Earns/utils'
+import { getDexVersion } from 'pages/Earns/utils/position'
+import type { UnfinalizedPositionSnapshot } from 'state/transactions/type'
 
-const CACHE_EXPIRY_MS = 5 * 60 * 1000 // 5 minutes
-const CACHE_KEY_PREFIX = 'kyber_earn_unfinalized_positions'
+/**
+ * A zap is confirmed on chain before the backend indexes it. Until it does, the positions list and the
+ * position detail page render a locally authored placeholder so the user sees the position they just
+ * created. This module owns that cache: what is persisted, how an entry is matched against indexed data,
+ * and when an entry stops being relevant.
+ */
 
-const getCacheKey = (owner?: string) => {
-  if (!owner) return CACHE_KEY_PREFIX
-  return `${CACHE_KEY_PREFIX}_${owner.toLowerCase()}`
+/** How long a placeholder survives when the indexer never catches up, measured from write time. */
+export const UNFINALIZED_POSITION_TTL_MS = 5 * 60 * 1000
+
+// An increase-liquidity placeholder is dropped once the indexed value lands within this relative distance
+// of the value the zap reported, i.e. the added liquidity has been picked up.
+const VALUE_MATCH_TOLERANCE = 0.01
+
+const STORAGE_KEY_PREFIX = 'kyber_earn_unfinalized_positions_v2'
+// Entries under this prefix hold a superseded record shape. Note the current prefix also starts with it.
+const LEGACY_STORAGE_KEY_PREFIX = 'kyber_earn_unfinalized_positions'
+
+export interface UnfinalizedPositionTokenInput {
+  address: string
+  symbol: string
+  logo: string
+  amount: number
+  decimals?: number
 }
 
-export const updateUnfinalizedPosition = (data: ParsedPosition, owner?: string) => {
-  try {
-    const cacheKey = getCacheKey(owner)
-    const storedData = localStorage.getItem(cacheKey)
-    let positions: ParsedPosition[] = []
+export interface UnfinalizedPositionInput {
+  chainId: number
+  dexId: Exchange
+  dexLogo?: string
+  poolAddress: string
+  poolFee: number
+  /** The minted NFT id. Required for NFT positions, unused for UniV2 pairs. */
+  tokenId?: string
+  txHash: string
+  value: number
+  createdAt: number
+  isValueUpdating: boolean
+  token0: UnfinalizedPositionTokenInput
+  token1: UnfinalizedPositionTokenInput
+}
 
-    if (storedData) {
-      try {
-        positions = JSON.parse(storedData)
-        if (!Array.isArray(positions)) {
-          positions = []
-        }
-      } catch (error) {
-        console.warn('Failed to parse stored unfinalized positions:', error)
-        positions = []
-      }
-    }
+interface UnfinalizedPositionToken {
+  address: string
+  symbol: string
+  logo: string
+  amount: number
+  decimals: number
+}
 
-    const now = Date.now()
+export interface UnfinalizedPositionRecord {
+  key: string
+  positionId: string
+  chainId: number
+  dexId: Exchange
+  dexLogo: string
+  poolAddress: string
+  poolFee: number
+  tokenId: string
+  txHash: string
+  value: number
+  /** When the position was created on chain. */
+  createdAt: number
+  /** Wall clock at write time; the only input to the TTL. */
+  cachedAt: number
+  isValueUpdating: boolean
+  token0: UnfinalizedPositionToken
+  token1: UnfinalizedPositionToken
+}
 
-    // Remove expired positions (older than 5 minutes)
-    positions = positions.filter(position => {
-      const isExpired = now - position.createdTime > CACHE_EXPIRY_MS
-      return !isExpired
-    })
+/** The shape every zap widget reports for the position its route produces. */
+interface WidgetPosition {
+  positionId?: string
+  chainId: number
+  dexLogo: string
+  pool: { address: string; fee: number }
+  token0: { address: string; symbol: string; logo: string; amount: number; decimals?: number }
+  token1: { address: string; symbol: string; logo: string; amount: number; decimals?: number }
+  value: number
+  createdAt: number
+}
 
-    // Check if position already exists (by txHash)
-    const existingIndex = positions.findIndex(pos => pos.txHash === data.txHash)
+export interface ResolvedUnfinalizedPositions {
+  /** Placeholder rows for positions the indexer has not returned yet, newest first. */
+  placeholders: ParsedPosition[]
+  /** Every live placeholder addressable by key, including increase-liquidity ones. */
+  placeholderByKey: Map<string, ParsedPosition>
+  /** Keys whose indexed row exists but still reports a pre-zap value. */
+  valueUpdatingKeys: Set<string>
+  /** Keys that expired or finalized and can be dropped from storage. */
+  staleKeys: string[]
+}
 
-    if (existingIndex >= 0) {
-      positions[existingIndex] = data
-    } else {
-      positions.push(data)
-    }
+const isFiniteNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value)
 
-    localStorage.setItem(cacheKey, JSON.stringify(positions))
-  } catch (error) {
-    console.error('Failed to update unfinalized position:', error)
+const isUniv2Dex = (dexId: Exchange) => EARN_DEXES[dexId].isForkFrom === CoreProtocol.UniswapV2
+
+// NFT managers mint from 1, so '0' never identifies a position — it is what `parsePosition` falls back to
+// for UniV2 rows, which would otherwise collide with an NFT entry that failed to resolve its id.
+const normalizeTokenId = (tokenId?: string | number): string | undefined => {
+  const raw = tokenId === undefined || tokenId === null ? '' : tokenId.toString().trim()
+  if (!raw || raw === '0') return undefined
+  // Ids are uint256, so compare them as canonical decimal strings rather than as numbers.
+  return /^\d+$/.test(raw) ? raw.replace(/^0+(?=\d)/, '') : raw.toLowerCase()
+}
+
+/**
+ * Identity shared by a cached placeholder and its indexed row. NFT positions are unique per
+ * (chain, dex, NFT id); UniV2 pairs have no NFT, and a wallet holds a single LP balance per pool, so they
+ * key on the pool address. Returns undefined when the position is not addressable yet.
+ */
+export const getUnfinalizedPositionKey = ({
+  chainId,
+  dexId,
+  poolAddress,
+  tokenId,
+}: {
+  chainId: number
+  dexId: Exchange
+  poolAddress?: string
+  tokenId?: string
+}): string | undefined => {
+  if (!isSupportedChainId(chainId) || !isSupportedExchange(dexId)) return undefined
+
+  if (isUniv2Dex(dexId)) {
+    const pool = poolAddress?.trim().toLowerCase()
+    return pool ? `${chainId}:${dexId.toLowerCase()}:v2:${pool}` : undefined
+  }
+
+  const normalizedTokenId = normalizeTokenId(tokenId)
+  return normalizedTokenId ? `${chainId}:${dexId.toLowerCase()}:nft:${normalizedTokenId}` : undefined
+}
+
+export const getUnfinalizedPositionKeyFromPosition = (position: ParsedPosition) =>
+  getUnfinalizedPositionKey({
+    chainId: position.chain.id,
+    dexId: position.dex.id,
+    poolAddress: position.pool.address,
+    tokenId: position.tokenId,
+  })
+
+/**
+ * The position-detail route carries `<nftManager>-<tokenId>` for NFT positions and the pool address for
+ * UniV2 pairs, so the key can be rebuilt from the URL alone, before any indexed data has arrived.
+ */
+export const getUnfinalizedPositionKeyFromRoute = ({
+  chainId,
+  dexId,
+  positionId,
+}: {
+  chainId?: number | string
+  dexId?: string
+  positionId?: string
+}): string | undefined => {
+  const parsedChainId = Number(chainId)
+  if (!isSupportedChainId(parsedChainId) || !isSupportedExchange(dexId) || !positionId) return undefined
+
+  const exchange = dexId as Exchange
+  return getUnfinalizedPositionKey({
+    chainId: parsedChainId,
+    dexId: exchange,
+    poolAddress: positionId,
+    tokenId: isUniv2Dex(exchange) ? undefined : positionId.split('-')[1],
+  })
+}
+
+const sanitizeToken = (value: unknown): UnfinalizedPositionToken | undefined => {
+  if (!value || typeof value !== 'object') return undefined
+  const token = value as Partial<UnfinalizedPositionToken>
+  if (typeof token.address !== 'string' || !isFiniteNumber(token.amount)) return undefined
+
+  return {
+    address: token.address,
+    symbol: typeof token.symbol === 'string' ? token.symbol : '',
+    logo: typeof token.logo === 'string' ? token.logo : '',
+    amount: token.amount,
+    decimals: isFiniteNumber(token.decimals) ? token.decimals : DEFAULT_PARSED_POSITION.token0.decimals,
   }
 }
 
-export const getUnfinalizedPositions = (positionsFromData: ParsedPosition[], owner?: string): ParsedPosition[] => {
-  try {
-    const cacheKey = getCacheKey(owner)
-    const storedData = localStorage.getItem(cacheKey)
-    if (!storedData) {
-      return []
-    }
+// Entries can predate a release or be truncated by a storage quota error, and a malformed one reaching the
+// positions list would take the route down, so anything that does not type-check is discarded.
+const sanitizeRecord = (value: unknown): UnfinalizedPositionRecord | undefined => {
+  if (!value || typeof value !== 'object') return undefined
+  const record = value as Partial<UnfinalizedPositionRecord>
+  const token0 = sanitizeToken(record.token0)
+  const token1 = sanitizeToken(record.token1)
 
-    let positions: ParsedPosition[] = []
-    try {
-      positions = JSON.parse(storedData)
-      if (!Array.isArray(positions)) {
-        return []
-      }
-    } catch (error) {
-      console.warn('Failed to parse stored unfinalized positions:', error)
-      return []
-    }
+  if (
+    !token0 ||
+    !token1 ||
+    typeof record.key !== 'string' ||
+    !record.key ||
+    typeof record.positionId !== 'string' ||
+    !isSupportedExchange(record.dexId) ||
+    !isSupportedChainId(record.chainId) ||
+    !isFiniteNumber(record.cachedAt) ||
+    !isFiniteNumber(record.value)
+  )
+    return undefined
 
-    const now = Date.now()
-
-    // Filter out expired positions
-    const validPositions = positions
-      .filter(position => {
-        const isExpired = now - position.createdTime > CACHE_EXPIRY_MS
-        const existingPosition = positionsFromData.find(p => Number(p.tokenId) === Number(position.tokenId))
-        const isValueDifferent = existingPosition
-          ? Math.abs(existingPosition.totalProvidedValue - position.totalProvidedValue) /
-              existingPosition.totalProvidedValue >
-            0.01
-          : position.isValueUpdating
-          ? true
-          : false
-        const isDataUpdated = !position.isValueUpdating ? !!existingPosition : !isValueDifferent
-
-        return !isExpired && !isDataUpdated
-      })
-      .map(position => {
-        const existingPosition = positionsFromData.find(p => Number(p.tokenId) === Number(position.tokenId))
-
-        if (existingPosition)
-          return {
-            ...existingPosition,
-            token0: {
-              ...existingPosition.token0,
-              totalProvide: position.token0.totalProvide,
-            },
-            token1: {
-              ...existingPosition.token1,
-              totalProvide: position.token1.totalProvide,
-            },
-            totalValueTokens: existingPosition.totalValueTokens.map(token => ({
-              ...token,
-              amount: position.totalValueTokens.find(t => t.address === token.address)?.amount || token.amount,
-            })),
-            totalProvidedValue: position.totalProvidedValue,
-            totalValue: position.totalValue,
-            isValueUpdating: true,
-          }
-
-        return position
-      })
-
-    // If we filtered out some positions, update localStorage
-    if (validPositions.length !== positions.length) {
-      localStorage.setItem(cacheKey, JSON.stringify(validPositions))
-    }
-
-    return validPositions.reverse()
-  } catch (error) {
-    console.error('Failed to get unfinalized positions:', error)
-    return []
+  return {
+    key: record.key,
+    positionId: record.positionId,
+    chainId: record.chainId,
+    dexId: record.dexId as Exchange,
+    dexLogo: typeof record.dexLogo === 'string' ? record.dexLogo : '',
+    poolAddress: typeof record.poolAddress === 'string' ? record.poolAddress : '',
+    poolFee: isFiniteNumber(record.poolFee) ? record.poolFee : 0,
+    tokenId: typeof record.tokenId === 'string' ? record.tokenId : '',
+    txHash: typeof record.txHash === 'string' ? record.txHash : '',
+    value: record.value,
+    createdAt: isFiniteNumber(record.createdAt) ? record.createdAt : record.cachedAt,
+    cachedAt: record.cachedAt,
+    isValueUpdating: record.isValueUpdating === true,
+    token0,
+    token1,
   }
+}
+
+/**
+ * Maps what a zap widget reports about the position it is creating onto the snapshot carried by the
+ * transaction. Returns undefined when the widget could not describe the position, in which case the zap
+ * simply gets no placeholder.
+ */
+export const toUnfinalizedPositionSnapshot = (
+  dexId: Exchange,
+  position?: WidgetPosition,
+): UnfinalizedPositionSnapshot | undefined =>
+  position
+    ? {
+        chainId: position.chainId,
+        dex: dexId,
+        dexLogo: position.dexLogo,
+        positionId: position.positionId,
+        pool: { address: position.pool.address, fee: position.pool.fee },
+        token0: { ...position.token0 },
+        token1: { ...position.token1 },
+        value: position.value,
+        createdAt: position.createdAt,
+      }
+    : undefined
+
+const EMPTY_RECORDS: readonly UnfinalizedPositionRecord[] = Object.freeze([])
+
+const listeners = new Set<() => void>()
+// `getSnapshot` runs on every render of every consumer, so the parsed array is reused while the serialized
+// payload is byte-identical. Comparing the stored string rather than trusting a change counter keeps the
+// snapshot correct no matter who wrote it.
+const snapshotCache = new Map<string, { raw: string | null; records: readonly UnfinalizedPositionRecord[] }>()
+
+const getStorageKey = (owner: string) => `${STORAGE_KEY_PREFIX}_${owner.toLowerCase()}`
+
+const emit = () => listeners.forEach(listener => listener())
+
+const handleStorageEvent = (event: StorageEvent) => {
+  // A null key means the whole store was cleared.
+  if (event.key !== null && !event.key.startsWith(LEGACY_STORAGE_KEY_PREFIX)) return
+  emit()
+}
+
+/** Subscribes to writes from this tab and to `storage` events from other tabs. */
+export const subscribeUnfinalizedPositions = (listener: () => void) => {
+  listeners.add(listener)
+  if (listeners.size === 1 && typeof window !== 'undefined') window.addEventListener('storage', handleStorageEvent)
+
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0 && typeof window !== 'undefined') window.removeEventListener('storage', handleStorageEvent)
+  }
+}
+
+const readRaw = (storageKey: string): string | null => {
+  try {
+    return window.localStorage.getItem(storageKey)
+  } catch (error) {
+    console.warn('Failed to read unfinalized positions:', error)
+    return null
+  }
+}
+
+const parseRecords = (raw: string | null): readonly UnfinalizedPositionRecord[] => {
+  if (!raw) return EMPTY_RECORDS
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return EMPTY_RECORDS
+    const records = parsed.map(sanitizeRecord).filter((record): record is UnfinalizedPositionRecord => !!record)
+    return records.length ? records : EMPTY_RECORDS
+  } catch (error) {
+    console.warn('Failed to parse unfinalized positions:', error)
+    return EMPTY_RECORDS
+  }
+}
+
+// Entries written under a superseded record shape are unreachable and would otherwise be kept forever.
+const sweepLegacyStorage = () => {
+  try {
+    const storage = window.localStorage
+    const staleKeys: string[] = []
+    for (let index = 0; index < storage.length; index++) {
+      const key = storage.key(index)
+      if (key && key.startsWith(LEGACY_STORAGE_KEY_PREFIX) && !key.startsWith(STORAGE_KEY_PREFIX)) staleKeys.push(key)
+    }
+    staleKeys.forEach(key => storage.removeItem(key))
+  } catch {
+    // Clearing superseded entries is best effort and must never block the current read or write.
+  }
+}
+
+/**
+ * Sanitized snapshot for the owner. The parsed array is reused while the serialized payload is unchanged,
+ * so `useSyncExternalStore` sees a stable reference.
+ */
+export const getUnfinalizedPositionRecords = (owner?: string): readonly UnfinalizedPositionRecord[] => {
+  if (typeof window === 'undefined' || !owner) return EMPTY_RECORDS
+
+  const storageKey = getStorageKey(owner)
+  const raw = readRaw(storageKey)
+  const cached = snapshotCache.get(storageKey)
+  if (cached && cached.raw === raw) return cached.records
+
+  const records = parseRecords(raw)
+  snapshotCache.set(storageKey, { raw, records })
+  return records
+}
+
+const mutateRecords = (
+  owner: string | undefined,
+  mutator: (records: readonly UnfinalizedPositionRecord[]) => UnfinalizedPositionRecord[],
+): boolean => {
+  if (typeof window === 'undefined' || !owner) return false
+
+  const storageKey = getStorageKey(owner)
+
+  const now = Date.now()
+  const next = mutator(getUnfinalizedPositionRecords(owner)).filter(
+    record => now - record.cachedAt <= UNFINALIZED_POSITION_TTL_MS,
+  )
+  const nextRaw = next.length ? JSON.stringify(next) : null
+  if (nextRaw === readRaw(storageKey)) return true
+
+  try {
+    if (nextRaw === null) window.localStorage.removeItem(storageKey)
+    else window.localStorage.setItem(storageKey, nextRaw)
+  } catch (error) {
+    console.warn('Failed to persist unfinalized positions:', error)
+    return false
+  }
+
+  snapshotCache.set(storageKey, { raw: nextRaw, records: next.length ? next : EMPTY_RECORDS })
+  emit()
+  return true
+}
+
+const toRecordToken = (token: UnfinalizedPositionTokenInput): UnfinalizedPositionToken => ({
+  address: token.address,
+  symbol: token.symbol,
+  logo: token.logo,
+  amount: isFiniteNumber(token.amount) ? token.amount : 0,
+  decimals: isFiniteNumber(token.decimals) ? token.decimals : DEFAULT_PARSED_POSITION.token0.decimals,
+})
+
+/**
+ * Caches the locally authored snapshot of a confirmed zap. Returns false when the position is not
+ * addressable — an NFT position whose minted id could not be read, or an unknown NFT manager — so nothing
+ * that the read sites could never match, and whose detail link would be dead, is ever stored.
+ */
+export const updateUnfinalizedPosition = (input: UnfinalizedPositionInput, owner?: string): boolean => {
+  if (typeof window === 'undefined' || !owner || !isFiniteNumber(input.value) || !isSupportedExchange(input.dexId))
+    return false
+
+  const key = getUnfinalizedPositionKey({
+    chainId: input.chainId,
+    dexId: input.dexId,
+    poolAddress: input.poolAddress,
+    tokenId: input.tokenId,
+  })
+  if (!key) return false
+
+  const isUniv2 = isUniv2Dex(input.dexId)
+  const tokenId = normalizeTokenId(input.tokenId) ?? ''
+  const nftManagerAddress = isUniv2 ? undefined : getNftManagerContractAddress(input.dexId, input.chainId)
+  if (!isUniv2 && (!tokenId || !nftManagerAddress)) return false
+
+  const cachedAt = Date.now()
+  const record: UnfinalizedPositionRecord = {
+    key,
+    positionId: isUniv2 ? input.poolAddress : `${nftManagerAddress}-${tokenId}`,
+    chainId: input.chainId,
+    dexId: input.dexId,
+    dexLogo: input.dexLogo || '',
+    poolAddress: input.poolAddress,
+    poolFee: isFiniteNumber(input.poolFee) ? input.poolFee : 0,
+    tokenId: isUniv2 ? '' : tokenId,
+    txHash: input.txHash,
+    value: input.value,
+    createdAt: isFiniteNumber(input.createdAt) ? input.createdAt : cachedAt,
+    cachedAt,
+    isValueUpdating: input.isValueUpdating,
+    token0: toRecordToken(input.token0),
+    token1: toRecordToken(input.token1),
+  }
+
+  return mutateRecords(owner, records => [...records.filter(existing => existing.key !== key), record])
+}
+
+/** Drops the given keys; no-op when none of them is cached. */
+export const removeUnfinalizedPositions = (keys: readonly string[], owner?: string): boolean => {
+  if (!keys.length) return false
+  const removed = new Set(keys)
+  return mutateRecords(owner, records => records.filter(record => !removed.has(record.key)))
+}
+
+/** Drops expired entries, and the superseded caches that nothing can read any more. */
+export const pruneUnfinalizedPositions = (owner?: string): boolean => {
+  if (typeof window === 'undefined') return false
+  sweepLegacyStorage()
+  return mutateRecords(owner, records => [...records])
+}
+
+const hasIndexedValueSettled = (indexedValue: number, cachedValue: number) => {
+  if (!Number.isFinite(indexedValue) || !Number.isFinite(cachedValue)) return false
+  const scale = Math.max(Math.abs(indexedValue), Math.abs(cachedValue))
+  // Both sides read zero, so there is nothing left to converge on.
+  if (scale === 0) return true
+  return Math.abs(indexedValue - cachedValue) / scale <= VALUE_MATCH_TOLERANCE
+}
+
+const toPlaceholderPosition = (record: UnfinalizedPositionRecord): ParsedPosition => {
+  const networkInfo = NETWORKS_INFO[record.chainId as keyof typeof NETWORKS_INFO]
+  const dexInfo = EARN_DEXES[record.dexId]
+
+  return {
+    ...DEFAULT_PARSED_POSITION,
+    positionId: record.positionId,
+    tokenId: record.tokenId,
+    chain: {
+      id: record.chainId,
+      name: networkInfo.name,
+      logo: EARN_CHAINS[record.chainId as EarnChain]?.logo || networkInfo.icon,
+    },
+    dex: {
+      id: record.dexId,
+      name: dexInfo.name,
+      logo: record.dexLogo || dexInfo.logo,
+      version: getDexVersion(record.dexId),
+    },
+    pool: {
+      ...DEFAULT_PARSED_POSITION.pool,
+      address: record.poolAddress,
+      fee: record.poolFee,
+      isUniv2: isUniv2Dex(record.dexId),
+      nativeToken: networkInfo.nativeToken,
+    },
+    token0: {
+      ...DEFAULT_PARSED_POSITION.token0,
+      address: record.token0.address,
+      symbol: record.token0.symbol,
+      logo: record.token0.logo,
+      decimals: record.token0.decimals,
+      totalProvide: record.token0.amount,
+      currentAmount: record.token0.amount,
+    },
+    token1: {
+      ...DEFAULT_PARSED_POSITION.token1,
+      address: record.token1.address,
+      symbol: record.token1.symbol,
+      logo: record.token1.logo,
+      decimals: record.token1.decimals,
+      totalProvide: record.token1.amount,
+      currentAmount: record.token1.amount,
+    },
+    totalValueTokens: [
+      { address: record.token0.address, symbol: record.token0.symbol, amount: record.token0.amount },
+      { address: record.token1.address, symbol: record.token1.symbol, amount: record.token1.amount },
+    ],
+    totalValue: record.value,
+    totalProvidedValue: record.value,
+    currentValue: record.value,
+    createdTime: record.createdAt,
+    txHash: record.txHash,
+    isUnfinalized: true,
+    isValueUpdating: record.isValueUpdating,
+  }
+}
+
+/**
+ * Pure projection of the cache against the indexed positions: what still needs a placeholder row, what only
+ * needs the updating badge on its indexed row, and what has gone stale. Touches no storage.
+ */
+export const resolveUnfinalizedPositions = ({
+  records,
+  positions,
+  now,
+}: {
+  records: readonly UnfinalizedPositionRecord[]
+  positions: readonly ParsedPosition[]
+  now: number
+}): ResolvedUnfinalizedPositions => {
+  const placeholders: ParsedPosition[] = []
+  const placeholderByKey = new Map<string, ParsedPosition>()
+  const valueUpdatingKeys = new Set<string>()
+  const staleKeys: string[] = []
+
+  const positionByKey = new Map<string, ParsedPosition>()
+  positions.forEach(position => {
+    const key = getUnfinalizedPositionKeyFromPosition(position)
+    if (key) positionByKey.set(key, position)
+  })
+
+  records.forEach(record => {
+    if (now - record.cachedAt > UNFINALIZED_POSITION_TTL_MS) {
+      staleKeys.push(record.key)
+      return
+    }
+
+    const indexedPosition = positionByKey.get(record.key)
+    // A brand-new position is finalized as soon as the indexer returns it at all; an increase only once the
+    // indexed value has caught up with the value the zap reported.
+    const isFinalized = record.isValueUpdating
+      ? !!indexedPosition && hasIndexedValueSettled(indexedPosition.totalProvidedValue, record.value)
+      : !!indexedPosition
+    if (isFinalized) {
+      staleKeys.push(record.key)
+      return
+    }
+
+    const placeholder = toPlaceholderPosition(record)
+    placeholderByKey.set(record.key, placeholder)
+    if (record.isValueUpdating) valueUpdatingKeys.add(record.key)
+    else placeholders.push(placeholder)
+  })
+
+  // Newest zap first.
+  placeholders.reverse()
+
+  return { placeholders, placeholderByKey, valueUpdatingKeys, staleKeys }
 }

--- a/apps/kyberswap-interface/src/pages/Earns/utils/unfinalizedPositionWriter.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/utils/unfinalizedPositionWriter.ts
@@ -1,0 +1,49 @@
+import { EARN_DEXES, isSupportedExchange } from 'pages/Earns/constants'
+import { CoreProtocol } from 'pages/Earns/constants/coreProtocol'
+import { getTokenId } from 'pages/Earns/utils'
+import { updateUnfinalizedPosition } from 'pages/Earns/utils/unfinalizedPosition'
+import type { UnfinalizedPositionSnapshot } from 'state/transactions/type'
+
+/**
+ * Turns the snapshot captured when a zap was submitted into a cached placeholder position, resolving the
+ * minted NFT id from the mined receipt. Lives apart from the cache module so reading the cache does not
+ * pull in the wallet stack.
+ *
+ * Returns false when the position cannot be addressed — an NFT id that no receipt could yield — in which
+ * case the position simply waits for the indexer instead of showing a row that leads nowhere.
+ */
+export const writeUnfinalizedPositionFromSnapshot = async ({
+  txHash,
+  snapshot,
+  owner,
+}: {
+  txHash: string
+  snapshot: UnfinalizedPositionSnapshot
+  owner?: string
+}): Promise<boolean> => {
+  const { chainId, dex, dexLogo, positionId, pool, token0, token1, value, createdAt } = snapshot
+  if (!isSupportedExchange(dex)) return false
+
+  const isUniv2 = EARN_DEXES[dex].isForkFrom === CoreProtocol.UniswapV2
+  const tokenId = isUniv2 ? undefined : positionId || (await getTokenId(chainId, txHash, dex, { waitForMined: true }))
+
+  return updateUnfinalizedPosition(
+    {
+      chainId,
+      dexId: dex,
+      dexLogo,
+      poolAddress: pool.address,
+      poolFee: pool.fee,
+      tokenId,
+      txHash,
+      value,
+      createdAt,
+      // A zap into a position that already exists leaves the indexed row in place and only makes its value
+      // stale, so it gets the updating badge rather than a placeholder row of its own.
+      isValueUpdating: !!positionId,
+      token0,
+      token1,
+    },
+    owner,
+  )
+}

--- a/apps/kyberswap-interface/src/pages/Earns/utils/zap.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/utils/zap.ts
@@ -88,7 +88,7 @@ export const navigateToPositionAfterZap = async (
         .replace(':chainId', chainId.toString())
         .replace(':exchange', exchange) + '?forceLoading=true'
   } else {
-    const tokenId = defaultTokenId || (await getTokenId(chainId, txHash, exchange))
+    const tokenId = defaultTokenId || (await getTokenId(chainId, txHash, exchange, { waitForMined: true }))
     if (!tokenId) {
       navigateFunc(APP_PATHS.EARN_POSITIONS)
       return

--- a/apps/kyberswap-interface/src/state/transactions/type.ts
+++ b/apps/kyberswap-interface/src/state/transactions/type.ts
@@ -65,6 +65,24 @@ export type TransactionExtraBaseInfo = {
   contract?: string // recipient, contract, spender, ...
 }
 
+/**
+ * Everything the placeholder row for a submitted-but-not-yet-indexed zap needs. It is captured when the
+ * transaction is submitted and rides along on the transaction, so dismissing the zap widget, navigating
+ * away, or reloading cannot lose it — the numbers live only in the widget's own route state.
+ */
+export type UnfinalizedPositionSnapshot = {
+  chainId: number
+  dex: Exchange
+  dexLogo: string
+  /** Set only when zapping into a position that already exists. */
+  positionId?: string
+  pool: { address: string; fee: number }
+  token0: { address: string; symbol: string; logo: string; amount: number; decimals?: number }
+  token1: { address: string; symbol: string; logo: string; amount: number; decimals?: number }
+  value: number
+  createdAt: number
+}
+
 export type EarnAddLiquidityExtraInfo = {
   pool: string
   dexLogoUrl?: string
@@ -75,6 +93,7 @@ export type EarnAddLiquidityExtraInfo = {
     amount: string
     symbol: string
   }>
+  unfinalizedPosition?: UnfinalizedPositionSnapshot
   contract?: string
 }
 
@@ -99,6 +118,7 @@ export type EarnMigrateLiquidityExtraInfo = {
   destinationDexLogoUrl?: string
   destinationDex: Exchange
   positionId: string
+  unfinalizedPosition?: UnfinalizedPositionSnapshot
   contract?: string
 }
 

--- a/apps/kyberswap-interface/src/utils/viem.ts
+++ b/apps/kyberswap-interface/src/utils/viem.ts
@@ -30,4 +30,4 @@ export {
 
 export { maxUint256, zeroAddress, zeroHash } from 'viem'
 
-export type { Abi, Address, Hash, Hex, PublicClient, WalletClient } from 'viem'
+export type { Abi, Address, Hash, Hex, Log, PublicClient, WalletClient } from 'viem'

--- a/packages/liquidity-widgets/src/components/Preview/index.tsx
+++ b/packages/liquidity-widgets/src/components/Preview/index.tsx
@@ -25,6 +25,7 @@ import Warning from '@/components/Preview/Warning';
 import ZapInAmount from '@/components/Preview/ZapInAmount';
 import useOnSuccess from '@/components/Preview/useOnSuccess';
 import useTxStatus from '@/components/Preview/useTxStatus';
+import usePositionSnapshot from '@/hooks/usePositionSnapshot';
 import useZapRoute from '@/hooks/useZapRoute';
 import { useZapState } from '@/hooks/useZapState';
 import { usePoolStore } from '@/stores/usePoolStore';
@@ -68,9 +69,12 @@ export default function Preview({ onDismiss }: { onDismiss: () => void }) {
 
   const { success: isUniV3 } = univ3PoolNormalize.safeParse(pool);
 
+  const buildPositionSnapshot = usePositionSnapshot();
+
   useOnSuccess({
     txHash: displayTxHash,
     txStatus,
+    buildPositionSnapshot,
   });
 
   const handleClick = async () => {
@@ -110,6 +114,7 @@ export default function Preview({ onDismiss }: { onDismiss: () => void }) {
           tokensIn: parsedTokensIn,
           pool: `${pool.token0.symbol}/${pool.token1.symbol}`,
           dexLogo: DEXES_INFO[poolType].icon,
+          position: buildPositionSnapshot() ?? undefined,
         },
       );
       setTxHash(txHash);

--- a/packages/liquidity-widgets/src/components/Preview/useOnSuccess.ts
+++ b/packages/liquidity-widgets/src/components/Preview/useOnSuccess.ts
@@ -1,87 +1,32 @@
 import { useEffect, useState } from 'react';
 
-import { DEXES_INFO, PoolType } from '@kyber/schema';
-import { formatUnits } from '@kyber/utils/number';
-
-import useZapRoute from '@/hooks/useZapRoute';
 import { useZapState } from '@/hooks/useZapState';
 import { usePoolStore } from '@/stores/usePoolStore';
-import { usePositionStore } from '@/stores/usePositionStore';
 import { useWidgetStore } from '@/stores/useWidgetStore';
+import { OnSuccessProps } from '@/types/index';
 
-export default function useOnSuccess({ txHash, txStatus }: { txHash: string; txStatus: string }) {
-  const { poolType, chainId, positionId, onSuccess } = useWidgetStore([
-    'poolType',
-    'chainId',
-    'positionId',
-    'onSuccess',
-  ]);
+export default function useOnSuccess({
+  txHash,
+  txStatus,
+  buildPositionSnapshot,
+}: {
+  txHash: string;
+  txStatus: string;
+  buildPositionSnapshot: () => OnSuccessProps['position'] | null;
+}) {
+  const { onSuccess } = useWidgetStore(['onSuccess']);
   const { pool } = usePoolStore(['pool']);
-  const { position } = usePositionStore(['position']);
   const { route } = useZapState();
-  const { initUsd, addedLiquidity } = useZapRoute();
 
   const [onSuccessTriggered, setOnSuccessTriggered] = useState(false);
-  const { icon: dexLogo } = DEXES_INFO[poolType as PoolType];
 
   useEffect(() => {
     if (!txHash || txStatus !== 'success' || !onSuccess || onSuccessTriggered || !route || !pool) return;
 
-    setOnSuccessTriggered(true);
+    const position = buildPositionSnapshot();
+    if (!position) return;
 
-    onSuccess({
-      txHash,
-      position: {
-        positionId,
-        chainId,
-        dexLogo,
-        token0: {
-          address: pool.token0.address,
-          symbol: pool.token0.symbol,
-          logo: pool.token0.logo || '',
-          amount: +formatUnits(
-            position ? position.amount0.toString() : addedLiquidity.addedAmount0.toString(),
-            pool.token0.decimals || 18,
-          ),
-        },
-        token1: {
-          address: pool.token1.address,
-          symbol: pool.token1.symbol,
-          logo: pool.token1.logo || '',
-          amount: +formatUnits(
-            position ? position.amount1.toString() : addedLiquidity.addedAmount1.toString(),
-            pool.token1.decimals || 18,
-          ),
-        },
-        pool: {
-          address: pool.address,
-          fee: pool.fee,
-        },
-        value: position
-          ? addedLiquidity.addedValue0 +
-            +formatUnits(position.amount0.toString(), pool.token0.decimals || 18) * (pool.token0.price || 0) +
-            addedLiquidity.addedValue1 +
-            +formatUnits(position.amount1.toString(), pool.token1.decimals || 18) * (pool.token1.price || 0)
-          : +initUsd,
-        createdAt: Date.now(),
-      },
-    });
-  }, [
-    addedLiquidity.addedAmount0,
-    addedLiquidity.addedAmount1,
-    addedLiquidity.addedValue0,
-    addedLiquidity.addedValue1,
-    chainId,
-    dexLogo,
-    initUsd,
-    onSuccess,
-    onSuccessTriggered,
-    pool,
-    poolType,
-    position,
-    positionId,
-    route,
-    txHash,
-    txStatus,
-  ]);
+    setOnSuccessTriggered(true);
+    onSuccess({ txHash, position });
+  }, [buildPositionSnapshot, onSuccess, onSuccessTriggered, pool, route, txHash, txStatus]);
 }

--- a/packages/liquidity-widgets/src/hooks/usePositionSnapshot.ts
+++ b/packages/liquidity-widgets/src/hooks/usePositionSnapshot.ts
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+
+import { DEXES_INFO, PoolType } from '@kyber/schema';
+import { formatUnits } from '@kyber/utils/number';
+
+import useZapRoute from '@/hooks/useZapRoute';
+import { usePoolStore } from '@/stores/usePoolStore';
+import { usePositionStore } from '@/stores/usePositionStore';
+import { useWidgetStore } from '@/stores/useWidgetStore';
+import { OnSuccessProps } from '@/types/index';
+
+/**
+ * Describes the position the current zap route produces. Consumers read it both when the transaction is
+ * submitted and when it succeeds, so the two report identical numbers for the same route.
+ */
+export default function usePositionSnapshot(): () => OnSuccessProps['position'] | null {
+  const { poolType, chainId, positionId } = useWidgetStore(['poolType', 'chainId', 'positionId']);
+  const { pool } = usePoolStore(['pool']);
+  const { position } = usePositionStore(['position']);
+  const { initUsd, addedLiquidity } = useZapRoute();
+
+  const { icon: dexLogo } = DEXES_INFO[poolType as PoolType];
+
+  return useCallback(() => {
+    if (!pool) return null;
+
+    return {
+      positionId,
+      chainId,
+      dexLogo,
+      token0: {
+        address: pool.token0.address,
+        symbol: pool.token0.symbol,
+        logo: pool.token0.logo || '',
+        decimals: pool.token0.decimals,
+        amount: +formatUnits(
+          position ? position.amount0.toString() : addedLiquidity.addedAmount0.toString(),
+          pool.token0.decimals || 18,
+        ),
+      },
+      token1: {
+        address: pool.token1.address,
+        symbol: pool.token1.symbol,
+        logo: pool.token1.logo || '',
+        decimals: pool.token1.decimals,
+        amount: +formatUnits(
+          position ? position.amount1.toString() : addedLiquidity.addedAmount1.toString(),
+          pool.token1.decimals || 18,
+        ),
+      },
+      pool: {
+        address: pool.address,
+        fee: pool.fee,
+      },
+      value: position
+        ? addedLiquidity.addedValue0 +
+          +formatUnits(position.amount0.toString(), pool.token0.decimals || 18) * (pool.token0.price || 0) +
+          addedLiquidity.addedValue1 +
+          +formatUnits(position.amount1.toString(), pool.token1.decimals || 18) * (pool.token1.price || 0)
+        : +initUsd,
+      createdAt: Date.now(),
+    };
+  }, [addedLiquidity, chainId, dexLogo, initUsd, pool, position, positionId]);
+}

--- a/packages/liquidity-widgets/src/types/index.ts
+++ b/packages/liquidity-widgets/src/types/index.ts
@@ -55,6 +55,8 @@ export interface WidgetProps {
           tokensIn: Array<{ symbol: string; amount: string; logoUrl?: string }>;
           pool: string;
           dexLogo: string;
+          /** The position this zap produces, so a host can show it before the transaction is indexed. */
+          position?: OnSuccessProps['position'];
         }
       | ApprovalAdditionalInfo,
   ) => Promise<string>;
@@ -76,12 +78,14 @@ export interface OnSuccessProps {
       symbol: string;
       logo: string;
       amount: number;
+      decimals?: number;
     };
     token1: {
       address: string;
       symbol: string;
       logo: string;
       amount: number;
+      decimals?: number;
     };
     pool: {
       address: string;

--- a/packages/zap-migration-widgets/src/components/Preview/index.tsx
+++ b/packages/zap-migration-widgets/src/components/Preview/index.tsx
@@ -25,12 +25,14 @@ import PreviewPoolInfo from '@/components/Preview/PreviewPoolInfo';
 import UpdatedPosition from '@/components/Preview/UpdatedPosition';
 import Warning from '@/components/Preview/Warning';
 import useOnSuccess from '@/hooks/useOnSuccess';
+import usePositionSnapshot from '@/hooks/usePositionSnapshot';
 import useTxStatus from '@/hooks/useTxStatus';
 import useZapRoute from '@/hooks/useZapRoute';
 import { usePoolStore } from '@/stores/usePoolStore';
 import { usePositionStore } from '@/stores/usePositionStore';
 import { useWidgetStore } from '@/stores/useWidgetStore';
 import { useZapStore } from '@/stores/useZapStore';
+import { OnSuccessProps } from '@/types/index';
 
 export function Preview({
   onSubmitTx,
@@ -46,6 +48,7 @@ export function Preview({
       sourceDexLogo: string;
       destinationPool: string;
       destinationDexLogo: string;
+      position?: OnSuccessProps['position'];
     },
   ) => Promise<string>;
   onViewPosition?: (txHash: string) => void;
@@ -81,8 +84,10 @@ export function Preview({
   // Use currentTxHash (which tracks replacements) for displaying to user
   const displayTxHash = currentTxHash || txHash;
 
+  const buildPositionSnapshot = usePositionSnapshot();
+
   // Call onSuccess when transaction is successful
-  useOnSuccess({ txHash: txHash || '', txStatus });
+  useOnSuccess({ txHash: txHash || '', txStatus, buildPositionSnapshot });
 
   if (route === null || !sourcePool || !targetPool || !account || !buildData) return null;
 
@@ -138,6 +143,7 @@ export function Preview({
           sourceDexLogo: DEXES_INFO[sourcePool.poolType].icon,
           destinationPool: `${targetPool.token0.symbol}/${targetPool.token1.symbol}`,
           destinationDexLogo: DEXES_INFO[targetPool.poolType].icon,
+          position: buildPositionSnapshot() ?? undefined,
         },
       );
       setTxHash(txHash);

--- a/packages/zap-migration-widgets/src/hooks/useOnSuccess.ts
+++ b/packages/zap-migration-widgets/src/hooks/useOnSuccess.ts
@@ -1,66 +1,30 @@
 import { useEffect, useState } from 'react';
 
-import { DEXES_INFO, PoolType } from '@kyber/schema';
-import { formatUnits } from '@kyber/utils/number';
-
-import useZapRoute from '@/hooks/useZapRoute';
 import { usePoolStore } from '@/stores/usePoolStore';
-import { usePositionStore } from '@/stores/usePositionStore';
 import { useWidgetStore } from '@/stores/useWidgetStore';
+import { OnSuccessProps } from '@/types/index';
 
-export default function useOnSuccess({ txHash, txStatus }: { txHash: string; txStatus: string }) {
-  const { chainId, targetPoolType, onSuccess } = useWidgetStore(['chainId', 'targetPoolType', 'onSuccess']);
+export default function useOnSuccess({
+  txHash,
+  txStatus,
+  buildPositionSnapshot,
+}: {
+  txHash: string;
+  txStatus: string;
+  buildPositionSnapshot: () => OnSuccessProps['position'] | null;
+}) {
+  const { onSuccess } = useWidgetStore(['onSuccess']);
   const { targetPool } = usePoolStore(['targetPool']);
-  const { targetPositionId } = usePositionStore(['targetPositionId']);
-  const { addedLiquidity, initUsd } = useZapRoute();
 
   const [onSuccessTriggered, setOnSuccessTriggered] = useState(false);
-  const poolType = targetPoolType as PoolType;
-  const { icon: dexLogo } = DEXES_INFO[poolType] || { icon: '' };
 
   useEffect(() => {
     if (!txHash || txStatus !== 'success' || !onSuccess || onSuccessTriggered || !targetPool) return;
 
-    setOnSuccessTriggered(true);
+    const position = buildPositionSnapshot();
+    if (!position) return;
 
-    onSuccess({
-      txHash,
-      position: {
-        positionId: targetPositionId,
-        chainId,
-        dexLogo,
-        token0: {
-          address: targetPool.token0.address,
-          symbol: targetPool.token0.symbol,
-          logo: targetPool.token0.logo || '',
-          amount: +formatUnits(addedLiquidity.addedAmount0.toString(), targetPool.token0.decimals || 18),
-        },
-        token1: {
-          address: targetPool.token1.address,
-          symbol: targetPool.token1.symbol,
-          logo: targetPool.token1.logo || '',
-          amount: +formatUnits(addedLiquidity.addedAmount1.toString(), targetPool.token1.decimals || 18),
-        },
-        pool: {
-          address: targetPool.address,
-          fee: targetPool.fee,
-        },
-        value: +initUsd,
-        createdAt: Date.now(),
-      },
-    });
-  }, [
-    addedLiquidity.addedAmount0,
-    addedLiquidity.addedAmount1,
-    chainId,
-    dexLogo,
-    initUsd,
-    onSuccess,
-    onSuccessTriggered,
-    poolType,
-    targetPool,
-    targetPositionId,
-    txHash,
-    txStatus,
-  ]);
+    setOnSuccessTriggered(true);
+    onSuccess({ txHash, position });
+  }, [buildPositionSnapshot, onSuccess, onSuccessTriggered, targetPool, txHash, txStatus]);
 }

--- a/packages/zap-migration-widgets/src/hooks/usePositionSnapshot.ts
+++ b/packages/zap-migration-widgets/src/hooks/usePositionSnapshot.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+
+import { DEXES_INFO, PoolType } from '@kyber/schema';
+import { formatUnits } from '@kyber/utils/number';
+
+import useZapRoute from '@/hooks/useZapRoute';
+import { usePoolStore } from '@/stores/usePoolStore';
+import { usePositionStore } from '@/stores/usePositionStore';
+import { useWidgetStore } from '@/stores/useWidgetStore';
+import { OnSuccessProps } from '@/types/index';
+
+/**
+ * Describes the position the current migration route produces. Consumers read it both when the transaction
+ * is submitted and when it succeeds, so the two report identical numbers for the same route.
+ */
+export default function usePositionSnapshot(): () => OnSuccessProps['position'] | null {
+  const { chainId, targetPoolType } = useWidgetStore(['chainId', 'targetPoolType']);
+  const { targetPool } = usePoolStore(['targetPool']);
+  const { targetPositionId } = usePositionStore(['targetPositionId']);
+  const { addedLiquidity, initUsd } = useZapRoute();
+
+  const { icon: dexLogo } = DEXES_INFO[targetPoolType as PoolType] || { icon: '' };
+
+  return useCallback(() => {
+    if (!targetPool) return null;
+
+    return {
+      positionId: targetPositionId,
+      chainId,
+      dexLogo,
+      token0: {
+        address: targetPool.token0.address,
+        symbol: targetPool.token0.symbol,
+        logo: targetPool.token0.logo || '',
+        decimals: targetPool.token0.decimals,
+        amount: +formatUnits(addedLiquidity.addedAmount0.toString(), targetPool.token0.decimals || 18),
+      },
+      token1: {
+        address: targetPool.token1.address,
+        symbol: targetPool.token1.symbol,
+        logo: targetPool.token1.logo || '',
+        decimals: targetPool.token1.decimals,
+        amount: +formatUnits(addedLiquidity.addedAmount1.toString(), targetPool.token1.decimals || 18),
+      },
+      pool: {
+        address: targetPool.address,
+        fee: targetPool.fee,
+      },
+      value: +initUsd,
+      createdAt: Date.now(),
+    };
+  }, [addedLiquidity, chainId, dexLogo, initUsd, targetPool, targetPositionId]);
+}

--- a/packages/zap-migration-widgets/src/types/index.ts
+++ b/packages/zap-migration-widgets/src/types/index.ts
@@ -16,12 +16,14 @@ export interface OnSuccessProps {
       symbol: string;
       logo: string;
       amount: number;
+      decimals?: number;
     };
     token1: {
       address: string;
       symbol: string;
       logo: string;
       amount: number;
+      decimals?: number;
     };
     pool: {
       address: string;
@@ -85,6 +87,8 @@ export interface ZapMigrationProps {
           sourceDexLogo: string;
           destinationPool: string;
           destinationDexLogo: string;
+          /** The position this migration produces, so a host can show it before the transaction is indexed. */
+          position?: OnSuccessProps['position'];
         }
       | ApprovalAdditionalInfo,
   ) => Promise<string>;


### PR DESCRIPTION
## Summary

After a zap-in, the app caches a placeholder position so the positions list and the position detail page can show it while the indexer catches up. It only worked some of the time.

- **One write path for every zap flow.** Each zap captures what its route produces at submit time and carries it on the transaction; a global updater writes the cache once the transaction mines. The pool-detail add-liquidity page — the page every "open pool" CTA now lands on — never wrote the cache at all, and the write no longer depends on the zap widget still being mounted, so dismissing the dialog, navigating away, or reloading all keep working.

- **Positions are matched by a composite key** (chain + dex + NFT id, or chain + dex + pool for UniV2 pairs) that the write, an indexed row, and the detail route all derive identically. The previous numeric token-id comparison could not address UniV2 pairs at all, picked the wrong entry when two zaps were pending, and could match unrelated rows across chains and protocols.

- **The cached record is a narrow, locally authored shape.** Indexed data can no longer be written back over it, an entry expires from its own write time (so an increase on an old position gets its full window), and the value-convergence check is scale-relative and guarded against NaN. Malformed or superseded entries are discarded rather than rendered.

- **Reads go through a subscribable store**, so a write that lands after a screen has mounted — the normal case, since resolving the minted NFT id needs a receipt — appears immediately instead of waiting for the next poll. Pruning runs in effects rather than during render.

- **`getTokenId` resolves the minted id far more reliably:** it waits for the receipt when a zap has just been sent, shares the in-flight lookup so caching and navigation agree on one id, scopes the log scan to the position manager, and reads the widened `IncreaseLiquidity` event for every Algebra fork — Thena and Camelot V3 matched the wrong topic and could never resolve an id. A position whose id cannot be resolved is not cached, since its row would link nowhere.

- **Detail page fixes:** the loading hand-off is scoped to the position the URL addresses (the query keeps serving the previously viewed position until new arguments resolve) and is time-bounded, and Increase / Reposition / Remove are disabled while a position is unfinalized, matching the list.

- **List rows keep a stable identity** across the placeholder → indexed-row handover, so the table no longer remounts when a placeholder resolves.

- Adds unit coverage for the cache: key symmetry, UniV2 and multi-pending addressing, TTL, convergence, and malformed-storage handling.

## Note for reviewers

`@kyberswap/liquidity-widgets` and `@kyberswap/zap-migration-widgets` gain an optional `position` field on the `zap` variant of `onSubmitTx`'s `additionalInfo`, plus optional `decimals` on the `OnSuccessProps` tokens. Both are additive, so existing consumers keep compiling, but the packages want a version bump before release.

Not covered here: `useZapCreatePoolWidget` and `useCompounding` still do not participate in the cache — the latter needs an `onSuccess` callback that `@kyberswap/compounding-widget` does not expose.
