### PR TITLE
fix(earn): avoid empty state during wallet restoration

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/SmartExitOrders/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/SmartExitOrders/index.tsx
@@ -34,6 +34,7 @@ import useSmartExitFilter from 'pages/Earns/SmartExitOrders/useSmartExitFilter'
 import { useSmartExitOrdersData } from 'pages/Earns/SmartExitOrders/useSmartExitOrdersData'
 import { SmartExit as SmartExitModal } from 'pages/Earns/components/SmartExit'
 import { SMART_EXIT_SUPPORTED_CHAINS, SMART_EXIT_SUPPORTED_EXCHANGES } from 'pages/Earns/constants'
+import useIsWalletRestoring from 'pages/Earns/hooks/useIsWalletRestoring'
 import { OrderStatus, ParsedPosition, SmartExitOrder, UserPosition } from 'pages/Earns/types'
 import { parsePosition } from 'pages/Earns/utils/position'
 import { useNotify, useWalletModalToggle } from 'state/application/hooks'
@@ -52,6 +53,7 @@ const SMART_EXIT_ORDERS_PAGE_SIZE = 10
 const SmartExit = () => {
   const navigate = useNavigate()
   const { account, chainId } = useActiveWeb3React()
+  const isRestoringWallet = useIsWalletRestoring()
   const notify = useNotify()
   const toggleWalletModal = useWalletModalToggle()
 
@@ -132,6 +134,7 @@ const SmartExit = () => {
     handlePageChange,
     shouldShowEmptyState,
   } = useSmartExitOrdersData({ account, filters, pageSize: SMART_EXIT_ORDERS_PAGE_SIZE, updateFilters })
+  const isInitialLoading = isRestoringWallet || tableLoading
   const upToMedium = useMedia(`(max-width: ${MEDIA_WIDTHS.upToMedium}px)`)
 
   // Fetch all active orders to get position IDs that should be excluded from position selector
@@ -234,9 +237,9 @@ const SmartExit = () => {
         )}
 
         <div className="relative">
-          <RefetchIndicator visible={overlayLoading} />
+          <RefetchIndicator visible={overlayLoading && !isInitialLoading} />
 
-          {tableLoading ? (
+          {isInitialLoading ? (
             <SmartExitListSkeleton />
           ) : shouldShowEmptyState ? (
             <div className="flex flex-col items-center justify-center gap-4 px-4 py-16">
@@ -280,7 +283,7 @@ const SmartExit = () => {
 
         <Pagination
           onPageChange={handlePageChange}
-          totalCount={tableLoading ? 0 : totalItems}
+          totalCount={isInitialLoading ? 0 : totalItems}
           currentPage={currentPage}
           pageSize={SMART_EXIT_ORDERS_PAGE_SIZE}
         />

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
@@ -22,7 +22,6 @@ import { HiddenH1, HiddenH2 } from 'components/Seo/components'
 import { HStack } from 'components/Stack'
 import { APP_PATHS } from 'constants/index'
 import { useActiveWeb3React } from 'hooks'
-import { useAccount } from 'hooks/useAccount'
 import Filter from 'pages/Earns/UserPositions/Filter'
 import PositionBanner from 'pages/Earns/UserPositions/PositionBanner'
 import TableContent, { FeeInfoFromRpc } from 'pages/Earns/UserPositions/TableContent'
@@ -36,6 +35,7 @@ import {
 import useFilter, { SortBy } from 'pages/Earns/UserPositions/useFilter'
 import useAccountChanged from 'pages/Earns/hooks/useAccountChanged'
 import useClosedPositions from 'pages/Earns/hooks/useClosedPositions'
+import useIsWalletRestoring from 'pages/Earns/hooks/useIsWalletRestoring'
 import useKemRewards from 'pages/Earns/hooks/useKemRewards'
 import useSupportedDexesAndChains, { AllChainsOption } from 'pages/Earns/hooks/useSupportedDexesAndChains'
 import useZapInWidget from 'pages/Earns/hooks/useZapInWidget'
@@ -50,11 +50,10 @@ const UserPositions = () => {
   const navigate = useNavigate()
   const upToCustomLarge = useMedia(`(max-width: ${1300}px)`)
   const { account } = useActiveWeb3React()
-  const { status: walletStatus } = useAccount()
+  const isRestoringWallet = useIsWalletRestoring()
   const { filters, updateFilters } = useFilter()
   const { supportedDexes, supportedChains } = useSupportedDexesAndChains(filters)
 
-  const [hasPassedInitialRender, setHasPassedInitialRender] = useState(false)
   const [feeInfoFromRpc, setFeeInfoFromRpc] = useState<FeeInfoFromRpc[]>([])
 
   const { closedPositionsFromRpc, checkClosedPosition } = useClosedPositions()
@@ -76,8 +75,6 @@ const UserPositions = () => {
   })
 
   const positionsStats = userPositionsData?.stats
-  // TODO: Replace this local first-render/reconnect guard with an explicit wallet hydration signal.
-  const isRestoringWallet = !hasPassedInitialRender || walletStatus === 'connecting' || walletStatus === 'reconnecting'
   const hasStartedPositionsRequest = !isUninitialized
   const isInitialLoading = isRestoringWallet || (!!account && (!hasStartedPositionsRequest || isLoading))
 
@@ -111,10 +108,6 @@ const UserPositions = () => {
   useAccountChanged(() => {
     refetch()
   })
-
-  useEffect(() => {
-    setHasPassedInitialRender(true)
-  }, [])
 
   const selectedChainsLabel = useMemo(() => {
     const arrValue = filters.chainIds?.split(',').filter(Boolean)

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useIsWalletRestoring.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useIsWalletRestoring.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+import { useAccount } from 'hooks/useAccount'
+
+export default function useIsWalletRestoring() {
+  const { status } = useAccount()
+  const [hasPassedInitialRender, setHasPassedInitialRender] = useState(false)
+
+  useEffect(() => {
+    setHasPassedInitialRender(true)
+  }, [])
+
+  return !hasPassedInitialRender || status === 'connecting' || status === 'reconnecting'
+}


### PR DESCRIPTION
## Summary
- share wallet restoration state across Earn positions and Smart Exit orders
- keep Smart Exit loading UI visible until the wallet connection settles