### PR TITLE
chore(embed): allow-list robinscan.io for iframe embedding

### DIFF
--- a/apps/kyberswap-interface/etc/csp.conf
+++ b/apps/kyberswap-interface/etc/csp.conf
@@ -56,6 +56,7 @@ map $embed_origin $frame_ancestors {
     "~*^https://app\.swapline\.com$"                 "'self' $embed_origin";
     "~*^https://chamberfi\.com$"                     "'self' $embed_origin";
     "~*^https://flap\.sh$"                           "'self' $embed_origin";
+    "~*^https://robinscan\.io$"                      "'self' $embed_origin";
 
     # Internal iframe-embed harness (apps/iframe-embed-demo deployed to Netlify).
     "~*^https://kyberswap-iframe-demo\.netlify\.app$"  "'self' $embed_origin";


### PR DESCRIPTION
Adds `https://robinscan.io` to the per-embedder `frame-ancestors` allowlist in `apps/kyberswap-interface/etc/csp.conf` so it can frame the KyberSwap `/partner-swap` widget.

**Origin:** `https://robinscan.io` (apex) — the Robinhood-chain block explorer.
- App is served on the apex (HTTP 200, Vercel); `www.robinscan.io` 308-redirects to the apex, so the embedding `Referer` is `https://robinscan.io`.
- Exact, fully-anchored match (`^https://robinscan\.io$`); verified it rejects `www.`/sub-domains, `robinscan.io.evil.com`, `robinscan.com`, and `http://`.
