### PR TITLE
chore(analytics): upgrade @formo/analytics to 1.38 and enable wagmi mode

### DIFF
--- a/apps/kyberswap-interface/package.json
+++ b/apps/kyberswap-interface/package.json
@@ -37,7 +37,7 @@
     "@coinbase/wallet-sdk": "^4.3.7",
     "@defuse-protocol/one-click-sdk-typescript": "^0.1.2",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
-    "@formo/analytics": "^1.27.0",
+    "@formo/analytics": "^1.38.0",
     "@kyber/hooks": "workspace:^",
     "@kyber/rpc-client": "workspace:*",
     "@kyber/schema": "workspace:^",

--- a/apps/kyberswap-interface/src/components/Analytics/FormoBridge.tsx
+++ b/apps/kyberswap-interface/src/components/Analytics/FormoBridge.tsx
@@ -1,6 +1,7 @@
 import { FormoAnalyticsProvider, type IFormoAnalytics, useFormo as useRealFormo } from '@formo/analytics'
 import { useEffect } from 'react'
 
+import { queryClient, wagmiConfig } from 'components/Web3Provider'
 import { FORMO_WRITE_KEY } from 'constants/env'
 
 // This module is loaded ONLY via the deferred dynamic import in DeferredFormoProvider, so it (and the heavy
@@ -23,6 +24,7 @@ export default function FormoBridge({ onReady }: { onReady: (analytics: IFormoAn
   return (
     <FormoAnalyticsProvider
       writeKey={FORMO_WRITE_KEY}
+      options={{ wagmi: { config: wagmiConfig, queryClient, eip1193Fallback: true } }}
       disabled={typeof window !== 'undefined' && window.location.hostname.endsWith('.pr.kyberengineering.io')}
     >
       <ReportInstance onReady={onReady} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3(esbuild@0.24.0)
       '@formo/analytics':
-        specifier: ^1.27.0
-        version: 1.27.0(@tanstack/react-query@5.67.1)(@types/react@19.2.16)(react@19.2.7)(typescript@5.9.3)(viem@2.48.11)(wagmi@3.6.20)
+        specifier: ^1.38.0
+        version: 1.38.1(@tanstack/react-query@5.67.1)(@types/react@19.2.16)(react@19.2.7)(typescript@5.9.3)(viem@2.48.11)(wagmi@3.6.20)
       '@kyber/hooks':
         specifier: workspace:^
         version: link:../../packages/hooks
@@ -8118,8 +8118,9 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /@formo/analytics@1.27.0(@tanstack/react-query@5.67.1)(@types/react@19.2.16)(react@19.2.7)(typescript@5.9.3)(viem@2.48.11)(wagmi@3.6.20):
-    resolution: {integrity: sha512-mrM/PBqQEHGNs6qUkCkO/rg1S2DmrviLQ3kvkDlwsM3k6oCjvlZW/DMJzel8vykN4kK2xTeMsqpaDb0BoBgrZA==}
+  /@formo/analytics@1.38.1(@tanstack/react-query@5.67.1)(@types/react@19.2.16)(react@19.2.7)(typescript@5.9.3)(viem@2.48.11)(wagmi@3.6.20):
+    resolution: {integrity: sha512-7EX9sb+wJ1mAerecgRvxxbsNsbuLsrukIf6CWW8sjuN7iuiRY6NPKXzVbyjOtZlVwsPDFHAOGByfK6XayNTQ7w==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       '@types/react': ^19.0.0
@@ -8128,6 +8129,10 @@ packages:
       wagmi: '>=2.0.0'
     peerDependenciesMeta:
       '@tanstack/react-query':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
         optional: true
       viem:
         optional: true


### PR DESCRIPTION
## Summary
- Bump `@formo/analytics` from `^1.27.0` to `^1.38.0` (resolves to 1.38.1).
- Enable Formo wagmi mode in `FormoBridge` by passing `options.wagmi` with the app's `wagmiConfig` and `queryClient` (`eip1193Fallback: true`).
