### PR TITLE
fix(wallet): restore the wallet the visitor chose, not whichever answers first

### DIFF
--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -427,8 +427,12 @@ const transports = Object.fromEntries(
 
 // Porto's connector id, spelled out rather than imported so reading it cannot pull the Porto SDK back into
 // the entry chunk. registerPortoConnector() matches on the live `connector.id`, so if this ever drifts from
-// upstream the only cost is the mount effect falling back to wagmi's full walk again.
+// upstream the only cost is the mount effect waiting out its timeout before Porto registers itself.
 const PORTO_CONNECTOR_ID = 'xyz.ithaca.porto'
+
+// How long the boot restore waits for an EIP-6963 wallet to announce itself. Extensions announce within a
+// few frames of the page loading; past this, the wallet is treated as gone rather than kept waiting on.
+const CONNECTOR_ANNOUNCE_TIMEOUT = 2_000
 
 /** The connector a returning visitor last connected with, as wagmi persists it (JSON-encoded). */
 const readRecentConnectorId = (): string | undefined => {
@@ -574,20 +578,48 @@ export default function Web3Provider({ children }: { children: ReactNode }) {
   // `disconnect()` — hence the persisted-connection check first, which is what tells a visitor who left
   // connected apart from one who disconnected and never came back.
   //
-  // Runs on mount rather than at idle so a returning visitor's wallet reconnects as promptly as before. If
-  // the stored id names a connector we cannot resolve yet — EIP-6963 wallets announce asynchronously, so a
-  // discovered connector may not be registered at this point — fall back to wagmi's full walk rather than
-  // leave that visitor disconnected. Porto is the one exception: it is knowingly absent until
-  // registerPortoConnector() runs, which reconnects it itself, so the full walk here would only load every
-  // other wallet's SDK for nothing.
+  // Runs on mount rather than at idle so a returning visitor's wallet reconnects promptly. EIP-6963 wallets
+  // announce asynchronously, so the connector the stored id names may not be registered at this point —
+  // wait for it to arrive rather than falling back to wagmi's full walk. A walk restores whichever
+  // connector authorizes first, and the targetless injected one resolves whatever holds `window.ethereum`;
+  // with more than one extension installed that is not necessarily the wallet the visitor chose, and coming
+  // back as a different account is worse than coming back disconnected. Porto is excluded because it is
+  // knowingly absent until registerPortoConnector() runs, which reconnects it itself.
   useEffect(() => {
     if (!hasPersistedConnection()) return
 
     const recentConnectorId = readRecentConnectorId()
     if (!recentConnectorId || recentConnectorId === PORTO_CONNECTOR_ID) return
 
-    const recentConnector = wagmiConfig.connectors.find(connector => connector.id === recentConnectorId)
-    reconnect(wagmiConfig, recentConnector ? { connectors: [recentConnector] } : undefined).catch(() => {})
+    const findRecentConnector = () => wagmiConfig.connectors.find(connector => connector.id === recentConnectorId)
+    const restore = (connector: Connector) => {
+      reconnect(wagmiConfig, { connectors: [connector] }).catch(() => {})
+    }
+
+    const registeredConnector = findRecentConnector()
+    if (registeredConnector) {
+      restore(registeredConnector)
+      return
+    }
+
+    let unsubscribe: (() => void) | undefined
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const stopWaiting = () => {
+      if (timeout) clearTimeout(timeout)
+      unsubscribe?.()
+      timeout = undefined
+      unsubscribe = undefined
+    }
+
+    timeout = setTimeout(stopWaiting, CONNECTOR_ANNOUNCE_TIMEOUT)
+    unsubscribe = wagmiConfig._internal.connectors.subscribe(() => {
+      const announcedConnector = findRecentConnector()
+      if (!announcedConnector) return
+      stopWaiting()
+      restore(announcedConnector)
+    })
+
+    return stopWaiting
   }, [])
 
   // SafePal reconnect recovery. The extension lazy-attaches its EVM provider
@@ -597,11 +629,12 @@ export default function Web3Provider({ children }: { children: ReactNode }) {
   // via `connector.getProvider()`, and gives up without ever reaching
   // `isAuthorized()` (where the shim lives). Poll for the bootstrap object and,
   // once it lands, re-trigger reconnect so the custom safepalConnector finds it.
-  // Guarded so it only runs while no other connector is current, and only for a visitor who left
-  // connected — recovering a session nobody had would walk every connector for nothing.
+  // Guarded so it only runs while no other connector is current, and only for a visitor who left connected
+  // on SafePal — this recovers that one session, so it reconnects that one connector.
   useEffect(() => {
     if (typeof window === 'undefined') return
     if (!hasPersistedConnection()) return
+    if (readRecentConnectorId() !== CONNECTION.SAFEPAL) return
 
     let triggered = false
     let pollHandle: ReturnType<typeof setInterval> | null = null
@@ -610,6 +643,8 @@ export default function Web3Provider({ children }: { children: ReactNode }) {
       if (triggered) return
       if (!getSafepalProvider()) return
       if (wagmiConfig.state.current) return
+      const safepalConnector = wagmiConfig.connectors.find(connector => connector.id === CONNECTION.SAFEPAL)
+      if (!safepalConnector) return
       // Status `reconnecting`/`connecting` means wagmi is still iterating
       // connectors; calling reconnect() now hits its `isReconnecting` re-entry
       // guard and no-ops. Defer to the next poll tick.
@@ -617,7 +652,7 @@ export default function Web3Provider({ children }: { children: ReactNode }) {
       if (status === 'reconnecting' || status === 'connecting') return
       triggered = true
       if (pollHandle) clearInterval(pollHandle)
-      reconnect(wagmiConfig).catch(() => {})
+      reconnect(wagmiConfig, { connectors: [safepalConnector] }).catch(() => {})
     }
 
     let pollCount = 0


### PR DESCRIPTION
## Problem

A visitor connected on Rabby comes back as a **different wallet** on a cold load — a new tab, a refresh,
a pasted link. Reported from production: connected as Rabby `0xa2DFeb…2D2d`, opened a position in a new
tab, and the new tab reported OKX `0x169077…48037`.

On `/earn/position/…` that surfaces as a bounce back to `/earn/positions`, because the position does not
belong to the account that turned up — so the page correctly decides it is not the visitor's. The
redirect is a symptom; the wrong wallet is the defect. It is not limited to Earn: any cold load can come
back as the wrong account.

## Root cause

The boot restore in `Web3Provider` looks up the connector wagmi recorded as the last one used:

```ts
const recentConnector = wagmiConfig.connectors.find(connector => connector.id === recentConnectorId)
reconnect(wagmiConfig, recentConnector ? { connectors: [recentConnector] } : undefined)
```

Rabby is an EIP-6963 wallet, so its connector (`io.rabby`) is registered only once the extension
announces itself — asynchronously, and on a cold load often after this effect runs. The lookup misses and
falls through to `undefined`, which is wagmi's **full walk**: try every configured connector and keep the
first that authorizes.

Among those is the targetless injected connector (`injected`), which resolves whatever holds
`window.ethereum`. OKX takes that over, is authorized for the site, and wins the walk. The visitor is
reconnected as OKX.

The SafePal recovery poll further down calls `reconnect(wagmiConfig)` — also a full walk — and so carries
the same hazard.

## Fix

Wait for the named connector to announce itself, then reconnect **only** that one:

```ts
const registeredConnector = findRecentConnector()
if (registeredConnector) return restore(registeredConnector)

const timeout = setTimeout(stopWaiting, CONNECTOR_ANNOUNCE_TIMEOUT)   // 2s
const unsubscribe = wagmiConfig._internal.connectors.subscribe(() => {
  const announcedConnector = findRecentConnector()
  if (!announcedConnector) return
  stopWaiting()
  restore(announcedConnector)
})
```

Past the timeout the visitor stays disconnected and can connect again — which beats coming back as an
account they did not choose. 2s is generous: extensions announce within a few frames, and it sits inside
the 5s cap `useIsWalletRestoring` already puts on the Earn pages, so nothing hangs on it.

Connectors that are always registered — MetaMask, WalletConnect, Coinbase, Safe, SafePal — are found on
the first look and never wait, so their restore timing is unchanged.

The SafePal poll is scoped to the SafePal connector, and only runs when SafePal is the session on record.
