### PR TITLE
fix(wallet-inventory): keep just-moved balances right after a transaction

### DIFF
--- a/apps/kyberswap-interface/src/state/transactions/updater.tsx
+++ b/apps/kyberswap-interface/src/state/transactions/updater.tsx
@@ -8,6 +8,7 @@ import { usePublicClient } from 'wagmi'
 
 import { NotificationType } from 'components/Announcement/type'
 import { CONNECTION } from 'components/Web3Provider'
+import { ETHER_ADDRESS } from 'constants/index'
 import { useActiveWeb3React, useWeb3React } from 'hooks'
 import useTracking, { NEED_CHECK_SUBGRAPH_TRANSACTION_TYPES, TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { AppDispatch, AppState } from 'state'
@@ -24,9 +25,11 @@ import {
   SerializableTransactionReceipt,
   TRANSACTION_TYPE,
   TransactionDetails,
+  TransactionExtraInfo,
   TransactionExtraInfo1Token,
 } from 'state/transactions/type'
 import { expireInventory } from 'state/walletInventory/store'
+import { isAddress } from 'utils/address'
 import { findTx } from 'utils/transaction'
 import { Address, Hash, decodeEventLog, formatUnits, keccak256, parseAbi, toBytes } from 'utils/viem'
 
@@ -111,6 +114,15 @@ function shouldCheck(
     // otherwise every block
     return true
   }
+}
+
+/** The ERC-20 tokens a confirmed transaction moved, checksummed; the native currency is read live already. */
+const touchedTokens = (chainId: ChainId, extraInfo: TransactionExtraInfo | undefined): string[] => {
+  const info = extraInfo as { tokenAddressIn?: string; tokenAddressOut?: string } | undefined
+  return [info?.tokenAddressIn, info?.tokenAddressOut].flatMap(address => {
+    const checksummed = address ? isAddress(chainId, address) : false
+    return checksummed && checksummed !== ETHER_ADDRESS ? [checksummed] : []
+  })
 }
 
 export default function Updater(): null {
@@ -211,6 +223,7 @@ export default function Updater(): null {
           chainId,
           transaction.from,
           receipt.blockNumber !== undefined ? Number(receipt.blockNumber) : undefined,
+          touchedTokens(chainId, transaction.extraInfo),
         )
         // The widget selectors keep their own inventory in `@kyber/hooks`; it refreshes on the same cue.
         expireWalletInventory(chainId, transaction.from)

--- a/apps/kyberswap-interface/src/state/wallet/hooks.ts
+++ b/apps/kyberswap-interface/src/state/wallet/hooks.ts
@@ -13,7 +13,7 @@ import { useBlockNumberFor } from 'state/application/hooks'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { useMultipleContractSingleData, useSingleCallResult } from 'state/multicall/hooks'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
-import { publishLiveBalances } from 'state/walletInventory/store'
+import { publishLiveBalances, retireLiveBalances } from 'state/walletInventory/store'
 import { isAddress } from 'utils/address'
 import { isTokenNative } from 'utils/tokenInfo'
 
@@ -188,6 +188,13 @@ export function useCurrencyBalances(
     })
     publishLiveBalances(chainId, account, blockNumber, reads)
   }, [account, chainId, currentChain, blockNumber, tokens, tokenBalances])
+  // The reads go with the tokens: once this form stops reading a token, its last read must not
+  // linger and outlive the balance it described.
+  useEffect(() => {
+    if (!account || chainId !== currentChain) return
+    const addresses = tokens.map(token => token.address)
+    return () => retireLiveBalances(chainId, account, addresses)
+  }, [account, chainId, currentChain, tokens])
 
   return useMemo(
     () =>

--- a/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
@@ -1,7 +1,10 @@
 import { ChainId, Token, TokenAmount } from '@kyberswap/ks-sdk-core'
 import { useEffect, useMemo, useSyncExternalStore } from 'react'
 
+import { ERC20_ABI } from 'constants/abis'
 import { useActiveWeb3React } from 'hooks'
+import { useBlockNumberFor } from 'state/application/hooks'
+import { useMultipleContractSingleData } from 'state/multicall/hooks'
 import { useNativeBalance } from 'state/wallet/hooks'
 import {
   TokenMetadata,
@@ -14,14 +17,51 @@ import {
   getStoreVersion,
   inventoryKey,
   isInventoryChain,
+  publishLiveBalances,
   readEntry,
   readLiveBalances,
+  readTouchedTokens,
   register,
+  retireLiveBalances,
   subscribeStore,
   unregister,
 } from 'state/walletInventory/store'
 
 export type { WalletInventory }
+
+const NO_ADDRESSES: string[] = []
+
+/**
+ * Reads the tokens the wallet's recent transactions moved straight from the chain, every block, for
+ * as long as the inventory is behind those transactions, and overlays the result. This is what keeps
+ * a just-swapped balance right on screen wherever the wallet is looked at — the indexer needs a
+ * while to catch up, and the forms that read their own tokens may already be gone.
+ */
+const useTouchedTokenReads = (chainId: ChainId, account: string | undefined, key: string | undefined) => {
+  const { chainId: currentChain } = useActiveWeb3React()
+  const storeVersion = useSyncExternalStore(subscribeStore, getStoreVersion, getStoreVersion)
+  // `storeVersion` re-reads the watch as transactions confirm and walks land.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const touched = useMemo(() => (key ? readTouchedTokens(key, Date.now()) : NO_ADDRESSES), [key, storeVersion])
+  // The multicall hook reads on the active chain only.
+  const addresses = account && chainId === currentChain ? touched : NO_ADDRESSES
+  const calls = useMultipleContractSingleData(addresses, ERC20_ABI, 'balanceOf', [account])
+  const blockNumber = useBlockNumberFor(chainId)
+
+  useEffect(() => {
+    if (!account || !addresses.length || blockNumber === undefined) return
+    const reads = addresses.flatMap((address, index) => {
+      const raw = calls[index]?.result?.[0]
+      return raw !== undefined ? [{ address, rawBalance: BigInt(raw.toString()) }] : []
+    })
+    if (reads.length) publishLiveBalances(chainId, account, blockNumber, reads)
+  }, [account, addresses, blockNumber, calls, chainId])
+
+  useEffect(() => {
+    if (!account || !addresses.length) return
+    return () => retireLiveBalances(chainId, account, addresses)
+  }, [account, addresses, chainId])
+}
 
 /**
  * Subscribes to the wallet's token inventory on a chain. Every consumer sharing a (chain, account)
@@ -44,6 +84,7 @@ export const useWalletInventory = (chainId?: ChainId, enabled = true): WalletInv
 
   const storeVersion = useSyncExternalStore(subscribeStore, getStoreVersion, getStoreVersion)
   const key = subscribed && account ? inventoryKey(resolvedChain, account) : undefined
+  useTouchedTokenReads(resolvedChain, account, key)
   // `storeVersion` is what makes these re-read when the store changes; both return stable references
   // while their data holds, so the resolver below only re-runs on a real change.
   /* eslint-disable react-hooks/exhaustive-deps */

--- a/apps/kyberswap-interface/src/state/walletInventory/store.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/store.ts
@@ -50,7 +50,15 @@ type Meta = {
    */
   awaitingBlock?: number
   awaitingUntil?: number
+  /**
+   * Tokens the watched transactions moved (checksummed). While the watch is on, consumers read
+   * these straight from the chain and overlay the result, so the indexer's lag is not on screen for
+   * exactly the balances that just changed.
+   */
+  touched?: string[]
 }
+
+const NO_ADDRESSES: string[] = []
 
 const EMPTY_ROWS: Record<string, InventoryRow> = {}
 
@@ -180,23 +188,40 @@ export const retireLiveBalances = (chainId: number, account: string, addresses: 
   emit()
 }
 
-/** Marks the wallet's inventory due on the next sweep, e.g. after a transaction of theirs confirms. */
-export const expireInventory = (chainId: number, account: string, awaitingBlock?: number) => {
+/**
+ * Marks the wallet's inventory due on the next sweep, e.g. after a transaction of theirs confirms.
+ * `touched` names the tokens that transaction moved; they are read live while the watch is on.
+ */
+export const expireInventory = (
+  chainId: number,
+  account: string,
+  awaitingBlock?: number,
+  touched: readonly string[] = NO_ADDRESSES,
+) => {
   // Confirmed transactions arrive from every chain the app serves; only the indexed ones have an
   // inventory to refresh, and writing meta for the rest would accrete dead keys and wake subscribers
   // over data no sweep will ever fetch.
   if (!isInventoryChain(chainId)) return
   const key = inventoryKey(chainId, account)
   const entry = meta.get(key)
+  // Touched tokens accumulate across the transactions of one watch; the array only changes when a
+  // new address joins, so consumers keyed on it do not re-subscribe for nothing.
+  const previousTouched = entry?.touched ?? NO_ADDRESSES
+  const added = touched.filter(address => !previousTouched.includes(address))
   meta.set(key, {
     failures: entry?.failures ?? 0,
     nextRetryAt: 0,
     forced: true,
     awaitingBlock: awaitingBlock ?? entry?.awaitingBlock,
     awaitingUntil: awaitingBlock ? Date.now() + INVENTORY_CATCHUP_TIMEOUT_MS : entry?.awaitingUntil,
+    touched: added.length ? [...previousTouched, ...added] : entry?.touched,
   })
   emit()
 }
+
+/** Tokens to read live for this wallet: those its watched transactions moved, while the watch is on. */
+export const readTouchedTokens = (key: string, now: number): string[] =>
+  isAwaitingBlock(key, now) ? meta.get(key)?.touched ?? NO_ADDRESSES : NO_ADDRESSES
 
 /** True while we are still chasing a transaction's block for this wallet. */
 export const isAwaitingBlock = (key: string, now: number): boolean => {

--- a/apps/kyberswap-interface/src/state/walletInventory/store.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/store.ts
@@ -159,6 +159,27 @@ export const publishLiveBalances = (
   emit()
 }
 
+/**
+ * Drops the live reads for tokens a form has stopped reading. A read only means something while its
+ * source refreshes it every block; left behind, it would keep restating a balance the wallet may
+ * since have sold off entirely — an emptied token has no inventory row to outrank it.
+ */
+export const retireLiveBalances = (chainId: number, account: string, addresses: readonly string[]) => {
+  const key = inventoryKey(chainId, account)
+  const previous = liveBalances.get(key)
+  if (!previous) return
+  let next: Map<string, LiveBalance> | undefined
+  addresses.forEach(address => {
+    if (!(next ?? previous).has(address)) return
+    next ??= new Map(previous)
+    next.delete(address)
+  })
+  if (!next) return
+  if (next.size) liveBalances.set(key, next)
+  else liveBalances.delete(key)
+  emit()
+}
+
 /** Marks the wallet's inventory due on the next sweep, e.g. after a transaction of theirs confirms. */
 export const expireInventory = (chainId: number, account: string, awaitingBlock?: number) => {
   // Confirmed transactions arrive from every chain the app serves; only the indexed ones have an

--- a/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
@@ -30,6 +30,7 @@ import {
   readEntry,
   readLiveBalances,
   readMeta,
+  readTouchedTokens,
   register,
   resetInventoryStore,
   retireLiveBalances,
@@ -266,6 +267,23 @@ describe('post-transaction catch-up', () => {
     commitResult(KEY, { rows: [row(USDT_CHECKSUM, 2n, 125)], complete: true, blockNumber: 125 })
     commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 110)], complete: true, blockNumber: 110 })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM]?.rawBalance).toBe(2n)
+  })
+
+  it('names the tokens a watched transaction moved, until the inventory catches up', () => {
+    const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+    register(ChainId.MAINNET, ACCOUNT)
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, blockNumber: 100 })
+    expireInventory(ChainId.MAINNET, ACCOUNT, 120, [USDT_CHECKSUM])
+    const first = readTouchedTokens(KEY, Date.now())
+    expect(first).toEqual([USDT_CHECKSUM])
+    // A second transaction in the same watch adds to the set; an address already there does not.
+    expireInventory(ChainId.MAINNET, ACCOUNT, 121, [USDT_CHECKSUM, DAI])
+    expect(readTouchedTokens(KEY, Date.now())).toEqual([USDT_CHECKSUM, DAI])
+    expireInventory(ChainId.MAINNET, ACCOUNT, 122, [DAI])
+    expect(readTouchedTokens(KEY, Date.now())).toBe(readTouchedTokens(KEY, Date.now()))
+    // Once a walk lands at or past the transaction's block, nothing is read live any more.
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 125)], complete: true, blockNumber: 125 })
+    expect(readTouchedTokens(KEY, Date.now())).toEqual([])
   })
 
   it('ignores transactions on chains off the served list', () => {

--- a/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
@@ -32,6 +32,7 @@ import {
   readMeta,
   register,
   resetInventoryStore,
+  retireLiveBalances,
 } from 'state/walletInventory/store'
 import { selectDue } from 'state/walletInventory/updater'
 
@@ -699,6 +700,21 @@ describe('publishLiveBalances', () => {
     publishLiveBalances(ChainId.MAINNET, ACCOUNT, 102, [{ address: USDT_CHECKSUM, rawBalance: 6n }])
     expect(readLiveBalances(KEY)?.get(USDT_CHECKSUM)).toEqual({ rawBalance: 6n, blockNumber: 102 })
     expect(getStoreVersion()).toBe(before + 1)
+  })
+
+  it('drops retired reads so a sold-off token is not restated from a stale read', () => {
+    // The swap form read 5 USDT, then the user moved on to another token and sold the USDT off.
+    publishLiveBalances(ChainId.MAINNET, ACCOUNT, 100, [{ address: USDT_CHECKSUM, rawBalance: 5n }])
+    retireLiveBalances(ChainId.MAINNET, ACCOUNT, [USDT_CHECKSUM])
+    expect(readLiveBalances(KEY)).toBeUndefined()
+
+    const soldOff: InventoryEntry = {
+      rows: { [ETHER_ADDRESS]: row(ETHER_ADDRESS, 10n, 120) },
+      status: 'settled',
+      blockNumber: 120,
+      fetchedAt: 1,
+    }
+    expect(resolveInventory(soldOff, true, '10', readLiveBalances(KEY)).rows[USDT_CHECKSUM]).toBeUndefined()
   })
 
   it('ignores chains off the served list', () => {


### PR DESCRIPTION
## Problem

Liquidating several tokens in a row without waiting for each swap to confirm — or closing the pending modal and leaving the page — left the token selector and My Assets showing the old balance of the tokens that had just moved, in some cases for good until the token was brought back into the swap form.

## Causes

1. The swap, limit-order, send and wrap forms publish the per-block balance reads of their tokens to the wallet inventory, which prefers a read newer than a row's last-change block. That read stayed behind after the user moved on to another token. Once the token was sold off, the inventory no longer listed it (zero holdings have no row), so the stale read had nothing to be compared against and was applied as if it were current.
2. The inventory indexer runs 15–70s behind the chain. After a transaction confirms the inventory is refetched at once and every 5s until it catches up, but during that window it can only return pre-transaction balances. While the tokens are still in a form their live reads cover the gap; once the user has navigated away and back, nothing does.

## Fix

- A form retires its reads the moment it stops reading a token, so a read only ever describes a balance that is still being refreshed every block.
- A confirmed transaction now names the tokens it moved (`tokenAddressIn` / `tokenAddressOut`). While the inventory is behind that transaction, every consumer of the inventory (token selector, wallet popup) reads those tokens' `balanceOf` straight from the chain each block and overlays the result, and drops the overlay once the inventory has caught up. The just-swapped balances are therefore right wherever the wallet is looked at, whatever page the user went to meanwhile.

## Testing

- Unit tests: a read published for USDT, retired when the form moves on, then an inventory without USDT resolves without restating it; touched tokens accumulate across the transactions of one watch and clear once a walk lands at the transaction's block.
- `walletInventory` suite 75/75, app type-check clean, selector smoke-tested in the browser.