### PR TITLE
feat(token-selector): show USD value under each token balance

### DIFF
--- a/packages/hooks/src/use-token-balances.ts
+++ b/packages/hooks/src/use-token-balances.ts
@@ -7,9 +7,9 @@ const EMPTY: { [address: string]: bigint } = {};
 
 export const useTokenBalances = (chainId: ChainId, tokenAddresses: string[], account?: string) => {
   const [balances, setBalances] = useState<{ [address: string]: bigint }>(EMPTY);
-  const [fetching, setFetching] = useState(false);
   // Which (chain, account, list) the balances on hand answer for; `loading` stays true until the
-  // current one has landed, so a caller never reads a previous request's map as this one's.
+  // current one has landed, so a caller never reads a previous request's map as this one's. A
+  // periodic refresh of an already-settled key is not loading: the map on screen stays valid.
   const [settledKey, setSettledKey] = useState('');
   const fetchIdRef = useRef(0);
   const prevAccountRef = useRef(account);
@@ -33,7 +33,6 @@ export const useTokenBalances = (chainId: ChainId, tokenAddresses: string[], acc
     }
 
     const currentFetchId = ++fetchIdRef.current;
-    setFetching(true);
 
     try {
       const balancesMap = await getTokenBalances({
@@ -51,7 +50,6 @@ export const useTokenBalances = (chainId: ChainId, tokenAddresses: string[], acc
       console.error('Failed to fetch balances:', error);
     } finally {
       if (currentFetchId === fetchIdRef.current) {
-        setFetching(false);
         // An attempt settles the key whatever its outcome: a failed poll leaves the previous map
         // on screen rather than a loader that nothing would ever clear.
         setSettledKey(requestKey);
@@ -72,7 +70,7 @@ export const useTokenBalances = (chainId: ChainId, tokenAddresses: string[], acc
   }, [fetchBalances, active]);
 
   return {
-    loading: active && (fetching || settledKey !== requestKey),
+    loading: active && settledKey !== requestKey,
     balances,
     refetch: fetchBalances,
   };

--- a/packages/hooks/src/use-token-prices.ts
+++ b/packages/hooks/src/use-token-prices.ts
@@ -1,60 +1,101 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { fetchTokenPrice } from '@kyber/utils';
+import { fetchTokenPrice, getMidPrice } from '@kyber/utils';
 
-export function useTokenPrices({ addresses, chainId }: { addresses: string[]; chainId: number }) {
-  const [loading, setLoading] = useState(true);
-  const [prices, setPrices] = useState<{ [key: string]: number }>(() => {
-    return addresses.reduce((acc, address) => ({ ...acc, [address]: 0 }), {});
+/** Matches the swap form's route refresh, so the two never drift by more than one interval. */
+const REFRESH_MS = 10_000;
+/** Server-enforced cap on addresses per chain per request. */
+const CHUNK_SIZE = 100;
+
+export type TokenPriceMap = { [address: string]: number };
+
+const EMPTY_PRICES: TokenPriceMap = {};
+
+const shallowEqual = (a: TokenPriceMap, b: TokenPriceMap) => {
+  const aKeys = Object.keys(a);
+  return aKeys.length === Object.keys(b).length && aKeys.every(key => a[key] === b[key]);
+};
+
+/**
+ * USD mid prices (see `getMidPrice`) for `addresses` on `chainId`, keyed by the address as passed
+ * in. Refreshes while mounted and the tab is visible. `loading` is true only until the first
+ * response for the current chain and address list lands; a failed refresh keeps the last good
+ * prices, and an address the service cannot price reads `0`.
+ */
+export function useTokenPrices({ addresses, chainId }: { addresses: string[]; chainId?: number }) {
+  // A primitive key so callers may rebuild the address array on every render.
+  const addressKey = addresses.join(',');
+  const requestKey = `${chainId ?? ''}:${addressKey}`;
+
+  const [state, setState] = useState<{ key: string; chainId?: number; byLowercase: TokenPriceMap }>({
+    key: '',
+    byLowercase: EMPTY_PRICES,
   });
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
   useEffect(() => {
-    const getPrice = async () => {
-      if (addresses.length === 0) {
-        setPrices({});
-        setLoading(false);
-        return;
-      }
+    const list = addressKey.split(',').filter(Boolean);
+    if (!chainId || !list.length) return;
 
-      setLoading(true);
-      fetchTokenPrice({ addresses, chainId })
-        .then(prices => {
-          setPrices(
-            addresses.reduce((acc, address) => {
-              return {
-                ...acc,
-                [address]: prices[address]?.PriceBuy || 0,
-              };
-            }, {}),
-          );
-        })
-        .finally(() => {
-          setLoading(false);
+    let cancelled = false;
+
+    const load = async () => {
+      const chunks: string[][] = [];
+      for (let i = 0; i < list.length; i += CHUNK_SIZE) chunks.push(list.slice(i, i + CHUNK_SIZE));
+      const results = await Promise.allSettled(chunks.map(chunk => fetchTokenPrice({ addresses: chunk, chainId })));
+      if (cancelled) return;
+
+      const fetched: TokenPriceMap = {};
+      results.forEach(result => {
+        if (result.status !== 'fulfilled') return;
+        // The API may echo checksummed addresses; index by lowercase to match what was requested.
+        Object.entries(result.value).forEach(([address, entry]) => {
+          fetched[address.toLowerCase()] = getMidPrice(entry) || 0;
         });
+      });
+
+      setState(prev => {
+        // Stale-while-revalidate: a chunk that failed leaves its previous prices in place.
+        const next = prev.chainId === chainId ? { ...prev.byLowercase, ...fetched } : fetched;
+        if (prev.key === requestKey && shallowEqual(prev.byLowercase, next)) return prev;
+        return { key: requestKey, chainId, byLowercase: next };
+      });
     };
 
-    getPrice();
+    const refresh = () => {
+      if (typeof document !== 'undefined' && document.hidden) return;
+      void load();
+    };
 
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-    intervalRef.current = setInterval(() => {
-      getPrice();
-    }, 10_000);
+    void load();
+    const interval = setInterval(refresh, REFRESH_MS);
+    document.addEventListener('visibilitychange', refresh);
 
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+      cancelled = true;
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', refresh);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId, addresses.join(',')]);
+  }, [chainId, addressKey, requestKey]);
+
+  const settled = state.key === requestKey;
+  // While a changed address list is in flight, the chain's last prices still serve the addresses
+  // they cover, so a token that was already priced does not blink to $0.
+  const byLowercase = state.chainId === chainId ? state.byLowercase : EMPTY_PRICES;
+
+  const prices = useMemo(
+    () =>
+      addressKey
+        .split(',')
+        .filter(Boolean)
+        .reduce<TokenPriceMap>((acc, address) => {
+          acc[address] = byLowercase[address.toLowerCase()] || 0;
+          return acc;
+        }, {}),
+    [addressKey, byLowercase],
+  );
 
   return {
-    loading,
+    loading: !!chainId && addresses.length > 0 && !settled,
     prices,
   };
 }

--- a/packages/token-selector/src/TokenSelector.tsx
+++ b/packages/token-selector/src/TokenSelector.tsx
@@ -17,11 +17,13 @@ import {
 
 import { useLingui } from "@lingui/react";
 
-import { Exchange, NATIVE_TOKEN_ADDRESS, Token } from "@kyber/schema";
+import { TokenPriceMap, useTokenPrices } from "@kyber/hooks";
+import { ChainId, Exchange, NATIVE_TOKEN_ADDRESS, Token } from "@kyber/schema";
 import { Button, Input, TokenLogo, TokenSymbol } from "@kyber/ui";
 import { fetchTokenInfo } from "@kyber/utils";
 import { isAddress } from "@kyber/utils/crypto";
-import { formatUnits } from "@kyber/utils/number";
+import { formatDisplayNumber, formatUnits } from "@kyber/utils/number";
+import { cn } from "@kyber/utils/tailwind-helpers";
 
 import Check from "@/assets/check.svg?react";
 import Info from "@/assets/info.svg?react";
@@ -35,6 +37,7 @@ import {
   TOKEN_SELECT_MODE,
   TokenSelectorVariant,
 } from "@/types";
+import { getNetworkInfo } from "@/TokenInfo/utils";
 import UserPositions, { TokenLoader } from "@/UserPositions";
 import { useTokenState } from "@/useTokenState";
 
@@ -100,6 +103,12 @@ interface TokenSelectorProps {
 
 const normalizeSpecialCharacters = (value: string) => value.replace(/₮/g, "T");
 
+const NATIVE_TOKEN_LOWER = NATIVE_TOKEN_ADDRESS.toLowerCase();
+const EMPTY_ADDRESSES: string[] = [];
+
+const formatUsdValue = (value: number) =>
+  formatDisplayNumber(value, { style: "currency", significantDigits: 4 });
+
 const TOKEN_ROW_HEIGHT = 52;
 // Restricted rows are taller to fit the "not available in your jurisdiction" line.
 const RESTRICTED_TOKEN_ROW_HEIGHT = 88;
@@ -116,6 +125,10 @@ interface TokenRowData {
   onShowTokenInfo: (e: React.MouseEvent, token: Token) => void;
   isTokenRestricted?: (token: Token) => boolean;
   warnedAddresses: Set<string>;
+  /** USD mid price per lowercased address; only held tokens are priced. */
+  tokenPrices: TokenPriceMap;
+  /** The native token is priced through its wrapped counterpart when it has no entry of its own. */
+  wrappedNativeAddress?: string;
   i18n: ReturnType<typeof useLingui>["i18n"];
 }
 
@@ -135,11 +148,22 @@ const TokenRow = memo(function TokenRow({
     onImportToken,
     onShowTokenInfo,
     warnedAddresses,
+    tokenPrices,
+    wrappedNativeAddress,
     i18n,
   } = data;
 
   const token = tokens[index];
   if (!token) return null;
+
+  const tokenAddrLower = token.address?.toLowerCase();
+  const price =
+    tokenPrices[tokenAddrLower] ||
+    (tokenAddrLower === NATIVE_TOKEN_LOWER && wrappedNativeAddress
+      ? tokenPrices[wrappedNativeAddress]
+      : 0) ||
+    0;
+  const usdValue = price * parseFloat(token.balance);
 
   // A discovered token is not on the list yet: the row is dimmed and clicking it starts the import.
   const discovered = !!token.discovered;
@@ -188,11 +212,14 @@ const TokenRow = memo(function TokenRow({
       }}
     >
       <div
-        className={`flex items-center gap-3 ${discovered ? "opacity-50" : ""}`}
+        className={cn(
+          "flex min-w-0 items-center gap-3",
+          discovered && "opacity-50",
+        )}
       >
         {mode === TOKEN_SELECT_MODE.ADD && (
           <div
-            className={`w-4 h-4 rounded-[4px] flex items-center justify-center cursor-pointer ${
+            className={`w-4 h-4 shrink-0 rounded-[4px] flex items-center justify-center cursor-pointer ${
               modalTokensInAddress.has(token.address?.toLowerCase())
                 ? "bg-accent"
                 : "bg-stroke"
@@ -204,24 +231,43 @@ const TokenRow = memo(function TokenRow({
           </div>
         )}
         <TokenLogo src={token.logo} size={24} />
-        <div>
+        <div className="min-w-0">
           <TokenSymbol
             className="leading-6"
             symbol={token.symbol}
             maxWidth={120}
           />
           <p
-            className={`${tabSelected === TOKEN_TAB.ALL ? "text-xs" : ""} text-subText`}
+            className={cn(
+              "truncate text-subText",
+              tabSelected === TOKEN_TAB.ALL && "text-xs",
+            )}
+            title={tabSelected === TOKEN_TAB.ALL ? token.name : undefined}
           >
             {tabSelected === TOKEN_TAB.ALL ? token.name : token.balance}
+            {tabSelected === TOKEN_TAB.IMPORTED && usdValue > 0 && (
+              <span className="ml-1 text-xs text-accent">
+                {formatUsdValue(usdValue)}
+              </span>
+            )}
           </p>
         </div>
       </div>
-      <div className="flex items-center gap-2 justify-end">
+      <div className="flex shrink-0 items-center justify-end gap-2">
         {tabSelected === TOKEN_TAB.ALL ? (
-          <span className={discovered ? "opacity-50" : ""}>
-            {token.balance}
-          </span>
+          <div
+            className={cn(
+              "flex flex-col items-end",
+              discovered && "opacity-50",
+            )}
+          >
+            <span>{token.balance}</span>
+            {usdValue > 0 && (
+              <span className="text-xs text-accent">
+                {formatUsdValue(usdValue)}
+              </span>
+            )}
+          </div>
         ) : (
           <TrashIcon
             className="w-[18px] text-subText hover:text-text !cursor-pointer"
@@ -288,6 +334,30 @@ export default function TokenSelector({
     () => [...tokens, ...importedTokens, ...discoveredTokens],
     [tokens, importedTokens, discoveredTokens],
   );
+
+  const wrappedNativeAddress = chainId
+    ? getNetworkInfo(chainId as ChainId)?.wrappedToken.address.toLowerCase()
+    : undefined;
+
+  // Only a held token can show a non-zero USD value, so only those are priced rather than the whole
+  // list. The wrapped native token rides along whenever the native one is held (see TokenRowData).
+  const heldAddresses = useMemo(() => {
+    const held = allTokens
+      .map((token) => token.address.toLowerCase())
+      .filter((address) => (tokenBalances[address] ?? 0n) > 0n);
+    if (
+      wrappedNativeAddress &&
+      held.includes(NATIVE_TOKEN_LOWER) &&
+      !held.includes(wrappedNativeAddress)
+    ) {
+      held.push(wrappedNativeAddress);
+    }
+    return held.length ? held : EMPTY_ADDRESSES;
+  }, [allTokens, tokenBalances, wrappedNativeAddress]);
+  const { prices: tokenPrices } = useTokenPrices({
+    chainId,
+    addresses: heldAddresses,
+  });
 
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState<string>("");
@@ -620,6 +690,8 @@ export default function TokenSelector({
       onShowTokenInfo: handleShowTokenInfo,
       isTokenRestricted,
       warnedAddresses: warnedRestricted,
+      tokenPrices,
+      wrappedNativeAddress,
       i18n,
     }),
     [
@@ -634,6 +706,8 @@ export default function TokenSelector({
       handleShowTokenInfo,
       isTokenRestricted,
       warnedRestricted,
+      tokenPrices,
+      wrappedNativeAddress,
       i18n,
     ],
   );

--- a/packages/utils/src/services/index.ts
+++ b/packages/utils/src/services/index.ts
@@ -44,6 +44,28 @@ interface PriceResponse {
   };
 }
 
+/** Either side can be absent when the price service cannot value that leg of the market. */
+export interface TokenPriceEntry {
+  PriceBuy?: number;
+  PriceSell?: number;
+}
+
+/** A buy/sell spread at or beyond this ratio is not a market, and its mid is not a price. */
+const MAX_PRICE_SPREAD_RATIO = 2;
+
+/**
+ * A token's USD price as the mid of its buy/sell spread, or `null` when either side is missing or the
+ * two sides are too far apart — a one-sided or wildly split quote comes from a market the price
+ * service could only value on one leg and can sit orders of magnitude away from the tradable price.
+ */
+export const getMidPrice = (entry?: TokenPriceEntry): number | null => {
+  if (!entry?.PriceBuy || !entry?.PriceSell) return null;
+  const [low, high] =
+    entry.PriceBuy < entry.PriceSell ? [entry.PriceBuy, entry.PriceSell] : [entry.PriceSell, entry.PriceBuy];
+  if (high >= low * MAX_PRICE_SPREAD_RATIO) return null;
+  return (low + high) / 2;
+};
+
 export const fetchTokenPrice = async ({ addresses, chainId }: { addresses: string[]; chainId: number }) => {
   const priceResponse: PriceResponse = await fetch(`${API_URLS.TOKEN_API}/v1/public/tokens/prices`, {
     method: 'POST',


### PR DESCRIPTION
## Summary

Adds a USD value beneath each token's balance in the shared token selector (`@kyber/token-selector`) used by the zap widgets, priced with the same buy/sell mid-price logic as the swap token selector.

## Changes

- **`@kyber/utils`**: new `getMidPrice` — the mid of the buy/sell spread, `null` when either side is missing or the spread is ≥2×, matching the swap token selector.
- **`@kyber/hooks` `useTokenPrices`**: reused (not duplicated) for the selector and upgraded:
  - resolves the mid price instead of `PriceBuy`
  - chunks requests at the server's 100-address cap
  - skips refreshes while the tab is hidden
  - keeps the last good prices when a request fails, and keeps the chain's last prices while an address-list change is in flight
  - `loading` is true only until the first response for the current chain/address list lands
- **`@kyber/hooks` `useTokenBalances`**: a periodic refresh of an already-settled key no longer reports `loading`, so the selector stops flashing its skeleton on every 15s poll.
- **`TokenSelector`**:
  - only tokens with a non-zero balance are priced (native token falls back to its wrapped counterpart)
  - All tab: USD value under the balance on the right; Imported tab: USD value next to the balance
  - long token names truncate with an ellipsis instead of wrapping

## Note

Other zap widgets that call `useTokenPrices` (zap-create, liquidity, compounding) now read the mid price instead of `PriceBuy`, consistent with the app-wide price definition.

## Testing

- `eslint` + `tsc --noEmit` clean on `hooks`, `utils`, `token-selector`; type-check passes on `zap-create-widgets`, `liquidity-widgets`, `compounding-widget`.
- Verified on the pool-detail Add Liquidity selector (Ethereum, wallet with many holdings): USD values render, prices refresh every 10s, skeleton appears only on first open across a 35s watch, and long names truncate at 420px viewport with the row height unchanged.