### PR TITLE
fix(wallet): stop a wallet the visitor did not pick from claiming the session

### DIFF
--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -463,6 +463,11 @@ export const hasPersistedConnection = (): boolean => {
   }
 }
 
+// Captured before `createConfig()` runs. wagmi rehydrates its persisted store asynchronously and writes
+// the empty pre-hydration state back to `wagmi.store` while it does, so a read taken any later in the same
+// tick reports no session for a visitor who has one.
+const hadPersistedConnectionAtBoot = hasPersistedConnection()
+
 export const wagmiConfig = createConfig({
   chains: wagmiChains,
   transports,
@@ -507,6 +512,38 @@ export const wagmiConfig = createConfig({
     ...HardCodedConnectors.map(connector => createPriorityConnector(connector)),
   ],
 })
+
+// wagmi turns a connector's own `connect` event straight into "this is the current connection", with no
+// authorization check and no regard for which wallet was last used — the hook that lets a wallet attach
+// itself when someone connects the site from inside the extension. Extensions fire that event while
+// announcing themselves on page load too, so with more than one installed, whichever fires first claims
+// the session: a visitor connected on one wallet comes back as another.
+//
+// While there is a session on record, leave the hook attached to that wallet alone. A visitor with no
+// session keeps every connector's hook and can still attach one from inside their extension, and picking
+// a wallet from the modal goes through `connect()`, which never consults it.
+//
+// Runs at module scope rather than from an effect because connectors are set up inside `createConfig()`,
+// so a wallet can claim the session before React has mounted.
+const restrictSelfConnectToRecordedWallet = () => {
+  if (!hadPersistedConnectionAtBoot) return
+
+  const recentConnectorId = readRecentConnectorId()
+  if (!recentConnectorId) return
+
+  const detachOthers = () => {
+    for (const connector of wagmiConfig.connectors) {
+      if (connector.id === recentConnectorId) continue
+      connector.emitter.off('connect', wagmiConfig._internal.events.connect)
+    }
+  }
+
+  detachOthers()
+  // EIP-6963 wallets register after this runs, so re-apply as they arrive.
+  wagmiConfig._internal.connectors.subscribe(detachOthers)
+}
+
+restrictSelfConnectToRecordedWallet()
 
 // Porto ships ~620KB of JS (the SDK plus its `ox` dependency) and is one wallet choice among many, so
 // importing it at module scope put all of it in the entry chunk that gates the app's first render for every


### PR DESCRIPTION
## Problem

Still reproducing after #3355: a visitor connected on Rabby `0xa2DFeb…2D2d` comes back as OKX
`0x169077…48037` on a cold load. On `/earn/position/…` that shows up as a bounce to the positions list,
because the position does not belong to the account that turned up.

#3355 fixed one route to this — the restore falling back to wagmi's full walk. This is a second,
independent one, which is why the symptom survived.

## Root cause

`createConfig()` wires **every** connector's own `connect` event straight into "this is now the current
connection":

```js
// This allows connectors to "connect" themselves without user interaction
// (e.g. MetaMask's "Manually connect to current site")
emitter.on('connect', connect)
```

`connect()` sets `current` and `status: 'connected'` with no authorization check and no regard for
`recentConnectorId`. Its only guard is `status === 'connecting' | 'reconnecting'`.

Extensions fire that event while announcing themselves on page load, not only when someone connects the
site by hand. With two installed, whichever fires takes the session — either before the scoped restore
has started, or *after* it has already put the right wallet in place, at which point it simply replaces
it.

Note this only affects **targeted** injected connectors, which is every EIP-6963 one:

```js
// Only start listening for events if `target` is set, otherwise `injected()` will also receive events
if (provider?.on && parameters.target) { provider.on('connect', …) }
```

## Fix

While a session is on record, leave that hook attached to the wallet on record and to nothing else —
detached via `connector.emitter.off('connect', wagmiConfig._internal.events.connect)`, exactly what
wagmi's own `reconnect()` does once a connector is connected. EIP-6963 wallets register after this runs,
so it re-applies from a `_internal.connectors` subscription.

A visitor with **no** session keeps every connector's hook, so attaching a wallet from inside the
extension still works. Picking a wallet from the modal goes through `connect()`, which never consults
this hook, so choosing a different wallet is unaffected.

It runs at module scope rather than from an effect because connectors are set up inside `createConfig()`
— a wallet can claim the session before React has mounted.

### The subtle part

Reading whether a session exists has to happen **before** `createConfig()`. wagmi rehydrates its
persisted store asynchronously and writes the empty pre-hydration state back to `wagmi.store` while it
does, so a read taken right after `createConfig()` reports `current: null` for a visitor who has a
session. That is exactly what happened on the first attempt at this fix — the guard bailed and the
restriction never ran. `hasPersistedConnection()` stays a live read for the React effects, which run
after hydration and want the current value.

## Testing

Two synthetic wallets in a real browser: OKX owning `window.ethereum`, both announcing over EIP-6963,
with providers that carry a real event emitter so `provider.on('connect')` actually fires. Persisted
Rabby session. Result read from `wagmi.store`.

| Scenario | Before | After |
| --- | --- | --- |
| OKX fires `connect` at 500ms | **OKX** (`com.okex.wallet`) | Rabby (`io.rabby`) |
| OKX fires `connect` at 6000ms, after the restore | **OKX** (`com.okex.wallet`) | Rabby (`io.rabby`) |
| Rabby announces late (800ms), OKX fires at 500ms | Rabby | Rabby |
| No OKX event at all | Rabby | Rabby |
| No session on record, OKX fires `connect` | OKX | OKX (unchanged — the legitimate case) |

Same script against `main` and this branch.

`tsc --noEmit`, `eslint` and `prettier --check` pass on the touched file.
