### PR TITLE
feat(earn): enable zap create on Robinhood, resolve FairFlow hook per chain

### DIFF
--- a/apps/kyberswap-interface/src/components/ZapCreatePool/CreatePoolModal.tsx
+++ b/apps/kyberswap-interface/src/components/ZapCreatePool/CreatePoolModal.tsx
@@ -68,6 +68,7 @@ const PROTOCOL_ALLOWLIST: Partial<Record<ChainId, Exchange[]>> = {
   [ChainId.Base]: [Exchange.DEX_UNISWAP_V4_FAIRFLOW, Exchange.DEX_UNISWAP_V4],
   [ChainId.Ethereum]: [Exchange.DEX_UNISWAP_V4_FAIRFLOW, Exchange.DEX_UNISWAP_V4],
   [ChainId.Arbitrum]: [Exchange.DEX_UNISWAP_V4_FAIRFLOW, Exchange.DEX_UNISWAP_V4],
+  [ChainId.Robinhood]: [Exchange.DEX_UNISWAP_V4_FAIRFLOW, Exchange.DEX_UNISWAP_V4],
 }
 
 const availableChains: ChainId[] = Object.keys(PROTOCOL_ALLOWLIST).map(Number)

--- a/apps/kyberswap-interface/src/pages/Earns/utils/zap.ts
+++ b/apps/kyberswap-interface/src/pages/Earns/utils/zap.ts
@@ -19,12 +19,26 @@ export const sortTokensByAddress = (tokenA: Token, tokenB: Token): [Token, Token
   return addressA < addressB ? [tokenA, tokenB] : [tokenB, tokenA]
 }
 
-const getConfigHooksAddress = (poolType?: PoolType): string | undefined => {
+// FairFlow hook contracts differ per chain; the zap service rejects a create
+// request whose hook does not match its configured allowlist for that chain.
+// Keep in sync with packages/zap-create-widgets/src/constants/index.ts.
+const UNISWAP_V4_FAIRFLOW_HOOKS: Partial<Record<ChainId, string>> = {
+  [ChainId.Ethereum]: '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4',
+  [ChainId.Arbitrum]: '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4',
+  [ChainId.Base]: '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4',
+  [ChainId.Robinhood]: '0x4445520306c9c70952bdfec28f3989f53d9f80c4',
+}
+
+const PANCAKE_INFINITY_CL_FAIRFLOW_HOOKS: Partial<Record<ChainId, string>> = {
+  [ChainId.Bsc]: '0x44428C6ce391915D51F963C0Dd395Cd0f95fdFD2',
+}
+
+const getConfigHooksAddress = (chainId: ChainId, poolType?: PoolType): string | undefined => {
   if (poolType === PoolType.DEX_UNISWAP_V4_FAIRFLOW) {
-    return '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4'
+    return UNISWAP_V4_FAIRFLOW_HOOKS[chainId]
   }
   if (poolType === PoolType.DEX_PANCAKE_INFINITY_CL_FAIRFLOW) {
-    return '0x44428C6ce391915D51F963C0Dd395Cd0f95fdFD2'
+    return PANCAKE_INFINITY_CL_FAIRFLOW_HOOKS[chainId]
   }
   return undefined
 }
@@ -52,7 +66,7 @@ export const fetchExistingPoolAddress = async (input: {
         'zap_in.position.tick_upper': tickSpacing * 10,
         'zap_in.tokens_in': token0.address,
         'zap_in.amounts_in': 10 ** (token0.decimals - 1),
-        'pool.uniswap_v4_config.hooks': getConfigHooksAddress(poolType),
+        'pool.uniswap_v4_config.hooks': getConfigHooksAddress(input.chainId as ChainId, poolType),
       },
     })
     .then(() => undefined)

--- a/packages/zap-create-widgets/src/constants/index.ts
+++ b/packages/zap-create-widgets/src/constants/index.ts
@@ -1,7 +1,7 @@
 import type { MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/macro';
 
-import { PoolType } from '@kyber/schema';
+import { ChainId, PoolType } from '@kyber/schema';
 
 import { i18n } from '@/lingui';
 
@@ -49,12 +49,25 @@ export const getSlippageStorageKey = (
   return `kyber_zap_create_widget_slippage_${sortedSymbols[0]}_${sortedSymbols[1]}_${chainId}_${feeTier}`;
 };
 
-export const getConfigHooksAddress = (poolType?: PoolType): string | undefined => {
+// FairFlow hook contracts differ per chain; the zap service rejects a create
+// request whose hook does not match its configured allowlist for that chain.
+const UNISWAP_V4_FAIRFLOW_HOOKS: Partial<Record<ChainId, string>> = {
+  [ChainId.Ethereum]: '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4',
+  [ChainId.Arbitrum]: '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4',
+  [ChainId.Base]: '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4',
+  [ChainId.Robinhood]: '0x4445520306c9c70952bdfec28f3989f53d9f80c4',
+};
+
+const PANCAKE_INFINITY_CL_FAIRFLOW_HOOKS: Partial<Record<ChainId, string>> = {
+  [ChainId.Bsc]: '0x44428C6ce391915D51F963C0Dd395Cd0f95fdFD2',
+};
+
+export const getConfigHooksAddress = (chainId: ChainId, poolType?: PoolType): string | undefined => {
   if (poolType === PoolType.DEX_UNISWAP_V4_FAIRFLOW) {
-    return '0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4';
+    return UNISWAP_V4_FAIRFLOW_HOOKS[chainId];
   }
   if (poolType === PoolType.DEX_PANCAKE_INFINITY_CL_FAIRFLOW) {
-    return '0x44428C6ce391915D51F963C0Dd395Cd0f95fdFD2';
+    return PANCAKE_INFINITY_CL_FAIRFLOW_HOOKS[chainId];
   }
   return undefined;
 };

--- a/packages/zap-create-widgets/src/hooks/useZapState.tsx
+++ b/packages/zap-create-widgets/src/hooks/useZapState.tsx
@@ -236,7 +236,7 @@ export const ZapContextProvider = ({ children }: { children: ReactNode }) => {
       'pool.uniswap_v4_config.fee': feeAmount,
       'pool.uniswap_v4_config.sqrt_p': sqrtPriceX96,
       'pool.uniswap_v4_config.tick_spacing': tickSpacing,
-      'pool.uniswap_v4_config.hooks': getConfigHooksAddress(poolType),
+      'pool.uniswap_v4_config.hooks': getConfigHooksAddress(chainId, poolType),
       'zap_in.position.tick_upper': debounceTickUpper ?? 0,
       'zap_in.position.tick_lower': debounceTickLower ?? 0,
       'zap_in.tokens_in': validTokenInAddresses,


### PR DESCRIPTION
## Summary

Enables the Create Pool flow on Robinhood Chain for Uniswap V4 and Uniswap V4 FairFlow.

- `CreatePoolModal.tsx`: add `ChainId.Robinhood` to `PROTOCOL_ALLOWLIST` (the chain dropdown is derived from its keys).
- FairFlow hook contracts differ per chain. Robinhood's Uniswap V4 FairFlow hook is `0x4445520306c9c70952bdfec28f3989f53d9f80c4`; Ethereum/Arbitrum/Base use `0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4`; Pancake Infinity CL FairFlow on BSC uses `0x44428C6ce391915D51F963C0Dd395Cd0f95fdFD2`. `getConfigHooksAddress` previously returned one hardcoded address per protocol regardless of chain, so a Robinhood FairFlow create would send the wrong hook and the zap service would reject it with "fairflow create hook is not configured". It now takes `chainId` and resolves the hook from a per-chain map, in both `pages/Earns/utils/zap.ts` and `packages/zap-create-widgets/src/constants/index.ts`.

The two copies are kept separate on purpose: the widget package is lazy-loaded by the app and does not export the helper, so importing it into `utils/zap.ts` would pull the widget into the main bundle.

Hook values match the zap-service config and the addresses verified in KyberNetwork/zap-service#385 fork proofs.

## Backend dependency

Create on Robinhood also needs the zap-service ks-setting row for `zap-4663` to carry `UniversalRouter` `0x8876789976decbfcbbbe364623c63652db8c0904` on dexes 68 and 73 and `Hooks` `0x4445…80c4` on 73. Until that lands, the API returns "missing v3 address: native v3 create UniversalRouter" regardless of this change.

## Verification

- eslint on the four touched files: clean.
- prettier --check: clean.
- `pnpm type-check` in `zap-create-widgets`: two pre-existing errors in `hooks/src/use-wallet-inventory.ts` and `src/Widget.tsx` (identical with the change stashed), none in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnA1CQ5n3WC6YFGRDKsNBk
