### PR TITLE
fix(earn): make pool explorer rows openable in a new tab

### DIFF
--- a/apps/kyberswap-interface/src/components/Listing/Table.tsx
+++ b/apps/kyberswap-interface/src/components/Listing/Table.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, HTMLAttributes } from 'react'
+import { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, createElement } from 'react'
 
 import { cn } from 'utils/cn'
 
@@ -44,6 +44,15 @@ export const TableCell = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>
   />
 )
 
-export const TableRow = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('grid items-center p-3 text-subText', className)} {...rest} />
-)
+type TableRowProps = HTMLAttributes<HTMLElement> &
+  Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'> & {
+    /** Render as a different element — pass `a` together with `href` to make the whole row a real link. */
+    as?: keyof React.JSX.IntrinsicElements
+  }
+
+export const TableRow = ({ as = 'div', className, ...rest }: TableRowProps) =>
+  createElement(as, {
+    // An `a` row must keep the row's own text color instead of the global link color/hover.
+    className: cn('grid items-center p-3 text-subText', as === 'a' && 'hover:text-subText', className),
+    ...rest,
+  })

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/DesktopTableRow.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/DesktopTableRow.tsx
@@ -16,6 +16,7 @@ import PoolAprInfo from 'pages/Earns/components/PoolAprInfo'
 import PoolRewardsInfo from 'pages/Earns/components/PoolRewardsInfo'
 import { ZapInInfo } from 'pages/Earns/hooks/useZapInWidget'
 import { ParsedEarnPool } from 'pages/Earns/types'
+import { getPoolDetailUrl } from 'pages/Earns/utils/url'
 import { formatDisplayNumber } from 'utils/numbers'
 import { prefetchPoolDetail } from 'utils/prefetch'
 
@@ -40,17 +41,20 @@ const DesktopTableRow = ({
   const theme = useTheme()
   const { trackingHandler } = useTracking()
 
+  const poolChainId = (pool.chain?.id || pool.chainId) as number
+
   // Stagger each row's fade-in by 50ms (capped at 300ms), matching the My Positions list.
   const animationDelay = `${Math.min(rowIndex * 50, 300)}ms`
 
   // The parent wires this row's onClick (onOpenZapInWidget) to open the pool's detail page, so warm
   // that page's chunk + its poolDetail query on hover.
-  const prefetchDetail = usePrefetchOnIntent(
-    () => prefetchPoolDetail((pool.chain?.id || pool.chainId) as number, pool.address),
-    { delay: 120 },
-  )
+  const prefetchDetail = usePrefetchOnIntent(() => prefetchPoolDetail(poolChainId, pool.address), { delay: 120 })
 
-  const handleOpenZapInWidget = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleOpenZapInWidget = (e: React.MouseEvent<HTMLElement>) => {
+    // Modified clicks (cmd/ctrl/shift/alt or a non-primary button) belong to the browser so the row's
+    // href can open in a new tab or window; only a plain click routes in-app.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return
+    e.preventDefault()
     e.stopPropagation()
     trackingHandler(TRACKING_EVENT_TYPE.LIQ_POOL_SELECTED, {
       pool_pair: `${pool.tokens?.[0]?.symbol}/${pool.tokens?.[1]?.symbol}`,
@@ -64,7 +68,7 @@ const DesktopTableRow = ({
     onOpenZapInWidget({
       pool: {
         dex: pool.exchange,
-        chainId: (pool.chain?.id || pool.chainId) as number,
+        chainId: poolChainId,
         address: pool.address,
       },
     })
@@ -72,12 +76,14 @@ const DesktopTableRow = ({
 
   return (
     <TableRow
+      as="a"
+      href={getPoolDetailUrl(poolChainId, pool.exchange, pool.address)}
       onClick={e => handleOpenZapInWidget(e)}
       className="animate-[fadeInUp_0.3s_ease-out_both] cursor-pointer hover:bg-primary-10 motion-reduce:animate-none"
       style={{ gridTemplateColumns: getPoolTableGridTemplateColumns(showRewards, showPoolPrice), animationDelay }}
       data-testid="earn-pool-row"
       data-pool-address={pool.address}
-      data-chain-id={pool.chain?.id || pool.chainId}
+      data-chain-id={poolChainId}
       data-exchange={pool.exchange}
       {...prefetchDetail}
     >

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/MobileTableRow.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/MobileTableRow.tsx
@@ -20,6 +20,7 @@ import PoolAprInfo from 'pages/Earns/components/PoolAprInfo'
 import PoolRewardsInfo from 'pages/Earns/components/PoolRewardsInfo'
 import { ZapInInfo } from 'pages/Earns/hooks/useZapInWidget'
 import { ParsedEarnPool } from 'pages/Earns/types'
+import { getPoolDetailUrl } from 'pages/Earns/utils/url'
 import { formatDisplayNumber } from 'utils/numbers'
 import { prefetchPoolDetail } from 'utils/prefetch'
 
@@ -40,17 +41,20 @@ const MobileTableRow = ({
   const theme = useTheme()
   const { trackingHandler } = useTracking()
 
+  const poolChainId = (pool.chain?.id || pool.chainId) as number
+
   // Stagger each row's fade-in by 50ms (capped at 300ms), matching the My Positions list.
   const animationDelay = `${Math.min(rowIndex * 50, 300)}ms`
 
   // Same as the desktop row: the row's onClick opens the pool's detail page, so warm that page's chunk +
   // poolDetail query on touch-intent (onTouchStart is the only practically-relevant trigger on mobile).
-  const prefetchDetail = usePrefetchOnIntent(
-    () => prefetchPoolDetail((pool.chain?.id || pool.chainId) as number, pool.address),
-    { delay: 120 },
-  )
+  const prefetchDetail = usePrefetchOnIntent(() => prefetchPoolDetail(poolChainId, pool.address), { delay: 120 })
 
-  const handleOpenZapInWidget = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleOpenZapInWidget = (e: React.MouseEvent<HTMLElement>) => {
+    // Modified clicks (cmd/ctrl/shift/alt or a non-primary button) belong to the browser so the row's
+    // href can open in a new tab or window; only a plain click routes in-app.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return
+    e.preventDefault()
     e.stopPropagation()
     trackingHandler(TRACKING_EVENT_TYPE.LIQ_POOL_SELECTED, {
       pool_pair: `${pool.tokens?.[0]?.symbol}/${pool.tokens?.[1]?.symbol}`,
@@ -64,7 +68,7 @@ const MobileTableRow = ({
     onOpenZapInWidget({
       pool: {
         dex: pool.exchange,
-        chainId: (pool.chain?.id || pool.chainId) as number,
+        chainId: poolChainId,
         address: pool.address,
       },
     })
@@ -72,12 +76,14 @@ const MobileTableRow = ({
 
   return (
     <MobileTableRowComponent
+      as="a"
+      href={getPoolDetailUrl(poolChainId, pool.exchange, pool.address)}
       onClick={e => handleOpenZapInWidget(e)}
       className="animate-[fadeInUp_0.3s_ease-out_both] motion-reduce:animate-none"
       style={{ animationDelay }}
       data-testid="earn-pool-row"
       data-pool-address={pool.address}
-      data-chain-id={pool.chain?.id || pool.chainId}
+      data-chain-id={poolChainId}
       data-exchange={pool.exchange}
       {...prefetchDetail}
     >

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/styles.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/styles.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, HTMLAttributes, forwardRef } from 'react'
+import { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, createElement, forwardRef } from 'react'
 
 import { TableWrapper } from 'components/Listing/Table'
 import { cn } from 'utils/cn'
@@ -126,14 +126,24 @@ export const Apr = forwardRef<HTMLDivElement, AprProps>(({ className, value, ...
 ))
 Apr.displayName = 'Apr'
 
-export const MobileTableRow = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...rest }, ref) => (
-    <div
-      ref={ref}
-      className={cn('cursor-pointer rounded-xl bg-background p-2 hover:bg-buttonGray', className)}
-      {...rest}
-    />
-  ),
+type MobileTableRowProps = HTMLAttributes<HTMLElement> &
+  Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'> & {
+    /** Render as a different element — pass `a` together with `href` to make the whole row a real link. */
+    as?: keyof React.JSX.IntrinsicElements
+  }
+
+export const MobileTableRow = forwardRef<HTMLElement, MobileTableRowProps>(({ as = 'div', className, ...rest }, ref) =>
+  createElement(as, {
+    ref,
+    // An `a` row stays block-level and inherits the surrounding text color instead of taking the
+    // global link color/hover.
+    className: cn(
+      'cursor-pointer rounded-xl bg-background p-2 hover:bg-buttonGray',
+      as === 'a' && 'block text-inherit hover:text-inherit',
+      className,
+    ),
+    ...rest,
+  }),
 )
 MobileTableRow.displayName = 'MobileTableRow'
 

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/useFavoritePool.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/useFavoritePool.ts
@@ -91,6 +91,8 @@ const useFavoritePool = ({ refetch }: { refetch?: () => void }) => {
   )
 
   const handleFavorite = async (e: React.MouseEvent<SVGElement, MouseEvent>, pool: ParsedEarnPool) => {
+    // The star sits inside the row's `a`, so cancel the link navigation as well as the row's onClick.
+    e.preventDefault()
     e.stopPropagation()
     if (favoriteLoading.includes(pool.address) || delayFavorite) return
 


### PR DESCRIPTION
## Summary

- Desktop and mobile rows in the Pool Explorer render as `a` elements pointing at the pool-detail URL (`/pools/<chain>/<protocol>/<address>`), so a pool can be opened in a new tab or window, copied as a link, and reached by keyboard.
- A plain click still routes in-app through the existing handler, keeping the `LIQ_POOL_SELECTED` tracking and SPA navigation. Clicks carrying cmd/ctrl/shift/alt or a non-primary button fall through to the browser.
- `TableRow` (`components/Listing/Table`) and the Pool Explorer's `MobileTableRow` take an `as` prop; when rendered as `a` they neutralise the global link color and hover rule, and the mobile row stays block-level, so the rows look exactly as before.
- The favorite star cancels the row link's default navigation in addition to stopping propagation, so toggling a favorite stays on the list.