### PR TITLE
feat(wallet-inventory): serve Arbitrum from the wallet inventory

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/OtherChainTokens.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/OtherChainTokens.tsx
@@ -106,7 +106,6 @@ export const OtherChainTokens = ({
                   padding="6px 12px"
                   fontWeight={500}
                   fontSize="14px"
-                  className={cn(isDimmed && 'opacity-50')}
                   onClick={event => {
                     event.stopPropagation()
                     onSelect(token)

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/PinnedTokens.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/PinnedTokens.tsx
@@ -50,16 +50,19 @@ export const PinnedTokens = ({ onSelect, selectedCurrency, tokens = [], onToggle
               >
                 {symbol}
               </div>
-              <XCircle
-                className={cn(
-                  'absolute right-[-5px] top-[-5px] z-10 hidden rounded-full bg-buttonGray text-subText',
-                  '[@media(hover:hover)]:hover:text-text',
-                  isEditMode ? 'block' : '[@media(hover:hover)]:group-hover/pinned-token:block',
-                )}
-                data-testid="close-btn"
-                size={16}
-                onClick={event => onToggleFavorite?.(event, token)}
-              />
+              {/* The native pill always leads the row and cannot be removed, so it offers no remove control. */}
+              {!isTokenNative(token) && (
+                <XCircle
+                  className={cn(
+                    'absolute right-[-5px] top-[-5px] z-10 hidden rounded-full bg-buttonGray text-subText',
+                    '[@media(hover:hover)]:hover:text-text',
+                    isEditMode ? 'block' : '[@media(hover:hover)]:group-hover/pinned-token:block',
+                  )}
+                  data-testid="close-btn"
+                  size={16}
+                  onClick={event => onToggleFavorite?.(event, token)}
+                />
+              )}
             </HStack>
           )
         })}

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -66,6 +66,7 @@ import {
   useTokenComparator,
 } from 'components/TokenSelectorModal/utils'
 import { MouseoverTooltip } from 'components/Tooltip'
+import { ETHER_ADDRESS } from 'constants/index'
 import { NETWORKS_INFO } from 'constants/networks'
 import { Z_INDEXS } from 'constants/styles'
 import { NativeCurrencies } from 'constants/tokens'
@@ -900,7 +901,9 @@ export const TokenSelectorContent = ({
   const handleClickFavorite = useCallback(
     (event: MouseEvent, currency: Currency) => {
       event.stopPropagation()
-      const address = currency.wrapped.address
+      // The native currency is favorited under its sentinel address. Its wrapped address is a real,
+      // different token: toggling that would add or remove the wrapped token's own pin.
+      const address = isTokenNative(currency) ? ETHER_ADDRESS : currency.wrapped.address
       if (!address) return
       toggleFavoriteToken({ chainId: currency.chainId, address })
     },

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -801,19 +801,24 @@ export const TokenSelectorContent = ({
   }, [switchChainToken, switchChainAndSelect, trackTokenSelected])
 
   // A hit in the "other chains" group is other-chain only relative to the chain selector, which the
-  // wallet need not be on — so the token can well sit on the app's own chain. Aim the selector at it
-  // and hand off to the row select path, which gates on the app chain and so asks for a network switch
-  // only when one is really needed.
+  // wallet need not be on — so the token can well sit on the app's own chain. Hand off to the row select
+  // path, which gates on the app chain and so asks for a network switch only when one is really needed.
   const handleOtherChainSelect = useCallback(
     (token: WrappedTokenInfo) => {
-      setSelectedChainId(token.chainId)
       if (getNeedsImport(token, address => isTokenImported(token.chainId, address), !!onImportToken)) {
+        setSelectedChainId(token.chainId)
         onImportToken?.(token.wrapped)
         return
       }
+      // A pick that still has to clear the Switch Chain confirm leaves the selector where it is: aiming it
+      // at the token's chain up front strands the row in that chain's list — Switch Chain button gone —
+      // as soon as the user cancels. Confirming closes the whole modal, so it never needs the aim either.
+      if (token.chainId === anchorChainId || onSelectChain) {
+        setSelectedChainId(token.chainId)
+      }
       handleCurrencySelect(token)
     },
-    [handleCurrencySelect, isTokenImported, onImportToken],
+    [anchorChainId, handleCurrencySelect, isTokenImported, onImportToken, onSelectChain],
   )
 
   const handleTabChange = useCallback(

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -606,11 +606,8 @@ export const TokenSelectorContent = ({
   const metricsExtras = useTokensMetrics(metricsSource, primaryChainId)
 
   // Imported and Favorites take their price from the live prices endpoint (buy/sell mid — the same
-  // source the swap box, the All tab and the wallet-value sort use, so a token reads the same
-  // everywhere), while 24h change / volume / market cap stay from the tokens-list metrics. Imported
-  // holds arbitrary user-added tokens, so it prices strictly from that endpoint and shows `--` when
-  // it has no quote rather than a catalog price the swap can't honour; Favorites, a whitelisted set,
-  // still tops up from the catalog metrics.
+  // source the All tab and the wallet-value sort use, so a token reads the same on every tab), while
+  // 24h change / volume / market cap stay from the tokens-list metrics.
   const localPriceAddresses = useMemo(
     () => (metricsSource.length ? metricsSource.map(currency => currency.wrapped.address) : EMPTY_ADDRESSES),
     [metricsSource],
@@ -621,13 +618,10 @@ export const TokenSelectorContent = ({
     metricsSource.forEach(currency => {
       const key = tokenRowKey(currency.chainId, currency.wrapped.address)
       const livePrice = localPrices[currency.wrapped.address.toLowerCase()]
-      result[key] = {
-        ...metricsExtras[key],
-        price: isImportedTab ? livePrice : livePrice || metricsExtras[key]?.price,
-      }
+      result[key] = { ...metricsExtras[key], price: livePrice || metricsExtras[key]?.price }
     })
     return result
-  }, [metricsSource, localPrices, metricsExtras, isImportedTab])
+  }, [metricsSource, localPrices, metricsExtras])
 
   // Both catalog-sourced tabs can come back short of `metrics.price` (Robinhood especially), so top
   // their rows up from the live prices endpoint — on Trending only while TRENDING_PRICE_FALLBACK_ENABLED.

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -606,8 +606,11 @@ export const TokenSelectorContent = ({
   const metricsExtras = useTokensMetrics(metricsSource, primaryChainId)
 
   // Imported and Favorites take their price from the live prices endpoint (buy/sell mid — the same
-  // source the All tab and the wallet-value sort use, so a token reads the same on every tab), while
-  // 24h change / volume / market cap stay from the tokens-list metrics.
+  // source the swap box, the All tab and the wallet-value sort use, so a token reads the same
+  // everywhere), while 24h change / volume / market cap stay from the tokens-list metrics. Imported
+  // holds arbitrary user-added tokens, so it prices strictly from that endpoint and shows `--` when
+  // it has no quote rather than a catalog price the swap can't honour; Favorites, a whitelisted set,
+  // still tops up from the catalog metrics.
   const localPriceAddresses = useMemo(
     () => (metricsSource.length ? metricsSource.map(currency => currency.wrapped.address) : EMPTY_ADDRESSES),
     [metricsSource],
@@ -618,10 +621,13 @@ export const TokenSelectorContent = ({
     metricsSource.forEach(currency => {
       const key = tokenRowKey(currency.chainId, currency.wrapped.address)
       const livePrice = localPrices[currency.wrapped.address.toLowerCase()]
-      result[key] = { ...metricsExtras[key], price: livePrice || metricsExtras[key]?.price }
+      result[key] = {
+        ...metricsExtras[key],
+        price: isImportedTab ? livePrice : livePrice || metricsExtras[key]?.price,
+      }
     })
     return result
-  }, [metricsSource, localPrices, metricsExtras])
+  }, [metricsSource, localPrices, metricsExtras, isImportedTab])
 
   // Both catalog-sourced tabs can come back short of `metrics.price` (Robinhood especially), so top
   // their rows up from the live prices endpoint — on Trending only while TRENDING_PRICE_FALLBACK_ENABLED.

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -789,9 +789,36 @@ export const TokenSelectorContent = ({
     ],
   )
 
+  // Once the switch lands the app sits on the token's chain, so the selector follows it there and an
+  // unlisted token still has to clear the import gate before it can be picked.
+  const importAfterSwitchRef = useRef(false)
+  const handleSelectAfterSwitch = useCallback(
+    (token: Currency) => {
+      setSelectedChainId(token.chainId)
+      if (getNeedsImport(token, address => isTokenImported(token.chainId, address), !!onImportToken)) {
+        importAfterSwitchRef.current = true
+        onImportToken?.(token.wrapped)
+        return
+      }
+      onCurrencySelect?.(token)
+    },
+    [isTokenImported, onCurrencySelect, onImportToken],
+  )
+  // The import view lives inside this same modal, so a hand-off to it keeps the modal open.
+  const handleDismissAfterSwitch = useCallback(() => {
+    if (importAfterSwitchRef.current) {
+      importAfterSwitchRef.current = false
+      return
+    }
+    onDismiss?.()
+  }, [onDismiss])
+
   // On confirm, switch to the token's chain and select it once the switch lands (see the hook — it
   // defers the selection past the network-param sync that would otherwise reset the pair to defaults).
-  const { switchChainAndSelect, resetPending } = usePendingCrossChainSelect(onCurrencySelect, onDismiss)
+  const { switchChainAndSelect, resetPending } = usePendingCrossChainSelect(
+    handleSelectAfterSwitch,
+    handleDismissAfterSwitch,
+  )
   const confirmSwitchChain = useCallback(() => {
     if (!switchChainToken) return
     const token = switchChainToken
@@ -805,16 +832,17 @@ export const TokenSelectorContent = ({
   // path, which gates on the app chain and so asks for a network switch only when one is really needed.
   const handleOtherChainSelect = useCallback(
     (token: WrappedTokenInfo) => {
-      if (getNeedsImport(token, address => isTokenImported(token.chainId, address), !!onImportToken)) {
-        setSelectedChainId(token.chainId)
-        onImportToken?.(token.wrapped)
+      // A pick that needs the app on another chain answers the Switch Chain confirm first — the import
+      // gate belongs to the chain the app lands on, and nothing here moves until the user agrees: aiming
+      // the selector early would strand the row in that chain's list with its Switch Chain button gone.
+      if (token.chainId !== anchorChainId && !onSelectChain) {
+        handleCurrencySelect(token)
         return
       }
-      // A pick that still has to clear the Switch Chain confirm leaves the selector where it is: aiming it
-      // at the token's chain up front strands the row in that chain's list — Switch Chain button gone —
-      // as soon as the user cancels. Confirming closes the whole modal, so it never needs the aim either.
-      if (token.chainId === anchorChainId || onSelectChain) {
-        setSelectedChainId(token.chainId)
+      setSelectedChainId(token.chainId)
+      if (getNeedsImport(token, address => isTokenImported(token.chainId, address), !!onImportToken)) {
+        onImportToken?.(token.wrapped)
+        return
       }
       handleCurrencySelect(token)
     },

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/types.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/types.ts
@@ -2,10 +2,7 @@ import { ChainId } from '@kyberswap/ks-sdk-core'
 
 /** Extra per-row metadata shown next to a token depending on the active tab. */
 export type TokenRowExtra = {
-  /**
-   * Current USD price. The catalog-sourced tabs read the token-catalog `metrics.price` field; the
-   * local-sourced tabs read the live buy/sell mid from the prices endpoint.
-   */
+  /** Current USD price, from the token-catalog `metrics.price` field. */
   price?: number
   /** 24h price change, as a percentage (e.g. 1.25 = +1.25%), from `metrics.priceChange24h`. */
   priceChange24h?: number

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/types.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/types.ts
@@ -2,7 +2,10 @@ import { ChainId } from '@kyberswap/ks-sdk-core'
 
 /** Extra per-row metadata shown next to a token depending on the active tab. */
 export type TokenRowExtra = {
-  /** Current USD price, from the token-catalog `metrics.price` field. */
+  /**
+   * Current USD price. The catalog-sourced tabs read the token-catalog `metrics.price` field; the
+   * local-sourced tabs read the live buy/sell mid from the prices endpoint.
+   */
   price?: number
   /** 24h price change, as a percentage (e.g. 1.25 = +1.25%), from `metrics.priceChange24h`. */
   priceChange24h?: number

--- a/apps/kyberswap-interface/src/components/WalletPopup/AccountInfo/index.tsx
+++ b/apps/kyberswap-interface/src/components/WalletPopup/AccountInfo/index.tsx
@@ -61,8 +61,8 @@ export default function AccountInfo({
         <div
           className={cn('relative z-[2] flex size-full flex-col justify-between gap-1 px-4 py-3', isMinimal && 'p-3')}
         >
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col gap-1">
+          <div className="flex min-w-0 items-center justify-between">
+            <div className="flex min-w-0 flex-col gap-1">
               <div
                 className="flex w-fit cursor-pointer gap-1"
                 onClick={() => {
@@ -84,10 +84,17 @@ export default function AccountInfo({
                 )}
               </div>
 
-              <span className={cn('truncate text-4xl font-medium', isMinimal && 'text-xl')}>
+              <span className={cn('max-w-full truncate text-4xl font-medium', isMinimal && 'text-xl')}>
                 {typeof totalBalanceInUsd === 'number' ? (
                   showBalance ? (
-                    `$${formatDisplayNumber(totalBalanceInUsd, { fractionDigits: 8 })}`
+                    // Cents are enough on a real total, and every digit stays on screen — a compact
+                    // "$10.9M" hides amounts that matter at this size. The long tail only matters
+                    // under a dollar. The wide significantDigits keeps the formatter off its compact
+                    // notation until far beyond any real total.
+                    `$${formatDisplayNumber(
+                      totalBalanceInUsd,
+                      totalBalanceInUsd >= 1 ? { fractionDigits: 2, significantDigits: 15 } : { fractionDigits: 8 },
+                    )}`
                   ) : (
                     '******'
                   )

--- a/packages/hooks/src/wallet-inventory-client.ts
+++ b/packages/hooks/src/wallet-inventory-client.ts
@@ -7,7 +7,7 @@ import { ChainId } from '@kyber/schema';
  * `isWalletInventoryChain`), so the list drifting ahead of the backend degrades to the caller's own
  * balance source rather than failing. Both the app and the widget packages read this one list.
  */
-export const WALLET_INVENTORY_CHAINS: ChainId[] = [ChainId.Ethereum, ChainId.Base, ChainId.Bsc];
+export const WALLET_INVENTORY_CHAINS: ChainId[] = [ChainId.Ethereum, ChainId.Base, ChainId.Bsc, ChainId.Arbitrum];
 
 /** The service answered that it does not index this chain. */
 export class UnsupportedChainError extends Error {


### PR DESCRIPTION
## Summary

Adds Arbitrum to `WALLET_INVENTORY_CHAINS`, the served-chain list shared by the app and the widget selectors. The list is the release gate for the wallet-inventory service; the backend has enabled chain 42161 and this lets the frontend read it.

## Also in this PR

- fix(token-selector): the native quick-select pill no longer offers a remove control (the row always leads with the native token by design), and favorite toggles key the native currency by its sentinel address — removing "ETH" used to toggle a WETH pill instead.

- fix(wallet-popup): a whale wallet's total pushed the popup past its edge; the header now shows every digit with cents at most (never compact notation) and truncates instead of stretching the panel.

- fix(token-selector): the Switch Chain button on an unlisted other-chain result stays sharp; only the token info dims.
