### PR TITLE
fix(earn): bound the wallet-restore gate so the positions list can settle

### DIFF
--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -431,7 +431,7 @@ const transports = Object.fromEntries(
 const PORTO_CONNECTOR_ID = 'xyz.ithaca.porto'
 
 /** The connector a returning visitor last connected with, as wagmi persists it (JSON-encoded). */
-const readRecentConnectorId = (): string | undefined => {
+export const readRecentConnectorId = (): string | undefined => {
   if (typeof window === 'undefined' || !window.localStorage) return undefined
   try {
     const raw = window.localStorage.getItem('wagmi.recentConnectorId')

--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -431,13 +431,31 @@ const transports = Object.fromEntries(
 const PORTO_CONNECTOR_ID = 'xyz.ithaca.porto'
 
 /** The connector a returning visitor last connected with, as wagmi persists it (JSON-encoded). */
-export const readRecentConnectorId = (): string | undefined => {
+const readRecentConnectorId = (): string | undefined => {
   if (typeof window === 'undefined' || !window.localStorage) return undefined
   try {
     const raw = window.localStorage.getItem('wagmi.recentConnectorId')
     return raw ? (JSON.parse(raw) as string) : undefined
   } catch {
     return undefined
+  }
+}
+
+/**
+ * Whether wagmi persisted a live connection, i.e. whether there is a session worth restoring at boot.
+ *
+ * `recentConnectorId` cannot answer this: wagmi leaves it in place through `disconnect()`, so it only
+ * says which wallet was picked last, not whether it is still connected. `state.current` does — wagmi
+ * clears it the moment the last connection goes away, and persists that.
+ */
+export const hasPersistedConnection = (): boolean => {
+  if (typeof window === 'undefined' || !window.localStorage) return false
+  try {
+    const raw = window.localStorage.getItem('wagmi.store')
+    if (!raw) return false
+    return !!(JSON.parse(raw) as { state?: { current?: string | null } }).state?.current
+  } catch {
+    return false
   }
 }
 
@@ -552,6 +570,10 @@ export default function Web3Provider({ children }: { children: ReactNode }) {
   // learn they have no session. Scoping the walk to the connector they actually last used skips all of it:
   // with no stored id there is nothing to restore, so no SDK loads at all.
   //
+  // The stored id alone is not enough to decide there is something to restore, since it outlives
+  // `disconnect()` — hence the persisted-connection check first, which is what tells a visitor who left
+  // connected apart from one who disconnected and never came back.
+  //
   // Runs on mount rather than at idle so a returning visitor's wallet reconnects as promptly as before. If
   // the stored id names a connector we cannot resolve yet — EIP-6963 wallets announce asynchronously, so a
   // discovered connector may not be registered at this point — fall back to wagmi's full walk rather than
@@ -559,6 +581,8 @@ export default function Web3Provider({ children }: { children: ReactNode }) {
   // registerPortoConnector() runs, which reconnects it itself, so the full walk here would only load every
   // other wallet's SDK for nothing.
   useEffect(() => {
+    if (!hasPersistedConnection()) return
+
     const recentConnectorId = readRecentConnectorId()
     if (!recentConnectorId || recentConnectorId === PORTO_CONNECTOR_ID) return
 
@@ -573,9 +597,11 @@ export default function Web3Provider({ children }: { children: ReactNode }) {
   // via `connector.getProvider()`, and gives up without ever reaching
   // `isAuthorized()` (where the shim lives). Poll for the bootstrap object and,
   // once it lands, re-trigger reconnect so the custom safepalConnector finds it.
-  // Guarded so it only runs while no other connector is current.
+  // Guarded so it only runs while no other connector is current, and only for a visitor who left
+  // connected — recovering a session nobody had would walk every connector for nothing.
   useEffect(() => {
     if (typeof window === 'undefined') return
+    if (!hasPersistedConnection()) return
 
     let triggered = false
     let pollHandle: ReturnType<typeof setInterval> | null = null

--- a/apps/kyberswap-interface/src/pages/Earns/SmartExitOrders/useSmartExitOrdersData.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/SmartExitOrders/useSmartExitOrdersData.ts
@@ -69,6 +69,8 @@ export type ParsedSmartExitOrder = SmartExitOrder & {
   }
 }
 
+const EMPTY_ORDERS: ParsedSmartExitOrder[] = []
+
 type UseSmartExitOrdersDataParams = {
   account?: string | null
   filters: SmartExitFilter
@@ -86,7 +88,7 @@ export function useSmartExitOrdersData({ account, filters, pageSize, updateFilte
   const lastCurrentPageRef = useRef<number>(1)
 
   const {
-    data: ordersData,
+    data: ordersResult,
     isLoading: smartExitLoading,
     isFetching: smartExitFetching,
     error: ordersError,
@@ -104,6 +106,10 @@ export function useSmartExitOrdersData({ account, filters, pageSize, updateFilte
       pollingInterval: 30000,
     },
   )
+
+  // RTK Query holds on to the last result once a query is skipped, so disconnecting would otherwise leave
+  // the previous wallet's orders and pagination on screen.
+  const ordersData = account ? ordersResult : undefined
 
   const orders = useMemo(() => ordersData?.orders || [], [ordersData])
   const totalItemsFromAPI = ordersData?.totalItems || 0
@@ -251,14 +257,17 @@ export function useSmartExitOrdersData({ account, filters, pageSize, updateFilte
     }
   }, [enrichedOrders, isDataSynced, totalItemsFromAPI, currentPage])
 
-  // Only show new orders when data is synced, otherwise keep showing cached orders
+  // Only show new orders when data is synced, otherwise keep showing cached orders. The cache exists to
+  // ride out a page change; with no wallet there is nothing to ride out and it holds orders belonging to
+  // the wallet that just went away.
   const renderedOrders = useMemo(() => {
+    if (!account) return EMPTY_ORDERS
     if (isDataSynced) {
       return enrichedOrders
     }
     // Keep showing cached orders while syncing
     return lastEnrichedOrdersRef.current
-  }, [enrichedOrders, isDataSynced])
+  }, [account, enrichedOrders, isDataSynced])
 
   const shouldShowEmptyState = useMemo(
     () =>
@@ -287,11 +296,12 @@ export function useSmartExitOrdersData({ account, filters, pageSize, updateFilte
   // Sync pagination with table data - update when fetch is complete
   // Use isFetchComplete (not isDataSynced) to handle empty results correctly
   const syncedTotalItems = useMemo(() => {
+    if (!account) return 0
     if (isFetchComplete) {
       return totalItemsFromAPI
     }
     return lastTotalItemsRef.current
-  }, [isFetchComplete, totalItemsFromAPI])
+  }, [account, isFetchComplete, totalItemsFromAPI])
 
   const syncedCurrentPage = useMemo(() => {
     if (isFetchComplete) {

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/TableContent.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/TableContent.tsx
@@ -306,7 +306,7 @@ export default function TableContent({
       {smartExitPosition && <SmartExit position={smartExitPosition} onDismiss={() => setSmartExitPosition(null)} />}
 
       <div className="max-[1300px]:flex max-[1300px]:flex-col max-[1300px]:gap-4">
-        {account && positions && positions.length > 0
+        {positions && positions.length > 0
           ? positions.map((position, index) => (
               <PositionRowItem
                 key={getUnfinalizedPositionKeyFromPosition(position) ?? position.positionId}

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
@@ -64,7 +64,7 @@ const UserPositions = () => {
   }, [account, filters])
 
   const {
-    data: userPositionsData,
+    data: userPositionsResult,
     isUninitialized,
     isLoading,
     isFetching,
@@ -74,6 +74,10 @@ const UserPositions = () => {
     skip: !account,
     pollingInterval: 15_000,
   })
+
+  // RTK Query holds on to the last result once a query is skipped, so disconnecting would otherwise leave
+  // the previous wallet's rows, table header and pagination on screen beside an empty list.
+  const userPositionsData = account ? userPositionsResult : undefined
 
   const positionsStats = userPositionsData?.stats
   const hasStartedPositionsRequest = !isUninitialized

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useIsWalletRestoring.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useIsWalletRestoring.ts
@@ -1,14 +1,41 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
+import { readRecentConnectorId } from 'components/Web3Provider'
 import { useAccount } from 'hooks/useAccount'
 
+// wagmi's boot walk has no timeout of its own: it awaits `connector.isAuthorized()` for each candidate,
+// and a wallet extension that never answers `eth_accounts` (locked, or busy behind an unresponsive
+// background page) leaves the status pinned at `connecting` for the rest of the session. Cap how long a
+// page defers to it, so a wallet that never reports back cannot hide the page's own empty state forever.
+// A wallet that lands after the cap still renders normally — `account` turns truthy and the data loads.
+const RESTORE_TIMEOUT = 5_000
+
+/**
+ * True while a previously connected wallet may still be restored, so a page can hold its loading state
+ * instead of flashing an empty "connect your wallet" view at a visitor whose wallet is about to return.
+ */
 export default function useIsWalletRestoring() {
   const { status } = useAccount()
-  const [hasPassedInitialRender, setHasPassedInitialRender] = useState(false)
+  const [isRestoring, setIsRestoring] = useState(true)
+  const hasStartedRestore = useRef(false)
 
   useEffect(() => {
-    setHasPassedInitialRender(true)
+    // Nothing was ever connected from this browser, so no restore will run at all.
+    if (!readRecentConnectorId()) {
+      setIsRestoring(false)
+      return
+    }
+
+    const timeout = setTimeout(() => setIsRestoring(false), RESTORE_TIMEOUT)
+    return () => clearTimeout(timeout)
   }, [])
 
-  return !hasPassedInitialRender || status === 'connecting' || status === 'reconnecting'
+  useEffect(() => {
+    // The restore starts in a Web3Provider effect, which React runs after this one, so `disconnected`
+    // here means "not started yet" until the status has been seen in flight at least once.
+    if (status === 'connecting' || status === 'reconnecting') hasStartedRestore.current = true
+    else if (hasStartedRestore.current) setIsRestoring(false)
+  }, [status])
+
+  return isRestoring
 }

--- a/apps/kyberswap-interface/src/pages/Earns/hooks/useIsWalletRestoring.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/hooks/useIsWalletRestoring.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-import { readRecentConnectorId } from 'components/Web3Provider'
+import { hasPersistedConnection } from 'components/Web3Provider'
 import { useAccount } from 'hooks/useAccount'
 
 // wagmi's boot walk has no timeout of its own: it awaits `connector.isAuthorized()` for each candidate,
@@ -20,8 +20,8 @@ export default function useIsWalletRestoring() {
   const hasStartedRestore = useRef(false)
 
   useEffect(() => {
-    // Nothing was ever connected from this browser, so no restore will run at all.
-    if (!readRecentConnectorId()) {
+    // The visitor left disconnected, so no restore will run and there is nothing to wait for.
+    if (!hasPersistedConnection()) {
       setIsRestoring(false)
       return
     }
@@ -31,6 +31,11 @@ export default function useIsWalletRestoring() {
   }, [])
 
   useEffect(() => {
+    // A wallet already in hand needs no restoring: this page was reached after one finished.
+    if (status === 'connected') {
+      setIsRestoring(false)
+      return
+    }
     // The restore starts in a Web3Provider effect, which React runs after this one, so `disconnected`
     // here means "not started yet" until the status has been seen in flight at least once.
     if (status === 'connecting' || status === 'reconnecting') hasStartedRestore.current = true


### PR DESCRIPTION
Two defects on the Earn listing pages, both about what they show when there is no wallet.

## Problem 1 — the page never leaves its skeleton

With no wallet connected, **My Liquidity Positions** (`/earn/positions`) and **Smart Exit Orders**
(`/earn/smart-exit`) sit on their loading skeleton instead of showing the empty state and its
**Connect Wallet** prompt — indefinitely for some visitors, and for several seconds after an explicit
disconnect and reload even though there is no wallet left to wait for.

### Root cause

Three things line up:

1. **`wagmi.recentConnectorId` outlives the session.** wagmi's `disconnect()` does not clear it, so every
   load in a browser that has *ever* connected a wallet starts the boot reconnect in `Web3Provider` —
   including for someone who deliberately disconnected.
2. **`@wagmi/core`'s `reconnect()` has no timeout.** It awaits `connector.isAuthorized()` per candidate,
   which for an injected connector means `eth_accounts`. A locked or unresponsive extension never
   answers, so the walk never finishes and `config.state.status` stays `'connecting'` for the rest of
   the session. (Its module-level `isReconnecting` flag stays `true` too, so no later reconnect can run
   either.)
3. **`useIsWalletRestoring()` mirrored that status with no upper bound**, and both pages feed it straight
   into `isInitialLoading`.

Introduced in 06424d054 (#3270), which replaced `initialLoading = isFetching && loading` with
`isInitialLoading = isRestoringWallet || …`. Before that, the positions query is `skip: !account`, so
with no wallet `isFetching` was `false` and the empty state rendered immediately. 6f0c6b6db (#3345)
later extracted the logic into `useIsWalletRestoring` and applied it to Smart Exit Orders as well,
widening the blast radius but not causing it.

### Fix

Keep the anti-flash intent of #3345 — a returning visitor should not see "Connect Wallet" blink while
their wallet reconnects — but only pay for it when a restore is actually possible, and never
unboundedly.

**Ask whether a session exists, not which wallet was last used.** wagmi persists `state.current` in
`wagmi.store` and clears it the moment the last connection goes away, so it distinguishes a visitor who
left connected from one who disconnected and never came back — which `recentConnectorId` cannot.
`hasPersistedConnection()` now gates the boot reconnect, the SafePal reconnect-recovery poll, and the
pages' restore state. A disconnected visitor renders immediately and loads no wallet SDK at boot.

**Bound what remains.** For a visitor who did leave connected, the wait is capped at `RESTORE_TIMEOUT`
(5s), released early as soon as a restore that started settles, and released immediately when the status
already reads `connected` — so reaching either page from an in-app navigation does not wait out the cap.

Effect ordering matters here and is called out in a comment: a page hook's effect runs *before*
`Web3Provider`'s reconnect effect, so a `'disconnected'` status at mount means "not started yet", not
"finished". A ref tracks whether the restore was ever seen in flight.

## Problem 2 — the previous wallet's data outlives the disconnect

Disconnecting left the last wallet's table header, rows and pagination on screen, sitting above an
empty list (see the report on this PR).

### Root cause

RTK Query keeps serving the last result once a query is skipped — `queryStatePreSelector` only discards
`lastResult` when the args are unchanged, and a skipped query's args are `skipToken` — so the data these
pages derive from outlives the account that produced it.

The positions table only looked half-right because the row list carried its own `account` guard
(`account && positions.length > 0`) that the table header and pagination did not share. Smart Exit Orders
had no guard at all and kept rendering the orders themselves, plus refs that cache orders and totals to
ride out a page change.

### Fix

Clear the query result at the boundary in both pages — `const data = account ? result : undefined` —
so everything derived from it agrees, and drop the row-level guard that papered over half of it. On the
Smart Exit page the ref caches are bypassed with no wallet: there is no page change to ride out, and
they hold the departed wallet's orders.
