### PR TITLE
fix(wallet): stop unchosen wallets from claiming the session on refresh

### DIFF
--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -463,11 +463,6 @@ export const hasPersistedConnection = (): boolean => {
   }
 }
 
-// Captured before `createConfig()` runs. wagmi rehydrates its persisted store asynchronously and writes
-// the empty pre-hydration state back to `wagmi.store` while it does, so a read taken any later in the same
-// tick reports no session for a visitor who has one.
-const hadPersistedConnectionAtBoot = hasPersistedConnection()
-
 export const wagmiConfig = createConfig({
   chains: wagmiChains,
   transports,
@@ -516,34 +511,33 @@ export const wagmiConfig = createConfig({
 // wagmi turns a connector's own `connect` event straight into "this is the current connection", with no
 // authorization check and no regard for which wallet was last used — the hook that lets a wallet attach
 // itself when someone connects the site from inside the extension. Extensions fire that event while
-// announcing themselves on page load too, so with more than one installed, whichever fires first claims
-// the session: a visitor connected on one wallet comes back as another.
+// announcing themselves on page load too, and any wallet that still holds a permission for the site
+// answers `eth_accounts` with an account, so with more than one installed, whichever fires first claims
+// the session: a visitor who disconnected comes back connected to a wallet they never picked, and one
+// connected on another wallet comes back as this one.
 //
-// While there is a session on record, leave the hook attached to that wallet alone. A visitor with no
-// session keeps every connector's hook and can still attach one from inside their extension, and picking
-// a wallet from the modal goes through `connect()`, which never consults it.
+// Nothing here needs that hook. A wallet is only ever picked from the modal, which goes through
+// `connect()`, or restored from the session on record, which goes through `reconnect()` — neither
+// consults it — so keep it off every connector. wagmi puts it back on a connector it sets up and on one it
+// disconnects, so re-apply on both.
 //
 // Runs at module scope rather than from an effect because connectors are set up inside `createConfig()`,
 // so a wallet can claim the session before React has mounted.
-const restrictSelfConnectToRecordedWallet = () => {
-  if (!hadPersistedConnectionAtBoot) return
-
-  const recentConnectorId = readRecentConnectorId()
-  if (!recentConnectorId) return
-
-  const detachOthers = () => {
+const keepWalletsFromClaimingTheSession = () => {
+  const detach = () => {
     for (const connector of wagmiConfig.connectors) {
-      if (connector.id === recentConnectorId) continue
       connector.emitter.off('connect', wagmiConfig._internal.events.connect)
     }
   }
 
-  detachOthers()
-  // EIP-6963 wallets register after this runs, so re-apply as they arrive.
-  wagmiConfig._internal.connectors.subscribe(detachOthers)
+  detach()
+  // EIP-6963 wallets and Porto register after this runs, each arriving with the hook attached.
+  wagmiConfig._internal.connectors.subscribe(detach)
+  // `disconnect()` re-attaches it to the wallet it just disconnected.
+  wagmiConfig.subscribe(state => state.connections, detach)
 }
 
-restrictSelfConnectToRecordedWallet()
+keepWalletsFromClaimingTheSession()
 
 // Porto ships ~620KB of JS (the SDK plus its `ox` dependency) and is one wallet choice among many, so
 // importing it at module scope put all of it in the entry chunk that gates the app's first render for every

--- a/apps/kyberswap-interface/src/hooks/index.ts
+++ b/apps/kyberswap-interface/src/hooks/index.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@kyberswap/ks-sdk-core'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { useSearchParams } from 'react-router-dom'
 import { useAccount as useAccountWagmi } from 'wagmi'
@@ -10,10 +10,7 @@ import { isSupportedChainId } from 'constants/networks'
 import { NetworkInfo } from 'constants/networks/type'
 import { useAccount } from 'hooks/useAccount'
 import { NETWORKS_INFO } from 'hooks/useChainsConfig'
-import useDisconnectWallet from 'hooks/web3/useDisconnectWallet'
 import { AppState } from 'state'
-import { useIsAcceptedTerm } from 'state/user/hooks'
-import { isInSafeApp } from 'utils/safeApp'
 
 export function useActiveWeb3React(): {
   chainId: ChainId
@@ -49,15 +46,6 @@ export function useActiveWeb3React(): {
 
 export function useWeb3React() {
   const account = useAccount()
-  const [isAcceptedTerm] = useIsAcceptedTerm()
-
-  const disconnect = useDisconnectWallet()
-  useEffect(() => {
-    // disconnect if the user is not accepted terms, dont apply to safe app
-    if (account.connector && !isAcceptedTerm && !isInSafeApp) {
-      disconnect()
-    }
-  }, [isAcceptedTerm, account.connector, disconnect])
 
   return useMemo(
     () => ({

--- a/apps/kyberswap-interface/src/hooks/web3/useDisconnectOnStaleTerms.ts
+++ b/apps/kyberswap-interface/src/hooks/web3/useDisconnectOnStaleTerms.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+
+import { useAccount } from 'hooks/useAccount'
+import useDisconnectWallet from 'hooks/web3/useDisconnectWallet'
+import { useIsAcceptedTerm } from 'state/user/hooks'
+import { isInSafeApp } from 'utils/safeApp'
+
+/**
+ * Disconnects a wallet whose owner has not accepted the current Terms of Use — a session restored from
+ * before the current document took effect. Safe App users acknowledge the Terms through their own dialog
+ * instead (see `useIsSafeAppAcceptedTerm`).
+ *
+ * Mount it once, at the app root. Every mounted instance issues its own `disconnect()`, and each of those
+ * sends the wallet a `wallet_revokePermissions` request.
+ */
+export default function useDisconnectOnStaleTerms() {
+  const { connector } = useAccount()
+  const [isAcceptedTerm] = useIsAcceptedTerm()
+  const disconnect = useDisconnectWallet()
+
+  useEffect(() => {
+    if (connector && !isAcceptedTerm && !isInSafeApp) disconnect()
+  }, [connector, isAcceptedTerm, disconnect])
+}

--- a/apps/kyberswap-interface/src/hooks/web3/useDisconnectWallet.ts
+++ b/apps/kyberswap-interface/src/hooks/web3/useDisconnectWallet.ts
@@ -1,15 +1,21 @@
+import { getConnections } from '@wagmi/core'
 import { useCallback } from 'react'
-import { useDisconnect as useDisconnectWagmi } from 'wagmi'
+import { useConfig, useDisconnect as useDisconnectWagmi } from 'wagmi'
 
+// Returns a callback whose identity holds across renders: `config` is a singleton and `disconnect` is
+// react-query's memoized `mutate`. Reading the live connections at call time is what makes that possible —
+// wagmi's `useDisconnect().connectors` is a new array on every render, and an effect keyed on this
+// callback would otherwise fire on every render until the store flips, sending the wallet one
+// `wallet_revokePermissions` per render.
 function useDisconnectWallet() {
-  const { connectors, disconnect } = useDisconnectWagmi()
-  const disconnectAll = useCallback(() => {
-    connectors.forEach(connector => {
-      disconnect({ connector })
-    })
-  }, [connectors, disconnect])
+  const config = useConfig()
+  const { disconnect } = useDisconnectWagmi()
 
-  return disconnectAll
+  return useCallback(() => {
+    for (const { connector } of getConnections(config)) {
+      disconnect({ connector })
+    }
+  }, [config, disconnect])
 }
 
 export default useDisconnectWallet

--- a/apps/kyberswap-interface/src/pages/App.tsx
+++ b/apps/kyberswap-interface/src/pages/App.tsx
@@ -30,6 +30,7 @@ import { useActiveWeb3React } from 'hooks'
 import usePageLocation from 'hooks/usePageLocation'
 import useSessionExpiredGlobal from 'hooks/useSessionExpire'
 import { useGlobalTrackingEvents } from 'hooks/useTracking'
+import useDisconnectOnStaleTerms from 'hooks/web3/useDisconnectOnStaleTerms'
 import { useSyncNetworkParamWithStore } from 'hooks/web3/useSyncNetworkParamWithStore'
 import { getPoolDetailUrl } from 'pages/Earns/utils/url'
 import { PROFILE_MANAGE_ROUTES } from 'pages/NotificationCenter/const'
@@ -200,6 +201,7 @@ const RoutesWithNetworkPrefix = () => {
 
 export default function App() {
   const { chainId } = useActiveWeb3React()
+  useDisconnectOnStaleTerms()
   const { pathname } = useLocation()
   const { isEmbeddedSwap } = usePageLocation()
   const [safeAppAcceptedTermOfUse, acceptSafeAppTermOfUse] = useIsSafeAppAcceptedTerm()


### PR DESCRIPTION
## Summary

- A visitor who disconnected — or whose session was cleared by the Terms auto-disconnect — could come back connected to a different wallet on refresh (e.g. OKX) if that wallet still held an `eth_accounts` permission for the site. The previous fix (#3356) only detached wagmi's self-connect hook while a session was on record, leaving it attached exactly when there is none — the state right after a disconnect. Now it's detached unconditionally; the app only ever connects through `connect()` (the modal) or `reconnect()` (session restore).
- The stale-terms disconnect effect lived inside `useWeb3React`, a hook called from ~360 places across the app, so a session past the current Terms version fired hundreds of `wallet_revokePermissions` requests at the wallet for a single disconnect. Moved to a single `useDisconnectOnStaleTerms()` mounted once at the app root.

## Test plan

- [x] Repro'd both bugs against `main` with a Playwright script simulating fake Rabby + OKX EIP-6963 providers (OKX holding a stale `eth_accounts` permission) and verified both are fixed on this branch:
  - disconnected + refresh → stays disconnected (was: OKX claims the session)
  - Terms bump clears an active Rabby session + refresh → stays disconnected (was: OKX claims the session)
  - active Rabby session, current Terms → still restores Rabby (no regression)
  - stale-terms disconnect now sends exactly 1 `wallet_revokePermissions` (was: 1,000+)
- [x] `pnpm lint` / `tsc --noEmit` clean (one pre-existing unrelated error in `packages/hooks`)