### PR TITLE
fix(rpc): cap every fallback hop at 3s and walk the list once

### DIFF
--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -385,26 +385,39 @@ const wagmiChains: readonly [Chain, ...Chain[]] = [
   withKyberRpc(rise),
 ] as const
 
+// One endpoint's share of the wait. `fallback()` walks its URLs in order and moves on only once the
+// current one has failed or run out of time, so a hop that hangs costs every call this long before
+// the next endpoint is tried. A healthy endpoint answers in well under a second; three seconds is
+// generous for one and still keeps a walk over the whole list to tens of seconds.
+const HOP_TIMEOUT_MS = 3_000
+const PUBLIC_HTTP_CONFIG = { timeout: HOP_TIMEOUT_MS } as const
+
 // JSON-RPC batching for the primary (KyberSwap) endpoint. viem sends one `eth_call` per multicall
 // chunk, so a sweep like the token selector's whole-whitelist `balanceOf` spans many calls that would
 // otherwise queue against the browser's per-host connection budget; batching folds them into a single
 // POST. Only the primary opts in — the public fallbacks are third-party endpoints whose batch support
 // we can't vouch for, and `batch.multicall.batchSize` keeps their call count in check on its own.
-const PRIMARY_HTTP_CONFIG = { batch: { batchSize: 50 } } as const
+const PRIMARY_HTTP_CONFIG = { ...PUBLIC_HTTP_CONFIG, batch: { batchSize: 50 } } as const
 
 // viem `fallback()` rotates through URLs on transport errors (network, 429, 5xx),
 // giving us true client-side RPC rotation for every wagmi-issued call (multicall,
 // useReadContract, polling). KyberSwap RPC sits first; public endpoints are tried
 // only when it errors. Connector-internal calls still use URL[0] of `rpcUrls.default`
 // (set by `withKyberRpc` above), which is the same KyberSwap RPC.
+//
+// One pass over the list, never two: a call every endpoint has just refused is not going to be
+// answered by the same endpoints a moment later, and the second pass doubles both the wait and the
+// load on endpoints that are already rate-limiting the user.
 
 const transports = Object.fromEntries(
   wagmiChains.map(c => {
     const primaryUrl = NETWORKS_INFO[c.id as ChainId]?.defaultRpcUrl
     const urls = getRpcUrlsForChain(c.id)
     const httpTransports =
-      urls.length > 0 ? urls.map(url => (url === primaryUrl ? http(url, PRIMARY_HTTP_CONFIG) : http(url))) : [http()]
-    return [c.id, fallback(httpTransports, { retryCount: 1 })]
+      urls.length > 0
+        ? urls.map(url => (url === primaryUrl ? http(url, PRIMARY_HTTP_CONFIG) : http(url, PUBLIC_HTTP_CONFIG)))
+        : [http(undefined, PUBLIC_HTTP_CONFIG)]
+    return [c.id, fallback(httpTransports, { retryCount: 0 })]
   }),
 ) as Record<(typeof wagmiChains)[number]['id'], ReturnType<typeof fallback>>
 


### PR DESCRIPTION
## Why

Users on rate-limited or slow RPC saw balances load for tens of seconds. Rotation itself works — a `429` moves to the next endpoint in ~2 ms — but an endpoint that *hangs* is a different story: viem's `fallback()` walks its URLs in order and moves on only once the current one has failed or run out of time, and no timeout was set, so every hop had viem's default of **10 s**. The fallback's own `retryCount: 1` then walked the whole list a second time. Ethereum has 11 endpoints: up to 11 × 10 s × 2 ≈ **220 s** for one call whose endpoints hang. The KyberSwap endpoint is first for every call, so a slow primary taxed all of them.

## What changes

One place, `transports` in `Web3Provider`:

- `timeout: 3_000` on every `http()` transport (the primary keeps its JSON-RPC batching).
- `fallback(..., { retryCount: 0 })` — one pass over the list, never two.

Same 11 endpoints, same order. Worst case drops from ~220 s to ~33 s, and a slow primary now costs 3 s instead of 10 s per call.

## How 3 s was chosen

Probed every endpoint on Ethereum, Base, BSC and Arbitrum, 4 rounds each, with `eth_blockNumber` and a multicall-sized `eth_call` (Multicall3 `aggregate3` × 50, 22.5 KB calldata), round-robined with 0.7 s spacing so no endpoint was hit more than once per ~30 s. Healthy endpoints only:

| call | p50 | p95 | p99 | max |
|---|---|---|---|---|
| light | 480 ms | 869 ms | 1.12 s | 2.09 s |
| heavy | 614 ms | 1.32 s | 1.81 s | 2.14 s |

Nothing healthy took over 3 s; two samples took just over 2 s. A timeout that is too high only slows the broken case, while one that is too low breaks the healthy case on every call, so 3 s keeps ~1.2 s of headroom over the heavy p99 for larger real sweep chunks and farther-away users. KyberSwap primaries sit at 0.3–0.6 s p95 on all four chains.

## Verified live

Drove the app's own `wagmiConfig` transport in the browser with the primary intercepted:

| primary | next endpoint tried after | call resolved in |
|---|---|---|
| returns 429 | 2 ms | 184 ms |
| hangs (routed to a 10 s server-side delay) | **3.008 s** | 3.16 s |

The second row is the change: the old default would have waited 10 s.
