### PR TITLE
fix(limit-order): use available making amount for presets

### DIFF
--- a/apps/kyberswap-interface/src/components/LimitOrder/CreateOrder/useCreateLimitOrder.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/CreateOrder/useCreateLimitOrder.tsx
@@ -68,8 +68,6 @@ export const useCreateLimitOrder = ({
     wrapAmount: nativeWrapAmount,
   })
 
-  const maxAmountInput = maxAmountSpend(balance)
-
   const inputCurrencySymbol = currencyIn?.symbol
   const insufficientBalanceText = insufficientBalance ? t`Insufficient ${inputCurrencySymbol} balance` : undefined
 
@@ -103,6 +101,17 @@ export const useCreateLimitOrder = ({
     } catch (error) {}
     return undefined
   }, [approvalCurrency, activeOrderMakingAmount])
+
+  const availableMakingAmount = useMemo(() => {
+    if (!balance || currencyIn?.isNative || !parsedActiveOrderMakingAmount) return balance
+    if (!balance.currency.equals(parsedActiveOrderMakingAmount.currency)) return undefined
+
+    const remainingAmount = JSBI.subtract(balance.quotient, parsedActiveOrderMakingAmount.quotient)
+    return TokenAmount.fromRawAmount(
+      balance.currency,
+      JSBI.greaterThan(remainingAmount, JSBI.BigInt(0)) ? remainingAmount : JSBI.BigInt(0),
+    )
+  }, [balance, currencyIn, parsedActiveOrderMakingAmount])
 
   // Allowance is checked inside the processing approve step so the modal can show the step even when it passes.
   const [approval, approveCallback] = useApproveCallback({
@@ -173,6 +182,7 @@ export const useCreateLimitOrder = ({
   })
 
   const handleMaxInput = () => {
+    const maxAmountInput = maxAmountSpend(availableMakingAmount)
     if (!maxAmountInput) return
     try {
       onSetInput?.(maxAmountInput.toExact())
@@ -180,7 +190,7 @@ export const useCreateLimitOrder = ({
   }
 
   const handleHalfInput = () => {
-    const halfAmountInput = halfAmountSpend(balance)
+    const halfAmountInput = halfAmountSpend(availableMakingAmount)
     if (!halfAmountInput) return
     try {
       onSetInput?.(halfAmountInput.toExact())

--- a/apps/kyberswap-interface/src/components/Listing/Table.tsx
+++ b/apps/kyberswap-interface/src/components/Listing/Table.tsx
@@ -1,4 +1,5 @@
-import { CSSProperties, HTMLAttributes } from 'react'
+import { CSSProperties, HTMLAttributes, forwardRef } from 'react'
+import { Link, LinkProps } from 'react-router-dom'
 
 import { cn } from 'utils/cn'
 
@@ -47,3 +48,8 @@ export const TableCell = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>
 export const TableRow = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>) => (
   <div className={cn('grid items-center p-3 text-subText', className)} {...rest} />
 )
+
+export const TableRowLink = forwardRef<HTMLAnchorElement, LinkProps>(({ className, ...rest }, ref) => (
+  <Link ref={ref} className={cn('grid items-center p-3 text-subText no-underline', className)} {...rest} />
+))
+TableRowLink.displayName = 'TableRowLink'

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/DesktopTableRow.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/DesktopTableRow.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { Star } from 'react-feather'
 
-import { TableCell, TableRow, getPoolTableGridTemplateColumns } from 'components/Listing/Table'
+import { TableCell, TableRowLink, getPoolTableGridTemplateColumns } from 'components/Listing/Table'
 import Loader from 'components/Loader'
 import { HStack } from 'components/Stack'
 import TokenLogo from 'components/TokenLogo'
@@ -14,8 +14,8 @@ import { FeeTier, SymbolText } from 'pages/Earns/PoolExplorer/styles'
 import PoolAprBadges from 'pages/Earns/components/PoolAprBadges'
 import PoolAprInfo from 'pages/Earns/components/PoolAprInfo'
 import PoolRewardsInfo from 'pages/Earns/components/PoolRewardsInfo'
-import { ZapInInfo } from 'pages/Earns/hooks/useZapInWidget'
 import { ParsedEarnPool } from 'pages/Earns/types'
+import { getPoolDetailUrl } from 'pages/Earns/utils/url'
 import { formatDisplayNumber } from 'utils/numbers'
 import { prefetchPoolDetail } from 'utils/prefetch'
 
@@ -24,7 +24,6 @@ const DesktopTableRow = ({
   showRewards = true,
   showPoolPrice = true,
   rowIndex,
-  onOpenZapInWidget,
   handleFavorite,
   favoriteLoading,
 }: {
@@ -33,7 +32,6 @@ const DesktopTableRow = ({
   showPoolPrice?: boolean
   /** 0-based position within the current page — drives the staggered fade-in delay. */
   rowIndex: number
-  onOpenZapInWidget: ({ pool, initialTick }: ZapInInfo) => void
   handleFavorite: (e: React.MouseEvent<SVGElement, MouseEvent>, pool: ParsedEarnPool) => Promise<void>
   favoriteLoading: string[]
 }) => {
@@ -43,15 +41,15 @@ const DesktopTableRow = ({
   // Stagger each row's fade-in by 50ms (capped at 300ms), matching the My Positions list.
   const animationDelay = `${Math.min(rowIndex * 50, 300)}ms`
 
-  // The parent wires this row's onClick (onOpenZapInWidget) to open the pool's detail page, so warm
-  // that page's chunk + its poolDetail query on hover.
+  const poolDetailUrl = getPoolDetailUrl((pool.chain?.id || pool.chainId) as number, pool.exchange, pool.address)
+
+  // Warm the detail page's chunk + poolDetail query on hover before the link is opened.
   const prefetchDetail = usePrefetchOnIntent(
     () => prefetchPoolDetail((pool.chain?.id || pool.chainId) as number, pool.address),
     { delay: 120 },
   )
 
-  const handleOpenZapInWidget = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation()
+  const handlePoolClick = () => {
     trackingHandler(TRACKING_EVENT_TYPE.LIQ_POOL_SELECTED, {
       pool_pair: `${pool.tokens?.[0]?.symbol}/${pool.tokens?.[1]?.symbol}`,
       pool_protocol: pool.dexName,
@@ -61,18 +59,12 @@ const DesktopTableRow = ({
       pool_apr: pool.allApr,
       chain: pool.chain?.name,
     })
-    onOpenZapInWidget({
-      pool: {
-        dex: pool.exchange,
-        chainId: (pool.chain?.id || pool.chainId) as number,
-        address: pool.address,
-      },
-    })
   }
 
   return (
-    <TableRow
-      onClick={e => handleOpenZapInWidget(e)}
+    <TableRowLink
+      to={poolDetailUrl}
+      onClick={handlePoolClick}
       className="animate-[fadeInUp_0.3s_ease-out_both] cursor-pointer hover:bg-primary-10 motion-reduce:animate-none"
       style={{ gridTemplateColumns: getPoolTableGridTemplateColumns(showRewards, showPoolPrice), animationDelay }}
       data-testid="earn-pool-row"
@@ -163,7 +155,7 @@ const DesktopTableRow = ({
           />
         )}
       </TableCell>
-    </TableRow>
+    </TableRowLink>
   )
 }
 

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/MobileTableRow.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/MobileTableRow.tsx
@@ -12,14 +12,14 @@ import {
   HeaderText,
   MobileTableBottomRow,
   MobileTableCell,
-  MobileTableRow as MobileTableRowComponent,
+  MobileTableRowLink,
   SymbolText,
 } from 'pages/Earns/PoolExplorer/styles'
 import PoolAprBadges from 'pages/Earns/components/PoolAprBadges'
 import PoolAprInfo from 'pages/Earns/components/PoolAprInfo'
 import PoolRewardsInfo from 'pages/Earns/components/PoolRewardsInfo'
-import { ZapInInfo } from 'pages/Earns/hooks/useZapInWidget'
 import { ParsedEarnPool } from 'pages/Earns/types'
+import { getPoolDetailUrl } from 'pages/Earns/utils/url'
 import { formatDisplayNumber } from 'utils/numbers'
 import { prefetchPoolDetail } from 'utils/prefetch'
 
@@ -27,14 +27,12 @@ const MobileTableRow = ({
   pool,
   showRewards = true,
   rowIndex,
-  onOpenZapInWidget,
   handleFavorite,
 }: {
   pool: ParsedEarnPool
   showRewards?: boolean
   /** 0-based position within the current page — drives the staggered fade-in delay. */
   rowIndex: number
-  onOpenZapInWidget: ({ pool, initialTick }: ZapInInfo) => void
   handleFavorite: (e: React.MouseEvent<SVGElement, MouseEvent>, pool: ParsedEarnPool) => Promise<void>
 }) => {
   const theme = useTheme()
@@ -43,15 +41,15 @@ const MobileTableRow = ({
   // Stagger each row's fade-in by 50ms (capped at 300ms), matching the My Positions list.
   const animationDelay = `${Math.min(rowIndex * 50, 300)}ms`
 
-  // Same as the desktop row: the row's onClick opens the pool's detail page, so warm that page's chunk +
-  // poolDetail query on touch-intent (onTouchStart is the only practically-relevant trigger on mobile).
+  const poolDetailUrl = getPoolDetailUrl((pool.chain?.id || pool.chainId) as number, pool.exchange, pool.address)
+
+  // Same as the desktop row: warm the detail page on touch intent before the link is opened.
   const prefetchDetail = usePrefetchOnIntent(
     () => prefetchPoolDetail((pool.chain?.id || pool.chainId) as number, pool.address),
     { delay: 120 },
   )
 
-  const handleOpenZapInWidget = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation()
+  const handlePoolClick = () => {
     trackingHandler(TRACKING_EVENT_TYPE.LIQ_POOL_SELECTED, {
       pool_pair: `${pool.tokens?.[0]?.symbol}/${pool.tokens?.[1]?.symbol}`,
       pool_protocol: pool.dexName,
@@ -61,18 +59,12 @@ const MobileTableRow = ({
       pool_apr: pool.allApr,
       chain: pool.chain?.name,
     })
-    onOpenZapInWidget({
-      pool: {
-        dex: pool.exchange,
-        chainId: (pool.chain?.id || pool.chainId) as number,
-        address: pool.address,
-      },
-    })
   }
 
   return (
-    <MobileTableRowComponent
-      onClick={e => handleOpenZapInWidget(e)}
+    <MobileTableRowLink
+      to={poolDetailUrl}
+      onClick={handlePoolClick}
       className="animate-[fadeInUp_0.3s_ease-out_both] motion-reduce:animate-none"
       style={{ animationDelay }}
       data-testid="earn-pool-row"
@@ -158,7 +150,7 @@ const MobileTableRow = ({
           />
         </MobileTableCell>
       </MobileTableBottomRow>
-    </MobileTableRowComponent>
+    </MobileTableRowLink>
   )
 }
 

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/TableContent.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/TableContent.tsx
@@ -11,7 +11,6 @@ import DesktopTableRow from 'pages/Earns/PoolExplorer/DesktopTableRow'
 import MobileTableRow from 'pages/Earns/PoolExplorer/MobileTableRow'
 import useFavoritePool from 'pages/Earns/PoolExplorer/useFavoritePool'
 import { EARN_DEXES } from 'pages/Earns/constants'
-import { ZapInInfo } from 'pages/Earns/hooks/useZapInWidget'
 import Updater from 'state/customizeDexes/updater'
 import { useAppSelector } from 'state/hooks'
 import { MEDIA_WIDTHS } from 'theme'
@@ -24,13 +23,12 @@ export const dexKeyMapping: { [key: string]: string } = {
 const POLLING_INTERVAL_MS = 5 * 60_000
 
 type Props = {
-  onOpenZapInWidget: ({ pool }: ZapInInfo) => void
   filters: PoolQueryParams
   showRewards?: boolean
   showPoolPrice?: boolean
 }
 
-const TableContent = ({ onOpenZapInWidget, filters, showRewards = true, showPoolPrice = true }: Props) => {
+const TableContent = ({ filters, showRewards = true, showPoolPrice = true }: Props) => {
   const allDexes = useAppSelector(state => state.customizeDexes.allDexes)
   const {
     data: poolData,
@@ -113,7 +111,6 @@ const TableContent = ({ onOpenZapInWidget, filters, showRewards = true, showPool
               pool={pool}
               rowIndex={index}
               showRewards={showRewards}
-              onOpenZapInWidget={onOpenZapInWidget}
               handleFavorite={handleFavorite}
             />
           ))}
@@ -126,7 +123,6 @@ const TableContent = ({ onOpenZapInWidget, filters, showRewards = true, showPool
             rowIndex={index}
             showRewards={showRewards}
             showPoolPrice={showPoolPrice}
-            onOpenZapInWidget={onOpenZapInWidget}
             handleFavorite={handleFavorite}
             favoriteLoading={favoriteLoading}
           />

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/index.tsx
@@ -28,9 +28,8 @@ import useFilter from 'pages/Earns/PoolExplorer/useFilter'
 import { Exchange } from 'pages/Earns/constants'
 import useSmartExitWidget from 'pages/Earns/hooks/useSmartExitWidget'
 import useZapCreatePoolWidget from 'pages/Earns/hooks/useZapCreatePoolWidget'
-import useZapInWidget, { ZapInInfo } from 'pages/Earns/hooks/useZapInWidget'
+import useZapInWidget from 'pages/Earns/hooks/useZapInWidget'
 import useZapMigrationWidget from 'pages/Earns/hooks/useZapMigrationWidget'
-import { getPoolDetailUrl } from 'pages/Earns/utils/url'
 import { Direction } from 'pages/MarketOverview/SortIcon'
 import { useNotify } from 'state/application/hooks'
 import { MEDIA_WIDTHS } from 'theme'
@@ -117,21 +116,6 @@ const PoolExplorer = () => {
       return
     }
   }
-
-  const handleNavigateToAddLiquidity = useCallback(
-    ({ pool, initialTick }: ZapInInfo) => {
-      const pathname = getPoolDetailUrl(pool.chainId, pool.dex, pool.address)
-      // tickLower/tickUpper are passed as optional query params: currently unread by the detail page,
-      // but preserved so a future zap-migration reader can still pick them up.
-      const params = new URLSearchParams()
-      if (initialTick?.tickLower !== undefined) params.set('tickLower', initialTick.tickLower.toString())
-      if (initialTick?.tickUpper !== undefined) params.set('tickUpper', initialTick.tickUpper.toString())
-      const search = params.toString()
-
-      navigate(search ? { pathname, search: `?${search}` } : pathname)
-    },
-    [navigate],
-  )
 
   const handleRemoveUrlParams = useCallback(() => {
     searchParams.delete('exchange')
@@ -265,12 +249,7 @@ const PoolExplorer = () => {
             showRewards={showRewards}
             showPoolPrice={showPoolPrice}
           />
-          <TableContent
-            onOpenZapInWidget={handleNavigateToAddLiquidity}
-            filters={filters}
-            showRewards={showRewards}
-            showPoolPrice={showPoolPrice}
-          />
+          <TableContent filters={filters} showRewards={showRewards} showPoolPrice={showPoolPrice} />
         </div>
         {!isError && (
           <Pagination

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/styles.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/styles.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, HTMLAttributes, forwardRef } from 'react'
+import { LinkProps } from 'react-router-dom'
 
-import { TableWrapper } from 'components/Listing/Table'
+import { TableRowLink, TableWrapper } from 'components/Listing/Table'
 import { cn } from 'utils/cn'
 
 export const HeadSection = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...rest }, ref) => (
@@ -136,6 +137,15 @@ export const MobileTableRow = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivE
   ),
 )
 MobileTableRow.displayName = 'MobileTableRow'
+
+export const MobileTableRowLink = forwardRef<HTMLAnchorElement, LinkProps>(({ className, ...rest }, ref) => (
+  <TableRowLink
+    ref={ref}
+    className={cn('block cursor-pointer rounded-xl bg-background p-2 text-inherit hover:bg-buttonGray', className)}
+    {...rest}
+  />
+))
+MobileTableRowLink.displayName = 'MobileTableRowLink'
 
 type MobileTableCellProps = HTMLAttributes<HTMLDivElement> & {
   alignItems?: CSSProperties['alignItems']

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/useFavoritePool.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/useFavoritePool.ts
@@ -92,6 +92,7 @@ const useFavoritePool = ({ refetch }: { refetch?: () => void }) => {
 
   const handleFavorite = async (e: React.MouseEvent<SVGElement, MouseEvent>, pool: ParsedEarnPool) => {
     e.stopPropagation()
+    e.preventDefault()
     if (favoriteLoading.includes(pool.address) || delayFavorite) return
 
     const isPoolFavorite = !!pool.favorite?.isFavorite

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/styles.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/styles.tsx
@@ -1,8 +1,8 @@
 import { HTMLAttributes, forwardRef } from 'react'
-import { Link, LinkProps } from 'react-router-dom'
+import { LinkProps } from 'react-router-dom'
 
 import { ReactComponent as IconCurrentPrice } from 'assets/svg/earn/ic_position_current_price.svg'
-import { TableHeader, TableWrapper, getPositionTableGridTemplateColumns } from 'components/Listing/Table'
+import { TableHeader, TableRowLink, TableWrapper, getPositionTableGridTemplateColumns } from 'components/Listing/Table'
 import { cn } from 'utils/cn'
 
 type PositionRowProps = LinkProps & {
@@ -13,10 +13,10 @@ export const PositionRow = forwardRef<HTMLAnchorElement, PositionRowProps>(
   ({ $isUnfinalized, $index, className, style, ...rest }, ref) => {
     const delay = Math.min(($index || 0) * 50, 300)
     return (
-      <Link
+      <TableRowLink
         ref={ref}
         className={cn(
-          'relative grid grid-rows-[1fr] items-center p-3 !text-inherit no-underline',
+          'relative grid-rows-[1fr] !text-inherit',
           'animate-[fadeInUp_0.3s_ease-out_both] motion-reduce:animate-none',
           'hover:cursor-pointer hover:bg-primary-10',
           $isUnfinalized && 'bg-tableHeader/40',


### PR DESCRIPTION
## Summary
- Derive the available maker amount after active order commitments and clamp it at zero.
- Use the available amount for Max, Half, and wallet-row actions while preserving native balance behavior.