### PR TITLE
fix(limit-order): extend approval polling window

### DIFF
--- a/apps/kyberswap-interface/src/components/LimitOrder/ProcessingOrder/useProcessingOrder.ts
+++ b/apps/kyberswap-interface/src/components/LimitOrder/ProcessingOrder/useProcessingOrder.ts
@@ -91,7 +91,7 @@ export const useProcessingOrder = ({
   }
 
   const waitForManualApproval = async () => {
-    for (let attempt = 0; attempt < 8; attempt++) {
+    for (let attempt = 0; attempt < 10; attempt++) {
       const hasEnoughAllowance = await checkApprovalManually()
       if (hasEnoughAllowance) return true
       await sleep(3000)

--- a/apps/kyberswap-interface/src/components/LimitOrder/ProcessingOrder/useProcessingOrder.ts
+++ b/apps/kyberswap-interface/src/components/LimitOrder/ProcessingOrder/useProcessingOrder.ts
@@ -94,7 +94,7 @@ export const useProcessingOrder = ({
     for (let attempt = 0; attempt < 8; attempt++) {
       const hasEnoughAllowance = await checkApprovalManually()
       if (hasEnoughAllowance) return true
-      await sleep(2000)
+      await sleep(3000)
     }
 
     return false


### PR DESCRIPTION
## Summary
- Increase the delay between Limit Order allowance checks from 2 to 3 seconds
- Extend the approval polling window to approximately 24 seconds before showing an error