### PR TITLE
fix(earn): keep a position open when it is loaded in a new tab

### DIFF
--- a/apps/kyberswap-interface/src/pages/Earns/PositionDetail/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PositionDetail/index.tsx
@@ -31,6 +31,7 @@ import { CoreProtocol } from 'pages/Earns/constants/coreProtocol'
 import useClosedPositions, { CheckClosedPositionParams } from 'pages/Earns/hooks/useClosedPositions'
 import useFarmingStablePools from 'pages/Earns/hooks/useFarmingStablePools'
 import useForceLoading from 'pages/Earns/hooks/useForceLoading'
+import useIsWalletRestoring from 'pages/Earns/hooks/useIsWalletRestoring'
 import useKemRewards from 'pages/Earns/hooks/useKemRewards'
 import useMerklRewards from 'pages/Earns/hooks/useMerklRewards'
 import useReduceFetchInterval from 'pages/Earns/hooks/useReduceFetchInterval'
@@ -57,6 +58,7 @@ const PositionDetail = () => {
   const navigate = useNavigate()
 
   const { account } = useActiveWeb3React()
+  const isRestoringWallet = useIsWalletRestoring()
   const { forceLoading, removeForceLoading } = useForceLoading()
   const { positionId, chainId, exchange } = useParams()
   const { widget: zapMigrationWidget, handleOpenZapMigration, triggerClose, setTriggerClose } = useZapMigrationWidget()
@@ -156,7 +158,14 @@ const PositionDetail = () => {
 
   // A request in flight with nothing to show for this route means the position is still on its way, whether
   // that is the first load or a move between two position pages; skeletons beat an empty state either way.
-  const initialLoading = !!(forceLoading || (isLoading && !firstLoading.current) || (!position && isFetching))
+  // A wallet still being restored counts too: the query is skipped until it lands, so nothing is in flight
+  // yet and "No position found" would be answering a question that has not been asked.
+  const initialLoading = !!(
+    forceLoading ||
+    isRestoringWallet ||
+    (isLoading && !firstLoading.current) ||
+    (!position && isFetching)
+  )
 
   const farmingPoolsByChain = useFarmingStablePools({ chainIds: position ? [position.chain.id] : [] })
 
@@ -272,9 +281,21 @@ const PositionDetail = () => {
     if (!firstLoading.current && !isLoading) firstLoading.current = true
   }, [isLoading])
 
+  // Sends the visitor back to the list once this page no longer belongs to the wallet in hand.
+  //
+  // Opening a position in a new tab lands here before the wallet has been restored, so `account` is
+  // briefly undefined through no fault of the visitor: waiting for the restore is what keeps that cold
+  // load on the page instead of bouncing it straight back to the list. The wallet that arrives is then
+  // the one this page belongs to — `currentWalletAddress` is seeded at mount, which a cold load reaches
+  // before there is anything to seed it with.
   useEffect(() => {
+    if (isRestoringWallet) return
+    if (account && !currentWalletAddress.current) {
+      currentWalletAddress.current = account
+      return
+    }
     if (!account || account !== currentWalletAddress.current) navigate(APP_PATHS.EARN_POSITIONS)
-  }, [account, navigate])
+  }, [account, isRestoringWallet, navigate])
 
   // `?forceLoading=true` is the hand-off from the zap flow: caching the placeholder needs the mined receipt,
   // so the page holds its skeletons rather than flashing "No position found" in between. `position` is


### PR DESCRIPTION
## Problem

Opening a position in a new tab (⌘-click / middle-click from **My Liquidity Positions**, or pasting the
URL) lands on the position for a moment and then bounces back to `/earn/positions`. Clicking through
from the list normally works fine — so the position, the route and the data are all fine. What differs
is that a new tab is a cold load.

Reported on production.

## Root cause

`PositionDetail` sends the visitor back to the list once the page no longer belongs to the wallet in
hand:

```ts
const currentWalletAddress = useRef(account)          // seeded at the first render
…
useEffect(() => {
  if (!account || account !== currentWalletAddress.current) navigate(APP_PATHS.EARN_POSITIONS)
}, [account, navigate])
```

A cold load reaches that first render *before* the wallet has been restored, so `account` is still
undefined:

- the guard reads that as "no wallet" and redirects immediately, and
- the ref is left holding `undefined`, so when the wallet lands a moment later `account !== ref` and it
  redirects a second time.

Clicking through from the list is a client-side navigation with the wallet already in hand, so `account`
is set at the first render, the ref matches it, and neither branch fires. Hence "only in a new tab".

It is a race, which is why it is easy to see on production and easy to miss locally: if the wallet
restore happens to land before the lazy `PositionDetail` chunk mounts, nothing redirects. With warm
chunks the component wins the race and the redirect fires.

Present since 2dfa281ce (Feat/zap-earn, #2557) — unrelated to #3353, which is what prompted the
investigation.

## Fix

Wait for the restore to settle before judging, and adopt the wallet that arrives as the one this page
belongs to:

```ts
useEffect(() => {
  if (isRestoringWallet) return
  if (account && !currentWalletAddress.current) {
    currentWalletAddress.current = account
    return
  }
  if (!account || account !== currentWalletAddress.current) navigate(APP_PATHS.EARN_POSITIONS)
}, [account, isRestoringWallet, navigate])
```

`useIsWalletRestoring()` (added in #3353) is exactly the "is a wallet still on its way?" signal this
needs: it is bounded, and it returns false immediately for a visitor with no persisted session, so a
direct URL with no wallet still bounces to the list without waiting.

That same window would also have rendered **"No position found"** over a page whose query is skipped
until the wallet lands — nothing was in flight yet, so `initialLoading` was false. `isRestoringWallet`
now feeds `initialLoading` too, holding the skeletons through it.
