### PR TITLE
fix(cross-chain): avoid read-only quote refresh loop

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/components/SwapAction.tsx
@@ -80,7 +80,7 @@ export const SwapAction = ({ setShowBtcModal }: { setShowBtcModal: (val: boolean
     })
 
   const isFindingRoute = loading || (allLoading && !selectedQuote)
-  const isSelectedQuoteExecutable = isQuoteExecutable(selectedQuote, isFromEvm ? account : sender, receiver)
+  const isSelectedQuoteExecutable = isQuoteExecutable(selectedQuote, sender, receiver)
 
   // Restricted-token check applies only to EVM sides (the restricted list is keyed by EVM chainId).
   const restrictedCurrency =

--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/hooks/useCrossChainSwap.tsx
@@ -352,7 +352,9 @@ export const CrossChainSwapRegistryProvider = ({ children }: { children: React.R
   const abortControllerRef = useRef(new AbortController())
   const requestIdRef = useRef(0)
 
-  const evmWalletAddress = walletClient?.data?.account?.address
+  // Quote ownership follows the active account. The gated client can resolve
+  // later (or fail independently) and is only required when executing.
+  const evmWalletAddress = account
 
   const resolveAddress = (chain: Chain | undefined, role: 'sender' | 'receiver') => {
     const recipientAddress = role === 'receiver' ? recipient : undefined


### PR DESCRIPTION
## Summary
- Derive quote ownership from the active account instead of the asynchronously gated wallet client.
- Validate the selected quote against the same sender and receiver used by the quote request.