### PR TITLE
feat(wallet-inventory): read just-moved tokens through the service, and never wait forever

### DIFF
--- a/apps/kyberswap-interface/src/components/WalletPopup/hooks/useWalletAssets.ts
+++ b/apps/kyberswap-interface/src/components/WalletPopup/hooks/useWalletAssets.ts
@@ -97,9 +97,10 @@ export const useWalletAssets = (): WalletAssets => {
       }
     }
     return {
-      // Not settled means the trust check is still waiting on the native read: the list could be
-      // handed back to multicall a block later, so it is not shown yet.
-      loading: !tokenListReady || !inventory.settled,
+      // Rows the index does list are shown as soon as they are known. What waits on the native read
+      // is only an inventory that lists nothing: that is either a wallet with no tokens or one the
+      // index has never seen, and the read is what tells the two apart.
+      loading: !tokenListReady || (!inventory.settled && !holdings.vetted.length && !holdings.hidden.length),
       currencies: ranked.currencies,
       currencyBalances: holdings.currencyBalances,
       usdBalances: prices,

--- a/apps/kyberswap-interface/src/services/walletInventory.ts
+++ b/apps/kyberswap-interface/src/services/walletInventory.ts
@@ -12,7 +12,7 @@ export { UnsupportedChainError, parseRawAmount }
 export type InventoryRow = {
   /** Checksummed. The API's native sentinel is normalized to `ETHER_ADDRESS`. */
   address: string
-  /** On-chain units. Divide by the token's real `decimals` only at display time. */
+  /** On-chain units; zero when a live read found the token emptied. Divide by `decimals` only at display time. */
   rawBalance: bigint
   /** Block at which this token's balance last changed — per token, not a snapshot of the response. */
   blockNumber: number
@@ -71,8 +71,8 @@ export const adaptRow = (chainId: ChainId, raw: InventoryRawRow): InventoryRow |
 /**
  * Every token the wallet holds on one chain, walked to completion by the shared client and adapted
  * to the app's checksummed row shape. Rows the service returns malformed are dropped rather than
- * poisoning the map; zero rows (tombstones) are dropped too, since for a full walk "gone" simply means
- * "not in the result".
+ * poisoning the map. Zero rows are kept: a live read reporting a token emptied is a fact stamped at
+ * the head, and the store needs it to outrank the index's lagging amount until the index catches up.
  */
 export const fetchWalletInventory = async ({
   chainId,
@@ -103,8 +103,7 @@ export const fetchWalletInventory = async ({
   raw.forEach(candidate => {
     if (!rowSchema.safeParse(candidate).success) return
     const row = adaptRow(chainId, candidate)
-    if (!row) return
-    if (row.rawBalance > 0n) rows.push(row)
+    if (row) rows.push(row)
   })
 
   return { rows, complete, blockNumber: indexedBlock }

--- a/apps/kyberswap-interface/src/services/walletInventory.ts
+++ b/apps/kyberswap-interface/src/services/walletInventory.ts
@@ -28,7 +28,11 @@ export type WalletInventoryResult = {
    * be read as "every other token is zero" — it only proves the tokens it does list are held.
    */
   complete: boolean
-  /** Highest `blockNumber` seen, i.e. how far this inventory has caught up to the chain. */
+  /**
+   * How far the index has caught up to the chain. Live reads are excluded on purpose: they are
+   * stamped at the head, and a caller waiting out the indexer's lag would otherwise stop waiting the
+   * moment it asked for one.
+   */
   blockNumber: number
 }
 
@@ -74,23 +78,34 @@ export const fetchWalletInventory = async ({
   chainId,
   account,
   signal,
+  liveAddrs,
 }: {
   chainId: ChainId
   account: string
   signal?: AbortSignal
+  /** Tokens the service should read from the node as it answers; see `walkWalletInventory`. */
+  liveAddrs?: readonly string[]
 }): Promise<WalletInventoryResult> => {
   if (!KD_API_URL) throw new Error('wallet inventory host is not configured')
-  const { rows: raw, complete } = await walkWalletInventory({ baseUrl: KD_API_URL, chainId, account, signal })
+  const {
+    rows: raw,
+    complete,
+    indexedBlock,
+  } = await walkWalletInventory({
+    baseUrl: KD_API_URL,
+    chainId,
+    account,
+    signal,
+    liveAddrs,
+  })
 
   const rows: InventoryRow[] = []
-  let blockNumber = 0
   raw.forEach(candidate => {
     if (!rowSchema.safeParse(candidate).success) return
     const row = adaptRow(chainId, candidate)
     if (!row) return
-    blockNumber = Math.max(blockNumber, row.blockNumber)
     if (row.rawBalance > 0n) rows.push(row)
   })
 
-  return { rows, complete, blockNumber }
+  return { rows, complete, blockNumber: indexedBlock }
 }

--- a/apps/kyberswap-interface/src/state/transactions/updater.tsx
+++ b/apps/kyberswap-interface/src/state/transactions/updater.tsx
@@ -219,14 +219,15 @@ export default function Updater(): null {
         // catches up; a receipt without one (the Safe path) still forces a refetch, just without a
         // block to chase — chasing the observed head instead would overshoot the execution block and
         // poll until the timeout for nothing.
+        const touched = touchedTokens(chainId, transaction.extraInfo)
         expireInventory(
           chainId,
           transaction.from,
           receipt.blockNumber !== undefined ? Number(receipt.blockNumber) : undefined,
-          touchedTokens(chainId, transaction.extraInfo),
+          touched,
         )
         // The widget selectors keep their own inventory in `@kyber/hooks`; it refreshes on the same cue.
-        expireWalletInventory(chainId, transaction.from)
+        expireWalletInventory(chainId, transaction.from, touched)
 
         // Swapped (address sender, address srcToken, address dstToken, address dstReceiver, uint256 spentAmount, uint256 returnAmount)
         const swapEventTopic = keccak256(toBytes('Swapped(address,address,address,address,uint256,uint256)'))

--- a/apps/kyberswap-interface/src/state/transactions/updater.tsx
+++ b/apps/kyberswap-interface/src/state/transactions/updater.tsx
@@ -118,8 +118,8 @@ function shouldCheck(
 
 /** The ERC-20 tokens a confirmed transaction moved, checksummed; the native currency is read live already. */
 const touchedTokens = (chainId: ChainId, extraInfo: TransactionExtraInfo | undefined): string[] => {
-  const info = extraInfo as { tokenAddressIn?: string; tokenAddressOut?: string } | undefined
-  return [info?.tokenAddressIn, info?.tokenAddressOut].flatMap(address => {
+  const info = extraInfo as { tokenAddress?: string; tokenAddressIn?: string; tokenAddressOut?: string } | undefined
+  return [info?.tokenAddress, info?.tokenAddressIn, info?.tokenAddressOut].flatMap(address => {
     const checksummed = address ? isAddress(chainId, address) : false
     return checksummed && checksummed !== ETHER_ADDRESS ? [checksummed] : []
   })
@@ -227,7 +227,12 @@ export default function Updater(): null {
           touched,
         )
         // The widget selectors keep their own inventory in `@kyber/hooks`; it refreshes on the same cue.
-        expireWalletInventory(chainId, transaction.from, touched)
+        expireWalletInventory(
+          chainId,
+          transaction.from,
+          touched,
+          receipt.blockNumber !== undefined ? Number(receipt.blockNumber) : undefined,
+        )
 
         // Swapped (address sender, address srcToken, address dstToken, address dstReceiver, uint256 spentAmount, uint256 returnAmount)
         const swapEventTopic = keccak256(toBytes('Swapped(address,address,address,address,uint256,uint256)'))

--- a/apps/kyberswap-interface/src/state/wallet/hooks.ts
+++ b/apps/kyberswap-interface/src/state/wallet/hooks.ts
@@ -9,11 +9,9 @@ import { useActiveWeb3React } from 'hooks'
 import { useEthBalanceOfAnotherChain, useTokensBalanceOfAnotherChain } from 'hooks/bridge'
 import { useMulticallContract } from 'hooks/useContract'
 import { useAllTokens } from 'hooks/useTokens'
-import { useBlockNumberFor } from 'state/application/hooks'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { useMultipleContractSingleData, useSingleCallResult } from 'state/multicall/hooks'
 import { useTokenPrices } from 'state/tokenPrices/hooks'
-import { publishLiveBalances, retireLiveBalances } from 'state/walletInventory/store'
 import { isAddress } from 'utils/address'
 import { isTokenNative } from 'utils/tokenInfo'
 
@@ -176,25 +174,6 @@ export function useCurrencyBalances(
 
   const tokenBalances = useTokenBalances(tokens, chainId)
   const ethBalance = useNativeBalance(chainId)
-
-  // The tokens a form transacts with are the ones the wallet inventory is most likely to be behind on
-  // right after a transaction; hand it these per-block reads so it can correct itself meanwhile.
-  const blockNumber = useBlockNumberFor(chainId)
-  useEffect(() => {
-    if (!account || chainId !== currentChain || blockNumber === undefined) return
-    const reads = tokens.flatMap(token => {
-      const amount = tokenBalances[token.address]
-      return amount ? [{ address: token.address, rawBalance: BigInt(amount.quotient.toString()) }] : []
-    })
-    publishLiveBalances(chainId, account, blockNumber, reads)
-  }, [account, chainId, currentChain, blockNumber, tokens, tokenBalances])
-  // The reads go with the tokens: once this form stops reading a token, its last read must not
-  // linger and outlive the balance it described.
-  useEffect(() => {
-    if (!account || chainId !== currentChain) return
-    const addresses = tokens.map(token => token.address)
-    return () => retireLiveBalances(chainId, account, addresses)
-  }, [account, chainId, currentChain, tokens])
 
   return useMemo(
     () =>

--- a/apps/kyberswap-interface/src/state/walletInventory/constants.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/constants.ts
@@ -1,3 +1,5 @@
+import { INDEXER_CATCHUP_WINDOW_MS } from '@kyber/hooks'
+
 // The served-chain list is `WALLET_INVENTORY_CHAINS` in `@kyber/hooks`, shared with the widget
 // selectors so the two can never drift; the store gates on it through `isWalletInventoryChain`.
 
@@ -11,10 +13,10 @@ export const INVENTORY_TTL_MS = 30_000
 export const INVENTORY_CATCHUP_INTERVAL_MS = 5_000
 
 /**
- * How long to keep chasing the indexer for a transaction's block before giving up and returning to
- * the normal TTL. Comfortably past the observed 15–70s indexing lag.
+ * How long after a transaction its tokens are read live and the inventory polled at the catch-up
+ * cadence, unless the index reaches the transaction's block first. Shared with the widget store.
  */
-export const INVENTORY_CATCHUP_TIMEOUT_MS = 150_000
+export const INVENTORY_CATCHUP_TIMEOUT_MS = INDEXER_CATCHUP_WINDOW_MS
 
 /** Backoff after consecutive failures. The last entry is the ceiling; retries never stop. */
 export const INVENTORY_RETRY_BACKOFF_MS = [5_000, 15_000, 45_000, 120_000]

--- a/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
@@ -1,10 +1,7 @@
 import { ChainId, Token, TokenAmount } from '@kyberswap/ks-sdk-core'
-import { useEffect, useMemo, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 
-import { ERC20_ABI } from 'constants/abis'
 import { useActiveWeb3React } from 'hooks'
-import { useBlockNumberFor } from 'state/application/hooks'
-import { useMultipleContractSingleData } from 'state/multicall/hooks'
 import { useNativeBalance } from 'state/wallet/hooks'
 import {
   TokenMetadata,
@@ -17,60 +14,17 @@ import {
   getStoreVersion,
   inventoryKey,
   isInventoryChain,
-  publishLiveBalances,
   readEntry,
-  readLiveBalances,
-  readTouchedTokens,
   register,
-  retireLiveBalances,
   subscribeStore,
   unregister,
 } from 'state/walletInventory/store'
 
 export type { WalletInventory }
 
-const NO_ADDRESSES: string[] = []
+/** How long the trust check waits for the live native read before handing the wallet back to multicall. */
+const NATIVE_READ_TIMEOUT_MS = 10_000
 
-/**
- * Reads the tokens the wallet's recent transactions moved straight from the chain, every block, for
- * as long as the inventory is behind those transactions, and overlays the result. This is what keeps
- * a just-swapped balance right on screen wherever the wallet is looked at — the indexer needs a
- * while to catch up, and the forms that read their own tokens may already be gone.
- */
-const useTouchedTokenReads = (chainId: ChainId, account: string | undefined, key: string | undefined) => {
-  const { chainId: currentChain } = useActiveWeb3React()
-  const storeVersion = useSyncExternalStore(subscribeStore, getStoreVersion, getStoreVersion)
-  // `storeVersion` re-reads the watch as transactions confirm and walks land.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const touched = useMemo(() => (key ? readTouchedTokens(key, Date.now()) : NO_ADDRESSES), [key, storeVersion])
-  // The multicall hook reads on the active chain only.
-  const addresses = account && chainId === currentChain ? touched : NO_ADDRESSES
-  const calls = useMultipleContractSingleData(addresses, ERC20_ABI, 'balanceOf', [account])
-  const blockNumber = useBlockNumberFor(chainId)
-
-  useEffect(() => {
-    if (!account || !addresses.length || blockNumber === undefined) return
-    const reads = addresses.flatMap((address, index) => {
-      const raw = calls[index]?.result?.[0]
-      return raw !== undefined ? [{ address, rawBalance: BigInt(raw.toString()) }] : []
-    })
-    if (reads.length) publishLiveBalances(chainId, account, blockNumber, reads)
-  }, [account, addresses, blockNumber, calls, chainId])
-
-  useEffect(() => {
-    if (!account || !addresses.length) return
-    return () => retireLiveBalances(chainId, account, addresses)
-  }, [account, addresses, chainId])
-}
-
-/**
- * Subscribes to the wallet's token inventory on a chain. Every consumer sharing a (chain, account)
- * shares one poll, so the selector, the token list and the wallet popup cost a single request between
- * them.
- *
- * Pass `enabled: false` for surfaces that are mounted but not showing balances (a closed modal), so
- * they register no traffic.
- */
 export const useWalletInventory = (chainId?: ChainId, enabled = true): WalletInventory => {
   const { chainId: currentChain, account } = useActiveWeb3React()
   const resolvedChain = chainId || currentChain
@@ -84,21 +38,31 @@ export const useWalletInventory = (chainId?: ChainId, enabled = true): WalletInv
 
   const storeVersion = useSyncExternalStore(subscribeStore, getStoreVersion, getStoreVersion)
   const key = subscribed && account ? inventoryKey(resolvedChain, account) : undefined
-  useTouchedTokenReads(resolvedChain, account, key)
   // `storeVersion` is what makes these re-read when the store changes; both return stable references
   // while their data holds, so the resolver below only re-runs on a real change.
   /* eslint-disable react-hooks/exhaustive-deps */
   const entry = useMemo(() => (key ? readEntry(key) : undefined), [key, storeVersion])
-  const live = useMemo(() => (key ? readLiveBalances(key) : undefined), [key, storeVersion])
   /* eslint-enable react-hooks/exhaustive-deps */
 
   // Read live per block. Identity changes every block even when the value does not, so the resolver is
   // keyed on the value to avoid rebuilding rows for a balance that did not move.
   const nativeRawBalance = useNativeBalance(resolvedChain)?.quotient.toString()
 
+  // A read that never arrives would hold the trust check open for good, and every consumer on a
+  // loader with it. Past the deadline the wallet goes back to the caller's own balance source.
+  const [nativeReadTimedOut, setNativeReadTimedOut] = useState(false)
+  useEffect(() => {
+    if (!subscribed || nativeRawBalance !== undefined) {
+      setNativeReadTimedOut(false)
+      return
+    }
+    const timer = setTimeout(() => setNativeReadTimedOut(true), NATIVE_READ_TIMEOUT_MS)
+    return () => clearTimeout(timer)
+  }, [subscribed, nativeRawBalance, resolvedChain, account])
+
   return useMemo(
-    () => resolveInventory(entry, subscribed, nativeRawBalance, live),
-    [entry, subscribed, nativeRawBalance, live],
+    () => resolveInventory(entry, subscribed, nativeRawBalance, nativeReadTimedOut),
+    [entry, subscribed, nativeRawBalance, nativeReadTimedOut],
   )
 }
 

--- a/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
@@ -1,5 +1,5 @@
 import { ChainId, Token, TokenAmount } from '@kyberswap/ks-sdk-core'
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useSyncExternalStore } from 'react'
 
 import { useActiveWeb3React } from 'hooks'
 import { useNativeBalance } from 'state/wallet/hooks'
@@ -22,9 +22,14 @@ import {
 
 export type { WalletInventory }
 
-/** How long the trust check waits for the live native read before handing the wallet back to multicall. */
-const NATIVE_READ_TIMEOUT_MS = 10_000
-
+/**
+ * Subscribes to the wallet's token inventory on a chain. Every consumer sharing a (chain, account)
+ * shares one poll, so the selector, the token list and the wallet popup cost a single request between
+ * them.
+ *
+ * Pass `enabled: false` for surfaces that are mounted but not showing balances (a closed modal), so
+ * they register no traffic.
+ */
 export const useWalletInventory = (chainId?: ChainId, enabled = true): WalletInventory => {
   const { chainId: currentChain, account } = useActiveWeb3React()
   const resolvedChain = chainId || currentChain
@@ -48,22 +53,7 @@ export const useWalletInventory = (chainId?: ChainId, enabled = true): WalletInv
   // keyed on the value to avoid rebuilding rows for a balance that did not move.
   const nativeRawBalance = useNativeBalance(resolvedChain)?.quotient.toString()
 
-  // A read that never arrives would hold the trust check open for good, and every consumer on a
-  // loader with it. Past the deadline the wallet goes back to the caller's own balance source.
-  const [nativeReadTimedOut, setNativeReadTimedOut] = useState(false)
-  useEffect(() => {
-    if (!subscribed || nativeRawBalance !== undefined) {
-      setNativeReadTimedOut(false)
-      return
-    }
-    const timer = setTimeout(() => setNativeReadTimedOut(true), NATIVE_READ_TIMEOUT_MS)
-    return () => clearTimeout(timer)
-  }, [subscribed, nativeRawBalance, resolvedChain, account])
-
-  return useMemo(
-    () => resolveInventory(entry, subscribed, nativeRawBalance, nativeReadTimedOut),
-    [entry, subscribed, nativeRawBalance, nativeReadTimedOut],
-  )
+  return useMemo(() => resolveInventory(entry, subscribed, nativeRawBalance), [entry, subscribed, nativeRawBalance])
 }
 
 /**

--- a/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
@@ -12,7 +12,7 @@ import { InventoryEntry } from 'state/walletInventory/store'
 const EMPTY_ROWS: Record<string, InventoryRow> = {}
 
 export type WalletInventory = {
-  /** Checksummed token address → row, for tokens with a non-zero balance. */
+  /** Checksummed token address → row, for tokens the wallet holds. */
   rows: Record<string, InventoryRow>
   /**
    * Whether consumers should read balances from here at all. False means the chain is not indexed,
@@ -55,18 +55,11 @@ const PENDING_INVENTORY: WalletInventory = { ...INACTIVE_INVENTORY, pending: tru
  * no native holding is not to be believed, and the caller falls back to multicall. It is also an
  * overlay, since having paid for that read already it may as well win over the indexed native row,
  * which is the balance users watch most closely.
-
  */
 export const resolveInventory = (
   entry: InventoryEntry | undefined,
   subscribed: boolean,
   nativeRawBalance?: string,
-  /**
-   * The live native read has had long enough and never arrived. Without it the trust check below can
-   * never run, so rather than hold every consumer on a loader for good, the caller's own balance
-   * source takes over.
-   */
-  nativeReadTimedOut = false,
 ): WalletInventory => {
   if (!subscribed) return INACTIVE_INVENTORY
   // Subscribed with nothing stored yet: the first fetch is on its way, so hold the fallback back.
@@ -76,15 +69,15 @@ export const resolveInventory = (
   // list, which is most of what the selector renders — multicall answers those in one block instead.
   if (entry.status !== 'settled') return INACTIVE_INVENTORY
 
-  const nativeRow = entry.rows[ETHER_ADDRESS]
+  const held = withoutTombstones(entry.rows)
+  const nativeRow = held[ETHER_ADDRESS]
   if (!nativeRow) {
     // Funded wallet the inventory failed to account for: the data is not to be believed.
     if (nativeRawBalance && nativeRawBalance !== '0') return INACTIVE_INVENTORY
     // The trust check cannot run until the native read lands. Serve the rows, but withhold `settled`
     // so no zeros are synthesized off data that may be about to fail the check.
     if (nativeRawBalance === undefined) {
-      if (nativeReadTimedOut) return INACTIVE_INVENTORY
-      return { rows: entry.rows, active: true, settled: false, pending: false }
+      return { rows: held, active: true, settled: false, pending: false }
     }
   }
 
@@ -93,10 +86,24 @@ export const resolveInventory = (
   // pre-transaction amount for the length of its lag.
   const rows =
     nativeRawBalance !== undefined && nativeRow
-      ? { ...entry.rows, [ETHER_ADDRESS]: { ...nativeRow, rawBalance: BigInt(nativeRawBalance) } }
-      : entry.rows
+      ? { ...held, [ETHER_ADDRESS]: { ...nativeRow, rawBalance: BigInt(nativeRawBalance) } }
+      : held
 
   return { rows, active: true, settled: true, pending: false }
+}
+
+/**
+ * The store keeps zero rows so a live read's "emptied" outranks the index's lagging amount; to a
+ * reader such a token is simply not held. Same object back when there is nothing to drop.
+ */
+const withoutTombstones = (rows: Record<string, InventoryRow>): Record<string, InventoryRow> => {
+  let next: Record<string, InventoryRow> | undefined
+  Object.values(rows).forEach(row => {
+    if (row.rawBalance !== 0n) return
+    next ??= { ...rows }
+    delete next[row.address]
+  })
+  return next ?? rows
 }
 
 // One zero per Token: a settled inventory synthesizes zeros for most of the whitelist, and rebuilding

--- a/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
@@ -2,7 +2,7 @@ import { Token, TokenAmount } from '@kyberswap/ks-sdk-core'
 import { InventoryRow } from 'services/walletInventory'
 
 import { ETHER_ADDRESS } from 'constants/index'
-import { InventoryEntry, LiveBalanceMap } from 'state/walletInventory/store'
+import { InventoryEntry } from 'state/walletInventory/store'
 
 /**
  * The decision layer between the raw store entry and what consumers render, kept free of React so the
@@ -55,18 +55,18 @@ const PENDING_INVENTORY: WalletInventory = { ...INACTIVE_INVENTORY, pending: tru
  * no native holding is not to be believed, and the caller falls back to multicall. It is also an
  * overlay, since having paid for that read already it may as well win over the indexed native row,
  * which is the balance users watch most closely.
- *
- * `live` carries per-block reads for the tokens the user is transacting with. A read observed at a
- * block past a row's last-change block is at least as current as the row and wins; the indexer's lag
- * after a transaction is exactly the window in which that matters. The comparison is strict because a
- * read can be stamped one block ahead of the state it reflects (the previous block's data is kept on
- * screen while the next block's query is in flight).
+
  */
 export const resolveInventory = (
   entry: InventoryEntry | undefined,
   subscribed: boolean,
   nativeRawBalance?: string,
-  live?: LiveBalanceMap,
+  /**
+   * The live native read has had long enough and never arrived. Without it the trust check below can
+   * never run, so rather than hold every consumer on a loader for good, the caller's own balance
+   * source takes over.
+   */
+  nativeReadTimedOut = false,
 ): WalletInventory => {
   if (!subscribed) return INACTIVE_INVENTORY
   // Subscribed with nothing stored yet: the first fetch is on its way, so hold the fallback back.
@@ -83,6 +83,7 @@ export const resolveInventory = (
     // The trust check cannot run until the native read lands. Serve the rows, but withhold `settled`
     // so no zeros are synthesized off data that may be about to fail the check.
     if (nativeRawBalance === undefined) {
+      if (nativeReadTimedOut) return INACTIVE_INVENTORY
       return { rows: entry.rows, active: true, settled: false, pending: false }
     }
   }
@@ -90,38 +91,12 @@ export const resolveInventory = (
   // Compared against undefined, not truthiness: a live balance of exactly '0' is the case the overlay
   // matters most for — a wallet just drained by a max-send must not keep showing the indexer's stale
   // pre-transaction amount for the length of its lag.
-  let rows =
+  const rows =
     nativeRawBalance !== undefined && nativeRow
       ? { ...entry.rows, [ETHER_ADDRESS]: { ...nativeRow, rawBalance: BigInt(nativeRawBalance) } }
       : entry.rows
 
-  rows = overlayLiveBalances(rows, live)
-
   return { rows, active: true, settled: true, pending: false }
-}
-
-/**
- * Applies the live reads that are newer than what the inventory holds. Returns the same object when
- * nothing changes, so an unchanged inventory keeps its identity through every block tick.
- */
-const overlayLiveBalances = (
-  rows: Record<string, InventoryRow>,
-  live: LiveBalanceMap | undefined,
-): Record<string, InventoryRow> => {
-  if (!live?.size) return rows
-  let next: Record<string, InventoryRow> | undefined
-  live.forEach((read, address) => {
-    if (address === ETHER_ADDRESS) return
-    const row = rows[address]
-    if (row && read.blockNumber <= row.blockNumber) return
-    if ((row?.rawBalance ?? 0n) === read.rawBalance) return
-    next ??= { ...rows }
-    // Rows only ever describe non-zero holdings; a token read as drained leaves the map, so
-    // consumers see it exactly as the indexer will report it once caught up.
-    if (read.rawBalance === 0n) delete next[address]
-    else next[address] = { ...row, address, rawBalance: read.rawBalance, blockNumber: read.blockNumber }
-  })
-  return next ?? rows
 }
 
 // One zero per Token: a settled inventory synthesizes zeros for most of the whitelist, and rebuilding

--- a/apps/kyberswap-interface/src/state/walletInventory/store.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/store.ts
@@ -30,7 +30,11 @@ export type InventoryStatus =
   | 'error'
 
 export type InventoryEntry = {
-  /** Checksummed token address → row. Only tokens with a non-zero balance. */
+  /**
+   * Checksummed token address → row, as merged across walks. Includes zero rows a live read
+   * established (tombstones): they hold their place against the index's lagging amount until it
+   * catches up. Readers take them as absent; see `resolveInventory`.
+   */
   rows: Record<string, InventoryRow>
   status: InventoryStatus
   /** How far this inventory has caught up to the chain. */
@@ -44,19 +48,20 @@ type Meta = {
   /** Set by `expireInventory`; makes the next sweep pick this entry up whatever its TTL says. */
   forced: boolean
   /**
-   * Block of a transaction the user just made. While the inventory's block is behind it the sweep
-   * polls at the catch-up cadence instead of the TTL; the watch retires by itself once caught up or
-   * on timeout.
+   * The catch-up watch opened by a transaction the user just made. While it is on, the sweep polls
+   * at the catch-up cadence and asks the service to read `touched` from the node (`liveAddrs`), so
+   * the balances that just changed are right before the index has caught up. It retires when the
+   * index reaches `awaitingBlock`, or at `awaitingUntil` when there is no block to chase (a Safe
+   * receipt carries none).
    */
   awaitingBlock?: number
   awaitingUntil?: number
-  /**
-   * Tokens the watched transactions moved (checksummed). While the watch is on, consumers read
-   * these straight from the chain and overlay the result, so the indexer's lag is not on screen for
-   * exactly the balances that just changed.
-   */
+  /** Checksummed tokens the watched transactions moved. */
   touched?: string[]
 }
+
+/** Live reads per catch-up poll are node reads on the service; a session of trading must not pile up. */
+const TOUCHED_CAP = 32
 
 const NO_ADDRESSES: string[] = []
 
@@ -135,36 +140,45 @@ export const expireInventory = (
   // inventory to refresh, and writing meta for the rest would accrete dead keys and wake subscribers
   // over data no sweep will ever fetch.
   if (!isInventoryChain(chainId)) return
+  const now = Date.now()
   const key = inventoryKey(chainId, account)
   const entry = meta.get(key)
-  // Touched tokens accumulate across the transactions of one watch; the array only changes when a
-  // new address joins, so consumers keyed on it do not re-subscribe for nothing.
-  const previousTouched = entry?.touched ?? NO_ADDRESSES
-  const added = touched.filter(address => !previousTouched.includes(address))
+  // Tokens accumulate across the transactions of one watch and are dropped with it: the list is the
+  // current transactions', not the session's. It only changes when an address joins, so consumers
+  // keyed on it do not re-subscribe for nothing.
+  const carried = entry && isCatchingUp(key, now) ? entry.touched ?? NO_ADDRESSES : NO_ADDRESSES
+  const added = touched.filter(address => !carried.includes(address))
+  const carriedBlock = carried.length ? entry?.awaitingBlock : undefined
   meta.set(key, {
     failures: entry?.failures ?? 0,
     nextRetryAt: 0,
     forced: true,
-    awaitingBlock: awaitingBlock ?? entry?.awaitingBlock,
-    awaitingUntil: awaitingBlock ? Date.now() + INVENTORY_CATCHUP_TIMEOUT_MS : entry?.awaitingUntil,
-    touched: added.length ? [...previousTouched, ...added] : entry?.touched,
+    awaitingBlock: awaitingBlock !== undefined ? Math.max(awaitingBlock, carriedBlock ?? 0) : carriedBlock,
+    awaitingUntil: now + INVENTORY_CATCHUP_TIMEOUT_MS,
+    touched: added.length ? [...carried, ...added].slice(-TOUCHED_CAP) : carried.length ? entry?.touched : undefined,
   })
   emit()
 }
 
-/** Tokens to read live for this wallet: those its watched transactions moved, while the watch is on. */
-export const readTouchedTokens = (key: string, now: number): string[] =>
-  isAwaitingBlock(key, now) ? meta.get(key)?.touched ?? NO_ADDRESSES : NO_ADDRESSES
-
-/** True while we are still chasing a transaction's block for this wallet. */
-export const isAwaitingBlock = (key: string, now: number): boolean => {
+/**
+ * True while the inventory is still chasing a transaction of this wallet's: until the index reaches
+ * the transaction's block, or, when the receipt carried none, until the window runs out.
+ */
+export const isCatchingUp = (key: string, now: number): boolean => {
   const entry = meta.get(key)
-  if (!entry?.awaitingBlock) return false
-  if (entry.awaitingUntil && now > entry.awaitingUntil) return false
-  return (entries.get(key)?.blockNumber ?? 0) < entry.awaitingBlock
+  if (!entry?.awaitingUntil || now > entry.awaitingUntil) return false
+  return entry.awaitingBlock === undefined || (entries.get(key)?.blockNumber ?? 0) < entry.awaitingBlock
 }
 
-/** Field-level equality for the render-relevant parts of two row maps. */
+/** Tokens to read live for this wallet: those its watched transactions moved, while the watch is on. */
+export const readTouchedTokens = (key: string, now: number): string[] =>
+  isCatchingUp(key, now) ? meta.get(key)?.touched ?? NO_ADDRESSES : NO_ADDRESSES
+
+/**
+ * Field-level equality for the rendered parts of two row maps. The block stamp is bookkeeping, not
+ * rendered: a live read re-stamped at every catch-up poll must not wake every consumer over a
+ * balance that did not move.
+ */
 const rowsEqual = (a: Record<string, InventoryRow>, b: Record<string, InventoryRow>): boolean => {
   const aKeys = Object.keys(a)
   if (aKeys.length !== Object.keys(b).length) return false
@@ -172,8 +186,7 @@ const rowsEqual = (a: Record<string, InventoryRow>, b: Record<string, InventoryR
     const x = a[key]
     const y = b[key]
     if (!y) return false
-    if (x.rawBalance !== y.rawBalance || x.blockNumber !== y.blockNumber) return false
-    if (x.decimals !== y.decimals || x.symbol !== y.symbol) return false
+    if (x.rawBalance !== y.rawBalance || x.decimals !== y.decimals || x.symbol !== y.symbol) return false
   }
   return true
 }
@@ -192,8 +205,25 @@ export const commitResult = (key: string, result: WalletInventoryResult) => {
   const rows: Record<string, InventoryRow> = {}
   result.rows.forEach(row => {
     const existing = previous?.rows[row.address]
-    rows[row.address] = existing && existing.blockNumber > row.blockNumber ? existing : row
+    if (existing && existing.blockNumber > row.blockNumber) {
+      rows[row.address] = existing
+      return
+    }
+    // The catalog description travels with the token whichever row wins: a live read may carry none.
+    rows[row.address] =
+      existing && (row.decimals === undefined || row.symbol === undefined)
+        ? { ...row, decimals: row.decimals ?? existing.decimals, symbol: row.symbol ?? existing.symbol }
+        : row
   })
+  // A walk only retires rows its index is authoritative about. Anything it did not list but that was
+  // stamped past what its index knows — a live read, a token bought or emptied at the head — is
+  // carried forward, so the index catching up later cannot restate a balance the node has already
+  // contradicted.
+  if (previous) {
+    Object.values(previous.rows).forEach(row => {
+      if (!rows[row.address] && row.blockNumber > result.blockNumber) rows[row.address] = row
+    })
+  }
 
   // The steady-state poll usually returns exactly what is already on screen. Committing it as a new
   // object would ripple identity changes all the way to a full re-sort of the token list every TTL

--- a/apps/kyberswap-interface/src/state/walletInventory/store.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/store.ts
@@ -66,19 +66,6 @@ const subscriptions = new Map<string, number>()
 const entries = new Map<string, InventoryEntry>()
 const meta = new Map<string, Meta>()
 
-/** A balance read straight from the chain, with the block it was observed at. */
-export type LiveBalance = { rawBalance: bigint; blockNumber: number }
-export type LiveBalanceMap = ReadonlyMap<string, LiveBalance>
-
-/**
- * Per wallet, the latest live reads for the tokens the user is transacting with (the swap pair, a
- * limit order's maker token, a send). These come from the per-block multicall that those forms run
- * anyway, so between a transaction confirming and the indexer catching up the inventory can be
- * corrected for exactly the tokens that just moved without paying for any extra request.
- */
-const liveBalances = new Map<string, LiveBalanceMap>()
-const LIVE_BALANCES_PER_WALLET = 64
-
 let version = 0
 const listeners = new Set<() => void>()
 
@@ -133,60 +120,6 @@ export const unregister = (chainId: number, account: string) => {
 export const readSubscriptions = () => subscriptions
 export const readEntry = (key: string) => entries.get(key)
 export const readMeta = (key: string) => meta.get(key)
-export const readLiveBalances = (key: string) => liveBalances.get(key)
-
-/**
- * Records live reads for a wallet. A read is stored the first time its value is seen, stamped with the
- * block it was observed at, and left alone while the value holds — the stamp advancing every block
- * would wake every inventory consumer per block over a balance that did not move.
- */
-export const publishLiveBalances = (
-  chainId: number,
-  account: string,
-  blockNumber: number,
-  reads: { address: string; rawBalance: bigint }[],
-) => {
-  if (!isInventoryChain(chainId) || !reads.length) return
-  const key = inventoryKey(chainId, account)
-  const previous = liveBalances.get(key)
-  let next: Map<string, LiveBalance> | undefined
-  reads.forEach(({ address, rawBalance }) => {
-    if (previous?.get(address)?.rawBalance === rawBalance) return
-    next ??= new Map(previous)
-    // Re-insert so the map stays in last-changed order for the size cap below.
-    next.delete(address)
-    next.set(address, { rawBalance, blockNumber })
-  })
-  if (!next) return
-  while (next.size > LIVE_BALANCES_PER_WALLET) {
-    const oldest = next.keys().next().value
-    if (oldest === undefined) break
-    next.delete(oldest)
-  }
-  liveBalances.set(key, next)
-  emit()
-}
-
-/**
- * Drops the live reads for tokens a form has stopped reading. A read only means something while its
- * source refreshes it every block; left behind, it would keep restating a balance the wallet may
- * since have sold off entirely — an emptied token has no inventory row to outrank it.
- */
-export const retireLiveBalances = (chainId: number, account: string, addresses: readonly string[]) => {
-  const key = inventoryKey(chainId, account)
-  const previous = liveBalances.get(key)
-  if (!previous) return
-  let next: Map<string, LiveBalance> | undefined
-  addresses.forEach(address => {
-    if (!(next ?? previous).has(address)) return
-    next ??= new Map(previous)
-    next.delete(address)
-  })
-  if (!next) return
-  if (next.size) liveBalances.set(key, next)
-  else liveBalances.delete(key)
-  emit()
-}
 
 /**
  * Marks the wallet's inventory due on the next sweep, e.g. after a transaction of theirs confirms.
@@ -312,7 +245,6 @@ export const resetInventoryStore = () => {
   subscriptions.clear()
   entries.clear()
   meta.clear()
-  liveBalances.clear()
   version = 0
   listeners.clear()
 }

--- a/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
+++ b/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
@@ -8,7 +8,7 @@ import {
   commitFailure,
   commitResult,
   getStoreVersion,
-  isAwaitingBlock,
+  isCatchingUp,
   isInventoryChain,
   markChainUnsupported,
   readEntry,
@@ -65,8 +65,9 @@ export const selectDue = (now: number, windowVisible: boolean): DueTarget[] => {
 
     if (!windowVisible) return
 
-    // Chasing a just-confirmed transaction: poll faster than the TTL until the indexer catches up.
-    if (isAwaitingBlock(key, now)) {
+    // Chasing a just-confirmed transaction: poll faster than the TTL until the index catches up (or,
+    // with no block to chase, until the window runs out).
+    if (isCatchingUp(key, now)) {
       if (now - entry.fetchedAt >= INVENTORY_CATCHUP_INTERVAL_MS) due.push({ key, chainId, account })
       return
     }
@@ -81,28 +82,6 @@ export const selectDue = (now: number, windowVisible: boolean): DueTarget[] => {
  * Owns every request to the wallet-balances endpoint. Consumers only subscribe (see ./store), so one
  * poll serves the selector, the token list and the wallet popup at once rather than each racing.
  */
-/**
- * Outer deadline for one wallet's walk. The client aborts its own requests, but an abort the
- * environment ignores — a mobile in-app browser, a tab the system froze — would leave the sweep's
- * in-flight flag raised and every wallet unfetched from then on. This settles the walk regardless,
- * so the wallet falls back to multicall instead of the screen waiting for good.
- */
-const WALK_DEADLINE_MS = 15_000
-
-export const withDeadline = async <T,>(work: Promise<T>): Promise<T> => {
-  let timer: ReturnType<typeof setTimeout> | undefined
-  try {
-    return await Promise.race([
-      work,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error('wallet inventory walk timed out')), WALK_DEADLINE_MS)
-      }),
-    ])
-  } finally {
-    clearTimeout(timer)
-  }
-}
-
 export default function Updater(): null {
   const windowVisible = useIsWindowVisible()
 
@@ -134,7 +113,7 @@ export default function Updater(): null {
           // Tokens a just-confirmed transaction moved are asked for as live reads, so the answer
           // carries their balance at the head block instead of the indexer's lagging one.
           const liveAddrs = readTouchedTokens(key, Date.now())
-          commitResult(key, await withDeadline(fetchWalletInventory({ chainId, account, signal, liveAddrs })))
+          commitResult(key, await fetchWalletInventory({ chainId, account, signal, liveAddrs }))
         } catch (error) {
           // An unindexed chain is a permanent answer, not a transient failure: disable it for the
           // session so consumers settle on the multicall path instead of retrying forever.

--- a/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
+++ b/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
@@ -14,6 +14,7 @@ import {
   readEntry,
   readMeta,
   readSubscriptions,
+  readTouchedTokens,
   subscribeStore,
 } from 'state/walletInventory/store'
 
@@ -80,6 +81,28 @@ export const selectDue = (now: number, windowVisible: boolean): DueTarget[] => {
  * Owns every request to the wallet-balances endpoint. Consumers only subscribe (see ./store), so one
  * poll serves the selector, the token list and the wallet popup at once rather than each racing.
  */
+/**
+ * Outer deadline for one wallet's walk. The client aborts its own requests, but an abort the
+ * environment ignores — a mobile in-app browser, a tab the system froze — would leave the sweep's
+ * in-flight flag raised and every wallet unfetched from then on. This settles the walk regardless,
+ * so the wallet falls back to multicall instead of the screen waiting for good.
+ */
+const WALK_DEADLINE_MS = 15_000
+
+export const withDeadline = async <T,>(work: Promise<T>): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('wallet inventory walk timed out')), WALK_DEADLINE_MS)
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export default function Updater(): null {
   const windowVisible = useIsWindowVisible()
 
@@ -108,7 +131,10 @@ export default function Updater(): null {
     try {
       const runTarget = async ({ key, chainId, account }: DueTarget) => {
         try {
-          commitResult(key, await fetchWalletInventory({ chainId, account, signal }))
+          // Tokens a just-confirmed transaction moved are asked for as live reads, so the answer
+          // carries their balance at the head block instead of the indexer's lagging one.
+          const liveAddrs = readTouchedTokens(key, Date.now())
+          commitResult(key, await withDeadline(fetchWalletInventory({ chainId, account, signal, liveAddrs })))
         } catch (error) {
           // An unindexed chain is a permanent answer, not a transient failure: disable it for the
           // session so consumers settle on the multicall path instead of retrying forever.

--- a/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
@@ -7,7 +7,11 @@ import { getTokenComparator, mergeHeldSearchResults } from 'components/TokenSele
 import { ETHER_ADDRESS } from 'constants/index'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { isTokenListReady, rankWalletHoldings, selectWalletHoldings } from 'state/walletInventory/assets'
-import { INVENTORY_CATCHUP_INTERVAL_MS, INVENTORY_TTL_MS } from 'state/walletInventory/constants'
+import {
+  INVENTORY_CATCHUP_INTERVAL_MS,
+  INVENTORY_CATCHUP_TIMEOUT_MS,
+  INVENTORY_TTL_MS,
+} from 'state/walletInventory/constants'
 import { computeInventoryDiscoveries } from 'state/walletInventory/discoveries'
 import {
   TokenMetadata,
@@ -25,14 +29,14 @@ import {
   expireInventory,
   getStoreVersion,
   inventoryKey,
-  isAwaitingBlock,
+  isCatchingUp,
   readEntry,
   readMeta,
   readTouchedTokens,
   register,
   resetInventoryStore,
 } from 'state/walletInventory/store'
-import { selectDue, withDeadline } from 'state/walletInventory/updater'
+import { selectDue } from 'state/walletInventory/updater'
 
 const fetchListTokenByAddresses = vi.hoisted(() => vi.fn())
 vi.mock('hooks/useTokens', async importOriginal => ({
@@ -114,6 +118,28 @@ describe('walkWalletInventory (shared client)', () => {
     const secondUrl = String(fetchMock.mock.calls[1][0])
     expect(secondUrl).toContain('sinceBlockNumber=999')
     expect(secondUrl).toContain(`lastTokenAddr=${address(1000)}`)
+  })
+})
+
+describe('walkWalletInventory deadline', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('settles a request the environment never does, so a caller is never wedged on it', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => undefined)),
+    )
+    const walk = walkWalletInventory({ baseUrl: 'http://kd', chainId: 1, account: ACCOUNT })
+    const outcome = walk.then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+    await vi.advanceTimersByTimeAsync(9_000)
+    expect(await outcome).toBe('rejected')
   })
 })
 
@@ -329,7 +355,7 @@ describe('store commits', () => {
     expireInventory(ChainId.MAINNET, ACCOUNT, 120)
 
     commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 125 })
-    expect(isAwaitingBlock(KEY, Date.now())).toBe(false)
+    expect(isCatchingUp(KEY, Date.now())).toBe(false)
   })
 
   it('serves stale data after a failure instead of blanking the screen', () => {
@@ -347,6 +373,80 @@ describe('store commits', () => {
   })
 })
 
+describe('live reads across walks', () => {
+  const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+
+  it('carries a live zero forward until the index has caught up with it', () => {
+    register(ChainId.MAINNET, ACCOUNT)
+    // The index still lists USDT; a live read at the head found it emptied.
+    commitResult(KEY, {
+      rows: [row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 0n, 500)],
+      complete: true,
+      blockNumber: 95,
+    })
+    expect(readEntry(KEY)?.rows[USDT_CHECKSUM].rawBalance).toBe(0n)
+    // The next walk, without a live read, still carries the index's stale amount: it must not win.
+    commitResult(KEY, {
+      rows: [row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 5n, 95)],
+      complete: true,
+      blockNumber: 95,
+    })
+    expect(readEntry(KEY)?.rows[USDT_CHECKSUM].rawBalance).toBe(0n)
+    expect(resolveInventory(readEntry(KEY), true, '10').rows[USDT_CHECKSUM]).toBeUndefined()
+    // Once the index has passed the block the zero was read at, its silence about USDT is authoritative.
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 600)], complete: true, blockNumber: 600 })
+    expect(readEntry(KEY)?.rows[USDT_CHECKSUM]).toBeUndefined()
+  })
+
+  it('carries a token first seen live forward until the index lists it', () => {
+    register(ChainId.MAINNET, ACCOUNT)
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 90), row(DAI, 7n, 500)], complete: true, blockNumber: 95 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 90)], complete: true, blockNumber: 96 })
+    expect(readEntry(KEY)?.rows[DAI].rawBalance).toBe(7n)
+  })
+
+  it('keeps the catalog description when a live row arrives without one', () => {
+    register(ChainId.MAINNET, ACCOUNT)
+    commitResult(KEY, {
+      rows: [{ ...row(USDT_CHECKSUM, 5n, 100), decimals: 6, symbol: 'USDT' }],
+      complete: true,
+      blockNumber: 100,
+    })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 500)], complete: true, blockNumber: 100 })
+    expect(readEntry(KEY)?.rows[USDT_CHECKSUM]).toMatchObject({ rawBalance: 9n, decimals: 6, symbol: 'USDT' })
+  })
+
+  it('does not wake subscribers when only the block stamp of a live row moved', () => {
+    register(ChainId.MAINNET, ACCOUNT)
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 500)], complete: true, blockNumber: 100 })
+    const before = getStoreVersion()
+    const entry = readEntry(KEY)
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 505)], complete: true, blockNumber: 100 })
+    expect(getStoreVersion()).toBe(before)
+    expect(readEntry(KEY)).toBe(entry)
+  })
+
+  it('reads live for the whole window when the receipt carries no block, as for a Safe', () => {
+    register(ChainId.MAINNET, ACCOUNT)
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, blockNumber: 100 })
+    expireInventory(ChainId.MAINNET, ACCOUNT, undefined, [USDT_CHECKSUM])
+    const now = Date.now()
+    expect(isCatchingUp(KEY, now)).toBe(true)
+    expect(readTouchedTokens(KEY, now)).toEqual([USDT_CHECKSUM])
+    expect(isCatchingUp(KEY, now + INVENTORY_CATCHUP_TIMEOUT_MS + 1)).toBe(false)
+  })
+
+  it('starts a fresh token list once the previous watch has retired', () => {
+    register(ChainId.MAINNET, ACCOUNT)
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, blockNumber: 100 })
+    expireInventory(ChainId.MAINNET, ACCOUNT, 110, [USDT_CHECKSUM])
+    // The index reaches the block: the watch retires and its tokens go with it.
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 120)], complete: true, blockNumber: 120 })
+    expireInventory(ChainId.MAINNET, ACCOUNT, 130, [DAI])
+    expect(readTouchedTokens(KEY, Date.now())).toEqual([DAI])
+  })
+})
+
 describe('post-transaction catch-up', () => {
   it('keeps the watch alive across commits fetched inside the indexer lag', () => {
     commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
@@ -356,11 +456,11 @@ describe('post-transaction catch-up', () => {
     // repaints nothing), but the watch must survive it, or catch-up would stop at the first stale poll.
     commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 110)], complete: true, blockNumber: 110 })
     expect(readEntry(KEY)?.blockNumber).toBe(110)
-    expect(isAwaitingBlock(KEY, Date.now())).toBe(true)
+    expect(isCatchingUp(KEY, Date.now())).toBe(true)
 
     commitResult(KEY, { rows: [row(USDT_CHECKSUM, 2n, 125)], complete: true, blockNumber: 125 })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM]?.rawBalance).toBe(2n)
-    expect(isAwaitingBlock(KEY, Date.now())).toBe(false)
+    expect(isCatchingUp(KEY, Date.now())).toBe(false)
   })
 
   it('never lets a stale in-flight walk overwrite a fresher committed balance', () => {
@@ -488,24 +588,29 @@ describe('resolveInventory', () => {
   })
 })
 
-describe('resolveInventory native-read deadline', () => {
-  const settledWithoutNative: InventoryEntry = {
-    rows: { [USDT_CHECKSUM]: row(USDT_CHECKSUM, 5n, 100) },
+describe('resolveInventory tombstones', () => {
+  const entry = (rows: InventoryRow[]): InventoryEntry => ({
+    rows: Object.fromEntries(rows.map(r => [r.address, r])),
     status: 'settled',
     blockNumber: 100,
     fetchedAt: 1,
-  }
-
-  it('serves the rows while the native read is on its way, without settling', () => {
-    const resolved = resolveInventory(settledWithoutNative, true, undefined)
-    expect(resolved.active).toBe(true)
-    expect(resolved.settled).toBe(false)
   })
 
-  it('hands the wallet back to multicall once the read has had long enough', () => {
-    const resolved = resolveInventory(settledWithoutNative, true, undefined, true)
-    expect(resolved.active).toBe(false)
-    expect(resolved.pending).toBe(false)
+  it('hides a zero row from readers, and hands back the same rows object when there is none', () => {
+    const clean = entry([row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 5n, 100)])
+    expect(resolveInventory(clean, true, undefined).rows).toBe(clean.rows)
+
+    const withTombstone = entry([row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 0n, 500)])
+    const resolved = resolveInventory(withTombstone, true, '10')
+    expect(resolved.rows[USDT_CHECKSUM]).toBeUndefined()
+    expect(resolved.settled).toBe(true)
+  })
+
+  it('serves the rows the index lists while the native read is still on its way', () => {
+    const resolved = resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)]), true, undefined)
+    expect(resolved.active).toBe(true)
+    expect(resolved.settled).toBe(false)
+    expect(resolved.rows[USDT_CHECKSUM].rawBalance).toBe(5n)
   })
 })
 
@@ -781,27 +886,6 @@ describe('getTokenComparator with unlisted holdings', () => {
       new Set([scam.address]),
     )
     expect([scam, usdt].sort(compare).map(t => t.address)).toEqual([usdt.address, scam.address])
-  })
-})
-
-describe('withDeadline', () => {
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('settles a walk the environment never settles, so the sweep is never wedged', async () => {
-    vi.useFakeTimers()
-    const hung = withDeadline(new Promise(() => undefined))
-    const outcome = hung.then(
-      () => 'resolved',
-      () => 'rejected',
-    )
-    await vi.advanceTimersByTimeAsync(16_000)
-    expect(await outcome).toBe('rejected')
-  })
-
-  it('passes a walk that answers straight through', async () => {
-    await expect(withDeadline(Promise.resolve('done'))).resolves.toBe('done')
   })
 })
 

--- a/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
@@ -26,16 +26,13 @@ import {
   getStoreVersion,
   inventoryKey,
   isAwaitingBlock,
-  publishLiveBalances,
   readEntry,
-  readLiveBalances,
   readMeta,
   readTouchedTokens,
   register,
   resetInventoryStore,
-  retireLiveBalances,
 } from 'state/walletInventory/store'
-import { selectDue } from 'state/walletInventory/updater'
+import { selectDue, withDeadline } from 'state/walletInventory/updater'
 
 const fetchListTokenByAddresses = vi.hoisted(() => vi.fn())
 vi.mock('hooks/useTokens', async importOriginal => ({
@@ -117,6 +114,110 @@ describe('walkWalletInventory (shared client)', () => {
     const secondUrl = String(fetchMock.mock.calls[1][0])
     expect(secondUrl).toContain('sinceBlockNumber=999')
     expect(secondUrl).toContain(`lastTokenAddr=${address(1000)}`)
+  })
+})
+
+describe('walkWalletInventory with live reads', () => {
+  const address = (i: number) => `0x${i.toString(16).padStart(40, '0')}`
+  const row = (addr: string, rawAmount: string, blockNumber: number) => ({
+    tokenAddress: addr,
+    rawAmount,
+    blockNumber,
+    decimals: 18,
+    symbol: 'TKN',
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('asks for the live tokens once, and their head-block rows outrank the indexed ones', async () => {
+    const held = address(1)
+    const soldOff = address(2)
+    const urls: string[] = []
+    const fetchMock = vi.fn(async (url: string) => {
+      urls.push(url)
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          code: 0,
+          data: {
+            // The indexer still has yesterday's picture of both tokens.
+            balances: [row(held, '0x0a', 100), row(soldOff, '0x64', 100)],
+            // The node read, at the head: one grew, the other was sold off entirely.
+            liveBalances: [row(held, '0x1e', 500), row(soldOff, '0x', 500)],
+          },
+        }),
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rows, complete } = await walkWalletInventory({
+      baseUrl: 'http://kd',
+      chainId: 1,
+      account: ACCOUNT,
+      liveAddrs: [held, soldOff],
+    })
+
+    expect(complete).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Repeated params, not a comma-separated list — the service ignores the latter.
+    expect(urls[0]).toContain(`liveAddrs=${held}&liveAddrs=${soldOff}`)
+
+    const byAddress = Object.fromEntries(rows.map(r => [r.tokenAddress, r]))
+    expect(byAddress[held].rawAmount).toBe('0x1e')
+    expect(byAddress[held].blockNumber).toBe(500)
+    // A token read as emptied comes back as an explicit zero, which the adapter drops — so it leaves
+    // the map entirely rather than lingering at its indexed amount.
+    expect(byAddress[soldOff].rawAmount).toBe('0x')
+    expect(parseRawAmount(byAddress[soldOff].rawAmount)).toBe(0n)
+  })
+
+  it('reports how far the index has come, not where the live reads were taken', async () => {
+    const held = address(1)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          code: 0,
+          data: { balances: [row(held, '0x0a', 100)], liveBalances: [row(held, '0x1e', 500)] },
+        }),
+      })),
+    )
+
+    const { indexedBlock } = await walkWalletInventory({
+      baseUrl: 'http://kd',
+      chainId: 1,
+      account: ACCOUNT,
+      liveAddrs: [held],
+    })
+
+    // 500 is the head the node was read at; the caller waits for the index, which is still at 100 —
+    // otherwise it would stop asking for live reads while the indexed rows were still stale.
+    expect(indexedBlock).toBe(100)
+  })
+
+  it('does not repeat the live read on later pages', async () => {
+    const urls: string[] = []
+    const full = Array.from({ length: 1000 }, (_, i) => row(address(i + 10), '0x01', 100))
+    const fetchMock = vi.fn(async (url: string) => {
+      urls.push(url)
+      const first = urls.length === 1
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, data: { balances: first ? full : [row(address(9999), '0x01', 101)] } }),
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await walkWalletInventory({ baseUrl: 'http://kd', chainId: 1, account: ACCOUNT, liveAddrs: [address(1)] })
+
+    expect(urls.length).toBe(2)
+    expect(urls[0]).toContain('liveAddrs=')
+    expect(urls[1]).not.toContain('liveAddrs=')
   })
 })
 
@@ -384,6 +485,27 @@ describe('resolveInventory', () => {
     // Max-send just mined: the per-block read says 0 while the indexer still reports the old 5.
     const resolved = resolveInventory(entry([row(ETHER_ADDRESS, 5n, 100)], 'settled'), true, '0')
     expect(resolved.rows[ETHER_ADDRESS].rawBalance).toBe(0n)
+  })
+})
+
+describe('resolveInventory native-read deadline', () => {
+  const settledWithoutNative: InventoryEntry = {
+    rows: { [USDT_CHECKSUM]: row(USDT_CHECKSUM, 5n, 100) },
+    status: 'settled',
+    blockNumber: 100,
+    fetchedAt: 1,
+  }
+
+  it('serves the rows while the native read is on its way, without settling', () => {
+    const resolved = resolveInventory(settledWithoutNative, true, undefined)
+    expect(resolved.active).toBe(true)
+    expect(resolved.settled).toBe(false)
+  })
+
+  it('hands the wallet back to multicall once the read has had long enough', () => {
+    const resolved = resolveInventory(settledWithoutNative, true, undefined, true)
+    expect(resolved.active).toBe(false)
+    expect(resolved.pending).toBe(false)
   })
 })
 
@@ -662,82 +784,24 @@ describe('getTokenComparator with unlisted holdings', () => {
   })
 })
 
-describe('resolveInventory with live reads', () => {
-  const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
-  const settled = (rows: InventoryRow[]): InventoryEntry => ({
-    rows: Object.fromEntries(rows.map(r => [r.address, r])),
-    status: 'settled',
-    blockNumber: 100,
-    fetchedAt: 1,
-  })
-  const funded = [row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 5n, 100)]
-
-  it('lets a read observed past the row block correct the indexed amount', () => {
-    const live = new Map([[USDT_CHECKSUM, { rawBalance: 7n, blockNumber: 101 }]])
-    const resolved = resolveInventory(settled(funded), true, '10', live)
-    expect(resolved.rows[USDT_CHECKSUM].rawBalance).toBe(7n)
-    expect(resolved.rows[USDT_CHECKSUM].blockNumber).toBe(101)
+describe('withDeadline', () => {
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
-  it('keeps the indexed row when the read is not strictly newer', () => {
-    const live = new Map([[USDT_CHECKSUM, { rawBalance: 7n, blockNumber: 100 }]])
-    expect(resolveInventory(settled(funded), true, '10', live).rows[USDT_CHECKSUM].rawBalance).toBe(5n)
+  it('settles a walk the environment never settles, so the sweep is never wedged', async () => {
+    vi.useFakeTimers()
+    const hung = withDeadline(new Promise(() => undefined))
+    const outcome = hung.then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+    await vi.advanceTimersByTimeAsync(16_000)
+    expect(await outcome).toBe('rejected')
   })
 
-  it('adds a token the indexer has not listed yet and drops one read as drained', () => {
-    const live = new Map([
-      [DAI, { rawBalance: 3n, blockNumber: 101 }],
-      [USDT_CHECKSUM, { rawBalance: 0n, blockNumber: 101 }],
-    ])
-    const resolved = resolveInventory(settled(funded), true, '10', live)
-    expect(resolved.rows[DAI].rawBalance).toBe(3n)
-    expect(resolved.rows[USDT_CHECKSUM]).toBeUndefined()
-  })
-
-  it('returns the same rows object when no read changes anything', () => {
-    const entry = settled(funded)
-    const live = new Map([[USDT_CHECKSUM, { rawBalance: 5n, blockNumber: 101 }]])
-    expect(resolveInventory(entry, true, undefined, live).rows).toBe(entry.rows)
-  })
-
-  it('never overlays the native row, which the live native read already owns', () => {
-    const live = new Map([[ETHER_ADDRESS, { rawBalance: 1n, blockNumber: 101 }]])
-    expect(resolveInventory(settled(funded), true, '10', live).rows[ETHER_ADDRESS].rawBalance).toBe(10n)
-  })
-})
-
-describe('publishLiveBalances', () => {
-  it('stores a read once and keeps its block while the value holds', () => {
-    publishLiveBalances(ChainId.MAINNET, ACCOUNT, 100, [{ address: USDT_CHECKSUM, rawBalance: 5n }])
-    const first = readLiveBalances(KEY)
-    expect(first?.get(USDT_CHECKSUM)).toEqual({ rawBalance: 5n, blockNumber: 100 })
-    const before = getStoreVersion()
-    publishLiveBalances(ChainId.MAINNET, ACCOUNT, 101, [{ address: USDT_CHECKSUM, rawBalance: 5n }])
-    expect(readLiveBalances(KEY)).toBe(first)
-    expect(getStoreVersion()).toBe(before)
-    publishLiveBalances(ChainId.MAINNET, ACCOUNT, 102, [{ address: USDT_CHECKSUM, rawBalance: 6n }])
-    expect(readLiveBalances(KEY)?.get(USDT_CHECKSUM)).toEqual({ rawBalance: 6n, blockNumber: 102 })
-    expect(getStoreVersion()).toBe(before + 1)
-  })
-
-  it('drops retired reads so a sold-off token is not restated from a stale read', () => {
-    // The swap form read 5 USDT, then the user moved on to another token and sold the USDT off.
-    publishLiveBalances(ChainId.MAINNET, ACCOUNT, 100, [{ address: USDT_CHECKSUM, rawBalance: 5n }])
-    retireLiveBalances(ChainId.MAINNET, ACCOUNT, [USDT_CHECKSUM])
-    expect(readLiveBalances(KEY)).toBeUndefined()
-
-    const soldOff: InventoryEntry = {
-      rows: { [ETHER_ADDRESS]: row(ETHER_ADDRESS, 10n, 120) },
-      status: 'settled',
-      blockNumber: 120,
-      fetchedAt: 1,
-    }
-    expect(resolveInventory(soldOff, true, '10', readLiveBalances(KEY)).rows[USDT_CHECKSUM]).toBeUndefined()
-  })
-
-  it('ignores chains off the served list', () => {
-    publishLiveBalances(ChainId.MATIC, ACCOUNT, 100, [{ address: USDT_CHECKSUM, rawBalance: 5n }])
-    expect(readLiveBalances(inventoryKey(ChainId.MATIC, ACCOUNT))).toBeUndefined()
+  it('passes a walk that answers straight through', async () => {
+    await expect(withDeadline(Promise.resolve('done'))).resolves.toBe('done')
   })
 })
 

--- a/packages/hooks/src/use-wallet-inventory.ts
+++ b/packages/hooks/src/use-wallet-inventory.ts
@@ -4,6 +4,7 @@ import { getBalance } from '@kyber/rpc-client';
 import { API_URLS, NATIVE_TOKEN_ADDRESS } from '@kyber/schema';
 
 import {
+  INDEXER_CATCHUP_WINDOW_MS,
   UnsupportedChainError,
   isChainUnsupported,
   isWalletInventoryChain,
@@ -19,6 +20,7 @@ export {
   markChainUnsupported,
   parseRawAmount,
   walkWalletInventory,
+  INDEXER_CATCHUP_WINDOW_MS,
 } from './wallet-inventory-client';
 export type { InventoryRawRow } from './wallet-inventory-client';
 
@@ -30,6 +32,8 @@ export type WalletInventoryHolding = {
   /** Lowercased; the native currency uses the lowercased sentinel. */
   address: string;
   rawBalance: bigint;
+  /** Block at which this balance last changed, or the head block for a value read live. */
+  blockNumber: number;
   decimals?: number;
   symbol?: string;
 };
@@ -62,12 +66,6 @@ const RETRY_BACKOFF_MS = [POLL_INTERVAL_MS, 30_000, 60_000, 120_000];
 const RETRY_JITTER = 0.4;
 /** Data older than this is dropped once a refresh fails, so an outage cannot freeze a screen for good. */
 const STALE_MAX_MS = 120_000;
-/**
- * How long after a transaction the service is asked to read that transaction's tokens from the node.
- * Comfortably past the indexing lag, after which the indexed rows are current on their own.
- */
-const LIVE_READ_WINDOW_MS = 150_000;
-
 /** Inventories kept for wallets no one is looking at, so a reopened selector paints at once. */
 const KEEP_IDLE_ENTRIES = 8;
 const NATIVE_KEY = NATIVE_TOKEN_ADDRESS.toLowerCase();
@@ -89,13 +87,15 @@ type Entry = {
   /** A walk past the page cap is a property of the wallet, so it is never walked again. */
   terminal: boolean;
   /**
-   * Tokens a just-confirmed transaction moved. The next walk asks the service to read these from the
-   * node as it answers, so their balances are right straight away rather than after the indexer has
-   * caught up. Cleared once that walk has used them.
+   * Every row merged across walks, keyed by lowercased address, zero rows included: a live read
+   * that found a token emptied holds its place against the index's lagging amount until the index
+   * catches up. `balances`/`holdings` are the readers' view of this, without the zeros.
    */
-  live: string[];
-  /** Until when those live reads are worth asking for — the indexer's lag, generously covered. */
-  liveUntil: number;
+  rows: Map<string, WalletInventoryHolding>;
+  /** How far the index has come, live reads excluded. */
+  indexedBlock: number;
+  /** The catch-up watch opened by a transaction; see `expireWalletInventory`. */
+  live?: LiveWatch;
   /** An expiry arrived while a walk was in flight; the next walk follows at once, not after the poll. */
   dirty: boolean;
   listeners: Set<() => void>;
@@ -104,10 +104,30 @@ type Entry = {
 };
 
 /**
+ * Tokens a just-confirmed transaction moved, read live from the node on every poll until the index
+ * has reached the transaction's block or the window has run out (a Safe receipt carries no block).
+ */
+type LiveWatch = { addresses: Set<string>; until: number; block?: number };
+
+/**
  * One poller per (chain, account), whatever number of selectors are open for it: every hook instance
  * subscribes to the same entry, so N modals cost one walk and one timer.
  */
 const entries = new Map<string, Entry>();
+
+/** Watches for wallets no selector has opened yet; picked up by the entry when one does. */
+const pendingWatches = new Map<string, LiveWatch>();
+
+const watchStillOn = (watch: LiveWatch | undefined, indexedBlock: number, now: number): watch is LiveWatch =>
+  !!watch && now <= watch.until && (watch.block === undefined || indexedBlock < watch.block);
+
+/** A node read the environment never settles must not hold the poller; the walk has the same guard. */
+const withTimeout = <T>(work: Promise<T>, ms: number): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timed out')), ms);
+    work.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+const NATIVE_READ_TIMEOUT_MS = 8_000;
 
 const keyOf = (chainId: number, account: string) => `${chainId}:${account.toLowerCase()}`;
 
@@ -184,19 +204,16 @@ const run = async (entry: Entry) => {
   const controller = new AbortController();
   entry.controller = controller;
   try {
-    // Asked for on every poll until the window closes: a single live answer would be overwritten by
+    // Asked for on every poll while the watch is on: a single live answer would be overwritten by
     // the next walk's still-lagging indexed rows.
-    if (entry.liveUntil && Date.now() > entry.liveUntil) {
-      entry.live = [];
-      entry.liveUntil = 0;
-    }
-    const live = entry.live;
-    const { rows, complete } = await walkWalletInventory({
+    const watch = watchStillOn(entry.live, entry.indexedBlock, Date.now()) ? entry.live : undefined;
+    if (!watch) entry.live = undefined;
+    const { rows, complete, indexedBlock } = await walkWalletInventory({
       baseUrl: API_URLS.KD_API,
       chainId: entry.chainId,
       account: entry.account,
       signal: controller.signal,
-      liveAddrs: live,
+      liveAddrs: watch ? Array.from(watch.addresses) : undefined,
     });
     if (controller.signal.aborted) return;
     if (!complete) {
@@ -205,28 +222,62 @@ const run = async (entry: Entry) => {
       return;
     }
 
+    // Per-address block monotonicity across walks: a live row stamped at the head keeps its place
+    // over the index's lagging row, and a walk only retires rows its index is authoritative about —
+    // anything stamped past `indexedBlock` that it did not list is carried forward.
+    const merged = new Map<string, WalletInventoryHolding>();
+    rows.forEach(row => {
+      const address = row.tokenAddress.toLowerCase();
+      const existing = entry.rows.get(address);
+      if (existing && existing.blockNumber > row.blockNumber) {
+        merged.set(address, existing);
+        return;
+      }
+      merged.set(address, {
+        address,
+        rawBalance: parseRawAmount(row.rawAmount),
+        blockNumber: row.blockNumber,
+        decimals: row.decimals ?? existing?.decimals,
+        symbol: row.symbol || existing?.symbol,
+      });
+    });
+    entry.rows.forEach((row, address) => {
+      if (!merged.has(address) && row.blockNumber > indexedBlock) merged.set(address, row);
+    });
+    entry.rows = merged;
+    entry.indexedBlock = Math.max(entry.indexedBlock, indexedBlock);
+
     const balances: WalletInventoryBalances = {};
     const holdings: WalletInventoryHolding[] = [];
-    rows.forEach(row => {
-      const amount = parseRawAmount(row.rawAmount);
-      if (amount <= 0n) return;
-      const address = row.tokenAddress.toLowerCase();
-      balances[address] = amount;
-      holdings.push({ address, rawBalance: amount, decimals: row.decimals, symbol: row.symbol || undefined });
+    merged.forEach(row => {
+      if (row.rawBalance <= 0n) return;
+      balances[row.address] = row.rawBalance;
+      holdings.push(row);
     });
     // Sorted so two walks over an unchanged wallet compare equal whatever order the service listed them in.
     holdings.sort((a, b) => (a.address < b.address ? -1 : a.address > b.address ? 1 : 0));
 
     // The service returns no rows both for an empty wallet and for one it has never indexed. A wallet
     // that holds native currency but has no native row is the latter, and its "zeros" are not to be
-    // believed; it is retried on the backoff schedule in case the indexer catches up.
-    if (!balances[NATIVE_KEY]) {
-      const native = await getBalance(entry.chainId, entry.account).catch(() => 0n);
+    // believed; it is retried on the backoff schedule in case the indexer catches up. The native
+    // currency is not read live through the service — its row is this trust check, which must stay
+    // independent of the node — so while a watch is on the same chain read stands in for it on screen.
+    if (!balances[NATIVE_KEY] || watch) {
+      const native = await withTimeout(getBalance(entry.chainId, entry.account), NATIVE_READ_TIMEOUT_MS).catch(
+        () => undefined,
+      );
       if (controller.signal.aborted) return;
-      if (native > 0n) {
+      if (!balances[NATIVE_KEY] && native !== undefined && native > 0n) {
         entry.failures += 1;
         commit(entry, null, 'unavailable');
         return;
+      }
+      if (watch && native !== undefined && native > 0n) {
+        balances[NATIVE_KEY] = native;
+        const index = holdings.findIndex(h => h.address === NATIVE_KEY);
+        const live = { address: NATIVE_KEY, rawBalance: native, blockNumber: indexedBlock };
+        if (index >= 0) holdings[index] = { ...holdings[index], rawBalance: native };
+        else holdings.push(live);
       }
     }
 
@@ -290,10 +341,12 @@ const subscribe = (chainId: number, account: string, listener: () => void) => {
     failures: 0,
     terminal: false,
     dirty: false,
-    live: [],
-    liveUntil: 0,
+    rows: new Map(),
+    indexedBlock: 0,
+    live: pendingWatches.get(key),
     listeners: new Set(),
   };
+  pendingWatches.delete(key);
   // Registered before pruning: an entry with a listener is never an eviction candidate, and a brand
   // new one (fetchedAt 0) would otherwise sort as the oldest idle entry and evict itself.
   entry.listeners.add(listener);
@@ -320,19 +373,37 @@ const subscribe = (chainId: number, account: string, listener: () => void) => {
 /**
  * Marks a wallet's inventory stale, e.g. after a transaction of its own confirms: a watched inventory
  * refetches at once, an unwatched one on its next subscriber. Stale data stays on screen meanwhile.
+ *
+ * `touched` names the tokens the transaction moved; they are read live from the node on every poll
+ * until the index has reached `block` — or, when the receipt carried none, until the catch-up window
+ * has run out. A wallet no selector has opened yet keeps the watch for when one does.
  */
-export const expireWalletInventory = (chainId: number, account: string, touched: readonly string[] = []) => {
-  const entry = entries.get(keyOf(chainId, account));
-  if (!entry || entry.terminal) return;
+export const expireWalletInventory = (
+  chainId: number,
+  account: string,
+  touched: readonly string[] = [],
+  block?: number,
+) => {
+  const key = keyOf(chainId, account);
+  const now = Date.now();
+  const entry = entries.get(key);
+  if (entry?.terminal) return;
+  if (touched.length) {
+    const previous = entry ? entry.live : pendingWatches.get(key);
+    const carried = watchStillOn(previous, entry?.indexedBlock ?? 0, now) ? previous : undefined;
+    const addresses = new Set(carried?.addresses);
+    touched.forEach(address => addresses.add(address.toLowerCase()));
+    const watch: LiveWatch = {
+      addresses,
+      until: now + INDEXER_CATCHUP_WINDOW_MS,
+      block: block !== undefined ? Math.max(block, carried?.block ?? 0) : carried?.block,
+    };
+    if (entry) entry.live = watch;
+    else pendingWatches.set(key, watch);
+  }
+  if (!entry) return;
   entry.fetchedAt = 0;
   entry.failures = 0;
-  if (touched.length) {
-    touched.forEach(address => {
-      const lower = address.toLowerCase();
-      if (!entry.live.includes(lower)) entry.live.push(lower);
-    });
-    entry.liveUntil = Date.now() + LIVE_READ_WINDOW_MS;
-  }
   // A walk already in flight started before the transaction confirmed and cannot see its effect;
   // flag it so its completion is followed by another walk immediately rather than after the poll.
   entry.dirty = true;

--- a/packages/hooks/src/use-wallet-inventory.ts
+++ b/packages/hooks/src/use-wallet-inventory.ts
@@ -62,6 +62,12 @@ const RETRY_BACKOFF_MS = [POLL_INTERVAL_MS, 30_000, 60_000, 120_000];
 const RETRY_JITTER = 0.4;
 /** Data older than this is dropped once a refresh fails, so an outage cannot freeze a screen for good. */
 const STALE_MAX_MS = 120_000;
+/**
+ * How long after a transaction the service is asked to read that transaction's tokens from the node.
+ * Comfortably past the indexing lag, after which the indexed rows are current on their own.
+ */
+const LIVE_READ_WINDOW_MS = 150_000;
+
 /** Inventories kept for wallets no one is looking at, so a reopened selector paints at once. */
 const KEEP_IDLE_ENTRIES = 8;
 const NATIVE_KEY = NATIVE_TOKEN_ADDRESS.toLowerCase();
@@ -82,6 +88,14 @@ type Entry = {
   failures: number;
   /** A walk past the page cap is a property of the wallet, so it is never walked again. */
   terminal: boolean;
+  /**
+   * Tokens a just-confirmed transaction moved. The next walk asks the service to read these from the
+   * node as it answers, so their balances are right straight away rather than after the indexer has
+   * caught up. Cleared once that walk has used them.
+   */
+  live: string[];
+  /** Until when those live reads are worth asking for — the indexer's lag, generously covered. */
+  liveUntil: number;
   /** An expiry arrived while a walk was in flight; the next walk follows at once, not after the poll. */
   dirty: boolean;
   listeners: Set<() => void>;
@@ -170,11 +184,19 @@ const run = async (entry: Entry) => {
   const controller = new AbortController();
   entry.controller = controller;
   try {
+    // Asked for on every poll until the window closes: a single live answer would be overwritten by
+    // the next walk's still-lagging indexed rows.
+    if (entry.liveUntil && Date.now() > entry.liveUntil) {
+      entry.live = [];
+      entry.liveUntil = 0;
+    }
+    const live = entry.live;
     const { rows, complete } = await walkWalletInventory({
       baseUrl: API_URLS.KD_API,
       chainId: entry.chainId,
       account: entry.account,
       signal: controller.signal,
+      liveAddrs: live,
     });
     if (controller.signal.aborted) return;
     if (!complete) {
@@ -268,6 +290,8 @@ const subscribe = (chainId: number, account: string, listener: () => void) => {
     failures: 0,
     terminal: false,
     dirty: false,
+    live: [],
+    liveUntil: 0,
     listeners: new Set(),
   };
   // Registered before pruning: an entry with a listener is never an eviction candidate, and a brand
@@ -297,11 +321,18 @@ const subscribe = (chainId: number, account: string, listener: () => void) => {
  * Marks a wallet's inventory stale, e.g. after a transaction of its own confirms: a watched inventory
  * refetches at once, an unwatched one on its next subscriber. Stale data stays on screen meanwhile.
  */
-export const expireWalletInventory = (chainId: number, account: string) => {
+export const expireWalletInventory = (chainId: number, account: string, touched: readonly string[] = []) => {
   const entry = entries.get(keyOf(chainId, account));
   if (!entry || entry.terminal) return;
   entry.fetchedAt = 0;
   entry.failures = 0;
+  if (touched.length) {
+    touched.forEach(address => {
+      const lower = address.toLowerCase();
+      if (!entry.live.includes(lower)) entry.live.push(lower);
+    });
+    entry.liveUntil = Date.now() + LIVE_READ_WINDOW_MS;
+  }
   // A walk already in flight started before the transaction confirmed and cannot see its effect;
   // flag it so its completion is followed by another walk immediately rather than after the poll.
   entry.dirty = true;

--- a/packages/hooks/src/wallet-inventory-client.ts
+++ b/packages/hooks/src/wallet-inventory-client.ts
@@ -55,6 +55,13 @@ const MAX_PAGES = 10;
 /** Per request, so a wallet that needs several pages is not aborted for the sum of them. */
 const REQUEST_TIMEOUT_MS = 8_000;
 
+/**
+ * How long after a transaction the service is still behind it, generously covered (observed lag is
+ * 15–70s). Callers keep asking for live reads of the transaction's tokens until the index has caught
+ * up or this much time has passed. One number shared by the app and the widget stores.
+ */
+export const INDEXER_CATCHUP_WINDOW_MS = 150_000;
+
 type PageResponse = {
   code?: number;
   message?: string;
@@ -67,11 +74,21 @@ const fetchPage = async (
   lifetime?: AbortSignal,
 ): Promise<{ balances: InventoryRawRow[]; live: InventoryRawRow[] }> => {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  // The abort is the polite cancel; the rejection is the guarantee. A mobile in-app browser or a tab
+  // the system froze can leave an aborted fetch pending for good, and a caller that never hears back
+  // would hold its in-flight state — and every wallet behind it — forever.
+  let expire: (() => void) | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    expire = () => {
+      controller.abort();
+      reject(new Error('wallet inventory request timed out'));
+    };
+  });
+  const timer = setTimeout(() => expire?.(), REQUEST_TIMEOUT_MS);
   const onAbort = () => controller.abort();
   lifetime?.addEventListener('abort', onAbort);
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    const response = await Promise.race([fetch(url, { signal: controller.signal }), deadline]);
     if (response.status === 400) {
       // Only the service's own "unsupported chain" answer disables the chain; any other 400 (a
       // rejected cursor, an edge rule) is a transient failure for this request alone.
@@ -83,7 +100,7 @@ const fetchPage = async (
       throw new Error(`wallet inventory rejected the request: ${body?.message ?? response.status}`);
     }
     if (!response.ok) throw new Error(`wallet inventory responded ${response.status}`);
-    const json = (await response.json()) as PageResponse;
+    const json = (await Promise.race([response.json(), deadline])) as PageResponse;
     if (json.code !== 0) throw new Error(json.message || 'wallet inventory returned an error code');
     return { balances: json.data?.balances ?? [], live: json.data?.liveBalances ?? [] };
   } finally {
@@ -100,6 +117,15 @@ const fetchPage = async (
  * a token that arrives during the walk is still picked up, and a token already collected that changes
  * again reappears with a fresher value. Rows are de-duplicated by address keeping the highest block.
  * Zero rows (tombstones) are kept; callers decide what a zero means to them.
+ *
+ * `liveAddrs` names tokens the service reads from the node as it answers, rather than from its
+ * index. Their rows come back stamped at the head block, so they outrank the indexed rows for the
+ * same tokens — which is how a balance that just changed is right on screen before the indexer has
+ * caught up. They are asked for once per walk: the reads are a point in time, not per page.
+ *
+ * `indexedBlock` in the result is how far the *index* has come, live reads excluded — a caller
+ * waiting for the indexer to catch up with a transaction must not be fooled by a live row stamped
+ * at the head.
  */
 export const walkWalletInventory = async ({
   baseUrl,
@@ -112,31 +138,28 @@ export const walkWalletInventory = async ({
   chainId: number;
   account: string;
   signal?: AbortSignal;
-  /**
-   * Tokens to have the service read from the node as it answers, rather than from its index. Their
-   * rows come back stamped at the head block, so they outrank the indexed rows for the same tokens —
-   * which is how a balance that just changed is right on screen before the indexer has caught up.
-   * Asked for once per walk: the reads are a point in time, not per page.
-   */
   liveAddrs?: readonly string[];
-  /**
-   * `indexedBlock` is how far the *index* has come, live reads excluded — a caller waiting for the
-   * indexer to catch up with a transaction must not be fooled by a live row stamped at the head.
-   */
 }): Promise<{ rows: InventoryRawRow[]; complete: boolean; indexedBlock: number }> => {
   const byAddress = new Map<string, InventoryRawRow>();
+  const merge = (row: InventoryRawRow) => {
+    const key = row.tokenAddress.toLowerCase();
+    const existing = byAddress.get(key);
+    if (!existing || row.blockNumber >= existing.blockNumber) byAddress.set(key, row);
+  };
   let cursor: { block: number; address: string } | undefined;
   let complete = false;
   let indexedBlock = 0;
 
   for (let page = 0; page < MAX_PAGES; page++) {
     const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
-    // The service reads one node value per address given here, so only the first page asks.
-    if (page === 0) liveAddrs?.forEach(addressToRead => params.append('liveAddrs', addressToRead));
     if (cursor) {
       params.set('sinceBlockNumber', String(cursor.block));
       // Echoed exactly as received: the server compares this cursor as a string.
       params.set('lastTokenAddr', cursor.address);
+    } else {
+      // The service reads one node value per address given, so only the first page asks. Repeated
+      // params: the service ignores a comma-separated list.
+      new Set(liveAddrs?.map(a => a.toLowerCase())).forEach(a => params.append('liveAddrs', a));
     }
     const batch = await fetchPage(
       `${baseUrl}/v1/wallets/${chainId}/${account}/balances?${params.toString()}`,
@@ -144,16 +167,13 @@ export const walkWalletInventory = async ({
       signal,
     );
 
-    // Live reads share the block-monotonic merge: stamped at the head, they win over the indexed row
-    // for the same token, including when they report it emptied.
     batch.balances.forEach(row => {
       indexedBlock = Math.max(indexedBlock, row.blockNumber);
+      merge(row);
     });
-    [...batch.balances, ...batch.live].forEach(row => {
-      const key = row.tokenAddress.toLowerCase();
-      const existing = byAddress.get(key);
-      if (!existing || row.blockNumber >= existing.blockNumber) byAddress.set(key, row);
-    });
+    // Live reads share the block-monotonic merge: stamped at the head, they win over the indexed row
+    // for the same token, including when they report it emptied.
+    batch.live.forEach(merge);
 
     // A short page is the only end-of-data signal the service gives; live rows are extra to it.
     if (batch.balances.length < PAGE_SIZE) {

--- a/packages/hooks/src/wallet-inventory-client.ts
+++ b/packages/hooks/src/wallet-inventory-client.ts
@@ -55,9 +55,17 @@ const MAX_PAGES = 10;
 /** Per request, so a wallet that needs several pages is not aborted for the sum of them. */
 const REQUEST_TIMEOUT_MS = 8_000;
 
-type PageResponse = { code?: number; message?: string; data?: { balances?: InventoryRawRow[] | null } | null };
+type PageResponse = {
+  code?: number;
+  message?: string;
+  data?: { balances?: InventoryRawRow[] | null; liveBalances?: InventoryRawRow[] | null } | null;
+};
 
-const fetchPage = async (url: string, chainId: number, lifetime?: AbortSignal): Promise<InventoryRawRow[]> => {
+const fetchPage = async (
+  url: string,
+  chainId: number,
+  lifetime?: AbortSignal,
+): Promise<{ balances: InventoryRawRow[]; live: InventoryRawRow[] }> => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   const onAbort = () => controller.abort();
@@ -77,7 +85,7 @@ const fetchPage = async (url: string, chainId: number, lifetime?: AbortSignal): 
     if (!response.ok) throw new Error(`wallet inventory responded ${response.status}`);
     const json = (await response.json()) as PageResponse;
     if (json.code !== 0) throw new Error(json.message || 'wallet inventory returned an error code');
-    return json.data?.balances ?? [];
+    return { balances: json.data?.balances ?? [], live: json.data?.liveBalances ?? [] };
   } finally {
     clearTimeout(timer);
     lifetime?.removeEventListener('abort', onAbort);
@@ -98,18 +106,33 @@ export const walkWalletInventory = async ({
   chainId,
   account,
   signal,
+  liveAddrs,
 }: {
   baseUrl: string;
   chainId: number;
   account: string;
   signal?: AbortSignal;
-}): Promise<{ rows: InventoryRawRow[]; complete: boolean }> => {
+  /**
+   * Tokens to have the service read from the node as it answers, rather than from its index. Their
+   * rows come back stamped at the head block, so they outrank the indexed rows for the same tokens —
+   * which is how a balance that just changed is right on screen before the indexer has caught up.
+   * Asked for once per walk: the reads are a point in time, not per page.
+   */
+  liveAddrs?: readonly string[];
+  /**
+   * `indexedBlock` is how far the *index* has come, live reads excluded — a caller waiting for the
+   * indexer to catch up with a transaction must not be fooled by a live row stamped at the head.
+   */
+}): Promise<{ rows: InventoryRawRow[]; complete: boolean; indexedBlock: number }> => {
   const byAddress = new Map<string, InventoryRawRow>();
   let cursor: { block: number; address: string } | undefined;
   let complete = false;
+  let indexedBlock = 0;
 
   for (let page = 0; page < MAX_PAGES; page++) {
     const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+    // The service reads one node value per address given here, so only the first page asks.
+    if (page === 0) liveAddrs?.forEach(addressToRead => params.append('liveAddrs', addressToRead));
     if (cursor) {
       params.set('sinceBlockNumber', String(cursor.block));
       // Echoed exactly as received: the server compares this cursor as a string.
@@ -121,20 +144,25 @@ export const walkWalletInventory = async ({
       signal,
     );
 
-    batch.forEach(row => {
+    // Live reads share the block-monotonic merge: stamped at the head, they win over the indexed row
+    // for the same token, including when they report it emptied.
+    batch.balances.forEach(row => {
+      indexedBlock = Math.max(indexedBlock, row.blockNumber);
+    });
+    [...batch.balances, ...batch.live].forEach(row => {
       const key = row.tokenAddress.toLowerCase();
       const existing = byAddress.get(key);
       if (!existing || row.blockNumber >= existing.blockNumber) byAddress.set(key, row);
     });
 
-    // A short page is the only end-of-data signal the service gives.
-    if (batch.length < PAGE_SIZE) {
+    // A short page is the only end-of-data signal the service gives; live rows are extra to it.
+    if (batch.balances.length < PAGE_SIZE) {
       complete = true;
       break;
     }
-    const last = batch[batch.length - 1];
+    const last = batch.balances[batch.balances.length - 1];
     cursor = { block: last.blockNumber, address: last.tokenAddress };
   }
 
-  return { rows: Array.from(byAddress.values()), complete };
+  return { rows: Array.from(byAddress.values()), complete, indexedBlock };
 };


### PR DESCRIPTION
## What changes

The wallet-inventory service can read named tokens from the node while answering a walk (`liveAddrs`), instead of serving them from its index. Those rows come back stamped at the head block, so the balances a transaction just changed are correct straight away — everywhere the wallet is shown, whatever page the user is on.

This replaces the frontend overlay that read the same tokens over RPC every block.

**Removed:** the live-read cache in the inventory store (`publishLiveBalances` / `retireLiveBalances`), the per-block multicall in `useWalletInventory`, the reads `useCurrencyBalances` published, and the overlay merge in `resolveInventory`.

That machinery caused both wallet-balance bugs of the past week: a read left behind after its form moved on (which then restated the balance of a token that had been sold off), and no reader at all once the user navigated away from the form.

## Verified against production kd-api

- The parameter repeats: `liveAddrs=A&liveAddrs=B`. A comma-separated list is silently ignored.
- Values match a direct `balanceOf`: `936142054804356` at head block 25895519, against an indexed row 4,984 USDT stale at block 25895512.
- A real token held at zero returns an explicit `"0x"` row; the native sentinel is accepted too (both casings).
- No latency cost: 0.28–0.43s with two live reads, against 0.29–0.37s without.

## How a live read holds its ground (worth reviewing)

A walk only retires rows its index is authoritative about. Zero rows a live read established are kept in the store as tombstones, and any row stamped past what a walk's index knows (`indexedBlock`, live reads excluded) is carried forward. So the index catching up later cannot restate a balance the node has already contradicted, nor drop a token first seen live. Readers never see the zeros (`resolveInventory` filters them, identity-preserving). The block stamp does not count as a change, so a live row re-stamped at every catch-up poll wakes nobody, and a live row inherits the catalog description of the row it replaces.

The catch-up watch keys on `indexedBlock`, not the merged maximum — a live row stamped at the head would otherwise retire the watch on the very walk that asked for it. It is a window that a known receipt block may close early, so a Safe receipt without a block still has its tokens read live for the window.

## Never waiting forever

Each page request in the shared client races its fetch against an 8s deadline in addition to aborting it, so an abort the environment ignores (a mobile in-app browser, a frozen tab) still settles the walk — for the app *and* the widget poller. This is the leading explanation for the report of a wallet stuck on "Loading tokens..." while the swap form's balances were fine: one hung request left the sweep's in-flight flag raised and every wallet unfetched. The widget's node read for its trust check gets the same guard.

The popup lists whatever the index has as soon as it has anything; only an inventory that lists nothing waits on the native read (which is what tells an empty wallet from an unindexed one).

## Widget registry (`@kyber/hooks`)

Same per-address block-monotonic merge across walks with carry-forward; a live watch keyed on the receipt block (passed from the app) with the window as fallback; a watch kept for a wallet no selector has opened yet; the native balance read from the chain while a watch is on (the service is not asked for native — its native row is the trust check).

## Testing

- 79 unit tests in `walletInventory.test.ts`, including: live rows outrank indexed rows and clear a sold-off token; the live read is asked for once per walk; `indexedBlock` excludes live rows; a live zero and a token first seen live are carried forward until the index catches up; a re-stamped live row wakes nobody; the Safe path reads live for the window; the token list resets per watch; a request the environment never settles is rejected by the client deadline.
- App suite 202/202, root lint 15/15, type-check 16/16, selector smoke-tested in the browser.