### PR TITLE
perf(token-selector): collapse the balance sweep into one batched multicall

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
@@ -1,4 +1,4 @@
-import { ChainId, Currency, CurrencyAmount, Token } from '@kyberswap/ks-sdk-core'
+import { ChainId, Currency, CurrencyAmount, Token, TokenAmount } from '@kyberswap/ks-sdk-core'
 import { Trans } from '@lingui/macro'
 import React, { CSSProperties, ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Info, Star, X } from 'react-feather'
@@ -23,7 +23,6 @@ import { useERC8056DisplayBalance, useERC8056TokenInfo } from 'hooks/useERC8056T
 import { restrictedTokenKey, restrictedTokenMessage, useIsTokenRestricted } from 'hooks/useRestrictedTokens'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
 import { useUserAddedTokens, useUserFavoriteTokens } from 'state/user/hooks'
-import { useCurrencyBalances } from 'state/wallet/hooks'
 import { shortenAddress } from 'utils/address'
 import { cn } from 'utils/cn'
 import { useCurrencyConvertedToNative } from 'utils/dmm'
@@ -40,8 +39,9 @@ const RESTRICTED_ITEM_SIZE = RESTRICTED_CONTENT_HEIGHT + 8 // 84px
 // Stable default so an omitted `itemStyle` prop doesn't mint a new object each render (which would
 // churn the row data bag and re-render every row).
 const EMPTY_ITEM_STYLE: CSSProperties = {}
-// Stable empties so gated balance/price subscriptions never allocate a fresh array to disable them.
-const EMPTY_CURRENCIES: Currency[] = []
+// Stable empties so a gated price subscription / balance column never allocates a fresh array to
+// disable itself.
+const EMPTY_BALANCES: (CurrencyAmount<Currency> | undefined)[] = []
 const EMPTY_ADDRESSES: string[] = []
 
 // Compact age badge for the New tab, counted from when the token was whitelisted: "NEW" under 12h,
@@ -531,6 +531,10 @@ type TokenListProps = {
   listTokenRef?: React.Ref<HTMLDivElement>
   itemStyle?: CSSProperties
   customChainId?: ChainId
+  /** Wallet balances keyed by token address, owned by the parent so one multicall serves the whole modal. */
+  balances?: { [tokenAddress: string]: TokenAmount | undefined }
+  /** Wallet balance of the chain's native currency, which lives outside the ERC20 `balances` map. */
+  nativeBalance?: CurrencyAmount<Currency>
   onShowTokenInfo?: (token: Token) => void
   /** Per-token price / 24h change / volume / added-at metadata keyed by `${chainId}-${address}`. */
   extras?: TokenRowExtraMap
@@ -560,6 +564,8 @@ const TokenList = ({
   showFavoriteIcon,
   itemStyle = EMPTY_ITEM_STYLE,
   customChainId,
+  balances,
+  nativeBalance,
   onShowTokenInfo,
   extras,
   showAddress,
@@ -572,10 +578,15 @@ const TokenList = ({
   const { favoriteTokens } = useUserFavoriteTokens(customChainId)
   const tokenImports = useUserAddedTokens(customChainId)
 
-  // The metric tabs show volume / market cap, not balance, so skip their per-block balanceOf
-  // multicall entirely.
-  const balanceCurrencies = metricColumn ? EMPTY_CURRENCIES : currencies
-  const currencyBalances = useCurrencyBalances(balanceCurrencies, customChainId)
+  // Row-aligned view of the shared balance map. The metric tabs show volume / market cap rather than
+  // a balance, so they read nothing.
+  const currencyBalances = useMemo(
+    () =>
+      metricColumn
+        ? EMPTY_BALANCES
+        : currencies.map(currency => (isTokenNative(currency) ? nativeBalance : balances?.[currency.wrapped.address])),
+    [metricColumn, currencies, balances, nativeBalance],
+  )
 
   // Only the All tab derives USD sub-lines from Redux prices (the others read price from catalog
   // extras), so skip the /prices subscription elsewhere. Within the All tab, only a row holding a

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -82,6 +82,7 @@ import {
   useUserAddedTokens,
   useUserFavoriteTokens,
 } from 'state/user/hooks'
+import { useNativeBalance, useTokenBalances } from 'state/wallet/hooks'
 import { CloseIcon, MEDIA_WIDTHS } from 'theme'
 import { isAddress } from 'utils/address'
 import { filterTruthy } from 'utils/array'
@@ -128,6 +129,8 @@ const SearchLoading = () => (
 
 // Stable empty list so `useTokensMetrics` doesn't refetch on tabs that don't need metrics.
 const EMPTY_CURRENCIES: Currency[] = []
+// Stable empty list so the tabs that show no balance column register no balanceOf multicall.
+const EMPTY_TOKENS: Token[] = []
 // Stable empty address list so `useTokenPrices` doesn't fetch on tabs that don't need it.
 const EMPTY_ADDRESSES: string[] = []
 // Stable empty extras so the All tab's `listExtras` keeps the same reference and doesn't re-render
@@ -352,17 +355,8 @@ export const TokenSelectorContent = ({
 
   const defaultTokens = useAllTokens(false, primaryChainId)
   const tokenImports = useUserAddedTokens(primaryChainId)
-  // Only the All (default order) and Imported tabs sort by wallet value; gate the comparator so the
-  // rest never register its whole-whitelist balanceOf multicall + /prices fetch.
-  const needsComparator = (isAllTab && !debouncedQuery) || isImportedTab
   // On the All tab, favorites float above non-favorites (but only after wallet value / balance).
   const favoriteAddressSet = useMemo(() => new Set(favoriteTokens ?? []), [favoriteTokens])
-  const tokenComparator = useTokenComparator(
-    false,
-    primaryChainId,
-    needsComparator,
-    isAllTab ? favoriteAddressSet : undefined,
-  )
 
   const {
     tokens: trendingTokens,
@@ -435,6 +429,52 @@ export const TokenSelectorContent = ({
     isFetchingTokenSearch,
     hasTokenSearchResults: !!tokenSearchResults.length,
   })
+
+  // One balanceOf multicall for the whole modal: the sort-by-wallet-value comparator and the list's
+  // balance column need the same tokens, and registering them apart doubles the RPC traffic. The set
+  // comes from each tab's *unsorted* source so it stays put while the rows re-sort on top of it, and
+  // it covers only the rows a tab actually shows — the Trending / New tabs render a metric column
+  // instead of a balance, so they read nothing.
+  const balanceTokens = useMemo<Token[]>(() => {
+    if (isTrendingTab || isNewTab) return EMPTY_TOKENS
+    const source: (Currency | undefined)[] = isImportedTab
+      ? tokenImports
+      : isFavoritesTab
+      ? pinnedTokens
+      : debouncedQuery
+      ? [...tokenSearchResults, currentChainRpcToken]
+      : Object.values(defaultTokens)
+    // Native balance comes from `getEthBalance`, not an ERC20 read; off-chain rows (a cross-chain
+    // search hit) have no balance to show here either.
+    return source.filter(
+      (token): token is Token => !!token && !isTokenNative(token) && token.chainId === primaryChainId,
+    )
+  }, [
+    isTrendingTab,
+    isNewTab,
+    isImportedTab,
+    isFavoritesTab,
+    debouncedQuery,
+    tokenImports,
+    pinnedTokens,
+    tokenSearchResults,
+    currentChainRpcToken,
+    defaultTokens,
+    primaryChainId,
+  ])
+  const balances = useTokenBalances(balanceTokens, primaryChainId)
+  const nativeBalance = useNativeBalance(primaryChainId)
+
+  // Only the All (default order) and Imported tabs sort by wallet value; gate the comparator so the
+  // rest never register its /prices fetch.
+  const needsComparator = (isAllTab && !debouncedQuery) || isImportedTab
+  const tokenComparator = useTokenComparator(
+    balances,
+    nativeBalance,
+    primaryChainId,
+    needsComparator,
+    isAllTab ? favoriteAddressSet : undefined,
+  )
 
   // All-tab dataset: API search results (with RPC fallback) when searching, else the sorted default
   // tokens. Only computed for the All tab — the other tabs never read it, so skip the whole-whitelist
@@ -1099,6 +1139,8 @@ export const TokenSelectorContent = ({
               loadMoreRows={handleLoadMore}
               hasMore={listHasMore}
               customChainId={primaryChainId}
+              balances={balances}
+              nativeBalance={nativeBalance}
               extras={listExtras}
               showAddress={isAllTab}
               showCopyAddress={!isAllTab}

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/utils.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/utils.ts
@@ -10,12 +10,10 @@ import { KS_SETTING_API } from 'constants/env'
 import { ETHER_ADDRESS } from 'constants/index'
 import { NETWORKS_INFO } from 'constants/networks'
 import type { NetworkInfo } from 'constants/networks/type'
-import { useActiveWeb3React } from 'hooks'
 import { fetchListTokenByAddresses, fetchTokenInfoFromRpc, formatAndCacheToken } from 'hooks/useTokens'
 import store from 'state'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
-import { useAllTokenBalances, useNativeBalance } from 'state/wallet/hooks'
 import { isAddress } from 'utils/address'
 import { filterTruthy } from 'utils/array'
 import { isTokenNative } from 'utils/tokenInfo'
@@ -24,7 +22,6 @@ export const TOKEN_SEARCH_PAGE_SIZE = 20
 
 const UNKNOWN_TOKEN_NAME = 'Unknown Token'
 const UNKNOWN_TOKEN_SYMBOL = 'UNKNOWN'
-const EMPTY_BALANCE_MAP = {}
 const EMPTY_PRICE_ADDRESSES: string[] = []
 
 type TokenBalanceMap = {
@@ -266,32 +263,30 @@ function getTokenComparator(
 }
 
 export function useTokenComparator(
-  inverted: boolean,
-  customChain?: ChainId,
-  // Only the tabs that sort by wallet value need this; when disabled it registers no whole-whitelist
-  // balanceOf multicall and no /prices fetch, and just falls back to a symbol sort.
+  // Balances for the tokens being sorted, plus the native balance, owned by the caller: the list's
+  // balance column reads the same tokens, and one shared multicall serves both.
+  balances: TokenBalanceMap,
+  ethBalance: CurrencyAmount<Currency> | undefined,
+  chainId: ChainId,
+  // Only the tabs that sort by wallet value need this; when disabled it registers no /prices fetch
+  // and just falls back to a symbol sort.
   enabled = true,
   // Lowercased favorite addresses to float above non-favorites once balance/value is a tie.
   favoriteAddresses?: Set<string>,
 ): (tokenA: Token, tokenB: Token) => number {
-  const { chainId: currentChain } = useActiveWeb3React()
-  const chainId = customChain || currentChain
-  const balances = useAllTokenBalances(chainId, enabled)
-  const ethBalance = useNativeBalance(chainId)
   // Only held tokens can contribute a USD value to the sort — `usdValueOf` returns 0 for a zero
   // balance whatever the price — so pricing the whole whitelist would be pure waste. The native
   // sentinel is always included: its balance lives in `ethBalance`, not in this map.
   const tokenPriceAddresses = useMemo(() => {
     if (!enabled) return EMPTY_PRICE_ADDRESSES
-    const balanceMap = balances ?? EMPTY_BALANCE_MAP
-    const held = Object.keys(balanceMap).filter(address => balanceMap[address]?.greaterThan('0'))
+    const held = Object.keys(balances).filter(address => balances[address]?.greaterThan('0'))
     held.push(NATIVE_TOKEN_ADDRESS)
     return held
   }, [balances, enabled])
   const tokenPrices = useTokenPrices(tokenPriceAddresses, chainId)
 
-  return useMemo(() => {
-    const comparator = getTokenComparator(balances ?? EMPTY_BALANCE_MAP, ethBalance, tokenPrices, favoriteAddresses)
-    return inverted ? (tokenA: Token, tokenB: Token) => comparator(tokenA, tokenB) * -1 : comparator
-  }, [balances, inverted, ethBalance, tokenPrices, favoriteAddresses])
+  return useMemo(
+    () => getTokenComparator(balances, ethBalance, tokenPrices, favoriteAddresses),
+    [balances, ethBalance, tokenPrices, favoriteAddresses],
+  )
 }

--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -385,15 +385,25 @@ const wagmiChains: readonly [Chain, ...Chain[]] = [
   withKyberRpc(rise),
 ] as const
 
+// JSON-RPC batching for the primary (KyberSwap) endpoint. viem sends one `eth_call` per multicall
+// chunk, so a sweep like the token selector's whole-whitelist `balanceOf` spans many calls that would
+// otherwise queue against the browser's per-host connection budget; batching folds them into a single
+// POST. Only the primary opts in — the public fallbacks are third-party endpoints whose batch support
+// we can't vouch for, and `batch.multicall.batchSize` keeps their call count in check on its own.
+const PRIMARY_HTTP_CONFIG = { batch: { batchSize: 50 } } as const
+
 // viem `fallback()` rotates through URLs on transport errors (network, 429, 5xx),
 // giving us true client-side RPC rotation for every wagmi-issued call (multicall,
 // useReadContract, polling). KyberSwap RPC sits first; public endpoints are tried
 // only when it errors. Connector-internal calls still use URL[0] of `rpcUrls.default`
 // (set by `withKyberRpc` above), which is the same KyberSwap RPC.
+
 const transports = Object.fromEntries(
   wagmiChains.map(c => {
+    const primaryUrl = NETWORKS_INFO[c.id as ChainId]?.defaultRpcUrl
     const urls = getRpcUrlsForChain(c.id)
-    const httpTransports = urls.length > 0 ? urls.map(url => http(url)) : [http()]
+    const httpTransports =
+      urls.length > 0 ? urls.map(url => (url === primaryUrl ? http(url, PRIMARY_HTTP_CONFIG) : http(url))) : [http()]
     return [c.id, fallback(httpTransports, { retryCount: 1 })]
   }),
 ) as Record<(typeof wagmiChains)[number]['id'], ReturnType<typeof fallback>>
@@ -434,7 +444,11 @@ const readRecentConnectorId = (): string | undefined => {
 export const wagmiConfig = createConfig({
   chains: wagmiChains,
   transports,
-  batch: { multicall: true },
+  // Multicall chunking is measured in calldata *bytes*: at viem's 1024-byte default a 36-byte
+  // `balanceOf(address)` fits only 28 calls per `aggregate3`, so a several-hundred-token sweep spans a
+  // dozen-plus eth_calls. 4096 quadruples the calls per chunk while staying well inside node eth_call
+  // gas caps for the heavier reads that share this path (pool state, positions).
+  batch: { multicall: { batchSize: 4096 } },
   pollingInterval: 12_000,
   connectors: [
     metaMask({

--- a/apps/kyberswap-interface/src/state/wallet/hooks.ts
+++ b/apps/kyberswap-interface/src/state/wallet/hooks.ts
@@ -87,8 +87,20 @@ export function useTokenBalancesWithLoadingIndicator(
   const { account, chainId: currentChain } = useActiveWeb3React()
   const chainId = customChain || currentChain
 
+  // Issue the calls in address order, de-duplicated: wagmi keys the multicall query on the contracts
+  // array, so a caller that re-orders its token list (the token selector re-sorts its rows as balances
+  // land) re-keys the query and refetches every chunk. The result is an address map, so the order the
+  // calls go out in is invisible to callers.
   const tokens = useMemo(() => {
-    return tokenParams?.[0]?.chainId === chainId ? tokenParams : EMPTY_ARRAY
+    if (tokenParams?.[0]?.chainId !== chainId) return EMPTY_ARRAY as Token[]
+    const seen = new Set<string>()
+    return tokenParams
+      .filter(token => {
+        if (!token || seen.has(token.address)) return false
+        seen.add(token.address)
+        return true
+      })
+      .sort((tokenA, tokenB) => (tokenA.address < tokenB.address ? -1 : tokenA.address > tokenB.address ? 1 : 0))
   }, [tokenParams, chainId])
 
   const isFetchOtherChain = chainId !== currentChain


### PR DESCRIPTION
Opening the token selector flooded the RPC: viem's 1024-byte multicall chunking split the whole-whitelist balanceOf sweep into ~17 eth_calls, each its own POST; the comparator and the list column registered the same sweep twice in different orders (two wagmi queries); and every UI re-sort re-keyed the query and refetched all chunks (~50 requests per open on Ethereum, repeated each block).

- enable JSON-RPC request batching on each chain's primary RPC transport
- raise multicall chunking to 4096 calldata bytes (28 -> 113 balanceOf per aggregate3)
- register one shared balanceOf multicall per modal, feeding both the wallet-value comparator and the list's balance column
- issue balance calls deduped and address-sorted so row re-sorts keep the wagmi query key stable

Measured on the Ethereum whitelist (474 tokens): ~50 requests per modal open -> 1, and 1 per block after.