### PR TITLE
chore(rpc): drop public endpoints that cannot serve a multicall-sized call

### DIFF
--- a/packages/rpc-client/src/endpoints.ts
+++ b/packages/rpc-client/src/endpoints.ts
@@ -12,17 +12,23 @@ const MEGAETH = 4326;
 const UNICHAIN = 130;
 const ROBINHOOD = 4663;
 
+/**
+ * Public endpoints tried, in order, when the KyberSwap RPC fails. An endpoint earns its place by
+ * serving the app's real calls — an `eth_call` the size of a multicall balance sweep — not by
+ * answering `eth_blockNumber`: free tiers that reject `eth_call` or cap the request body fail every
+ * such call and cost a hop for nothing. Endpoints that answer but consistently take two to three
+ * times longer than the rest sit last, so a walk reaches them only once the faster ones are out.
+ */
 export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
   [ChainId.Ethereum]: [
     'https://eth.blockrazor.xyz',
-    'https://eth.drpc.org',
-    'https://api.zan.top/eth-mainnet',
     'https://ethereum-rpc.publicnode.com',
     'https://mainnet.rpc.sentio.xyz',
     'https://ethereum-public.nodies.app',
     'https://mainnet.gateway.tenderly.co',
     'https://eth-mainnet.public.blastapi.io',
     'https://ethereum.public.blockpi.network/v1/rpc/public',
+    'https://eth.drpc.org',
     'https://0xrpc.io/eth',
   ],
   [ChainId.Bsc]: [
@@ -40,7 +46,6 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
   [ChainId.PolygonPos]: [
     'https://polygon.drpc.org',
     'https://polygon-bor-rpc.publicnode.com',
-    'https://api.zan.top/polygon-mainnet',
     'https://polygon-public.nodies.app',
     'https://rpc.satelink.network/rpc/polygon',
     'https://polygon.gateway.tenderly.co',
@@ -50,19 +55,15 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
   ],
   [ChainId.Arbitrum]: [
     'https://arbitrum-one-rpc.publicnode.com',
-    'https://api.zan.top/arb-one',
-    'https://arbitrum.drpc.org',
     'https://arbitrum-one-public.nodies.app',
     'https://arbitrum.gateway.tenderly.co',
     'https://arbitrum-one.public.blastapi.io',
     'https://arb1.arbitrum.io/rpc',
     'https://arb-one.api.pocket.network',
-    'https://public-arb-mainnet.fastnode.io',
   ],
   [ChainId.Avalanche]: [
     'https://avalanche-c-chain-rpc.publicnode.com',
     'https://avalanche.drpc.org',
-    'https://api.zan.top/avax-mainnet/ext/bc/C/rpc',
     'https://avalanche.rpc.sentio.xyz',
     'https://avalanche.api.onfinality.io/public/ext/bc/C/rpc',
     'https://api.avax.network/ext/bc/C/rpc',
@@ -70,7 +71,6 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
   ],
   [ChainId.Base]: [
     'https://base-rpc.publicnode.com',
-    'https://api.zan.top/base-mainnet',
     'https://base.gateway.tenderly.co',
     'https://base-mainnet.public.blastapi.io',
     'https://mainnet.base.org',
@@ -81,14 +81,12 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
   ],
   [ChainId.Optimism]: [
     'https://optimism-rpc.publicnode.com',
-    'https://api.zan.top/opt-mainnet',
     'https://optimism.rpc.sentio.xyz',
     'https://optimism-public.nodies.app',
     'https://optimism.gateway.tenderly.co',
     'https://optimism.api.onfinality.io/public',
     'https://mainnet.optimism.io',
     'https://optimism.public.blockpi.network/v1/rpc/public',
-    'https://public-op-mainnet.fastnode.io',
   ],
   [ChainId.Fantom]: [
     'https://fantom.api.onfinality.io/public',
@@ -107,7 +105,6 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
   ],
   [ChainId.ZkSync]: [
     'https://rpc.ankr.com/zksync_era',
-    'https://api.zan.top/zksync-mainnet',
     'https://zksync.drpc.org',
     'https://zksync-era.rpc.sentio.xyz',
     'https://mainnet.era.zksync.io',
@@ -122,7 +119,6 @@ export const PUBLIC_RPC_ENDPOINTS: Record<number, string[]> = {
     'https://blast.api.pocket.network',
   ],
   [ChainId.Mantle]: [
-    'https://api.zan.top/mantle-mainnet',
     'https://rpc.mantle.xyz',
     'https://mantle-rpc.publicnode.com',
     'https://mantle.drpc.org',


### PR DESCRIPTION
## Why

Follow-up to #3373. Probing every public endpoint on Ethereum, Base, BSC and Arbitrum showed that several pass a light health check (`eth_blockNumber`) but fail the app's real calls — an `eth_call` the size of a multicall balance sweep (Multicall3 `aggregate3` × 50, 22.5 KB calldata). They fail fast, so `fallback()` steps past them, but every call that reaches one pays that hop for nothing, and they are what users see as the `400`/`429` rows in their network tab.

`PUBLIC_RPC_ENDPOINTS` feeds both the app's viem `fallback()` and the widgets' `RpcClient`, so one change covers both.

## Evidence

One paced request per endpoint (2.5 s apart) with the heavy call, on every chain the provider was listed on:

| provider | chains checked | result |
|---|---|---|
| `api.zan.top` | Ethereum, Polygon, Arbitrum, Avalanche, Base, Optimism, zkSync, Mantle | **429 on all 8** — free tier does not admit `eth_call` ("cu limit exceeded") |
| `*.fastnode.io` | Arbitrum, Optimism | **413 on both** — request-body cap below a sweep chunk |
| `*.drpc.org` | Ethereum 3/4, Polygon OK, Avalanche OK, **Arbitrum 0/4** (408 / 500 / -32001) | chain-specific |

Full 4-chain probe (4 rounds, light + heavy, round-robined at 0.7 s so no endpoint was hit more than once per ~30 s) is in the #3373 description; healthy endpoints answered the heavy call in 614 ms p50 / 1.32 s p95.

## What changes

- Removed `api.zan.top` on all 8 chains, `fastnode` on both, and `arbitrum.drpc.org`.
- On Ethereum, `eth.drpc.org` (429 even at one hit per half minute) and `0xrpc.io/eth` (heavy p50 1.34 s, 2–3× its neighbours) move to the end of the list.
- A doc comment on `PUBLIC_RPC_ENDPOINTS` states the admission rule and the ordering rule, so the next endpoint added is held to the same bar.

Net: −11 endpoints across 8 chains, 2 reordered.

## Checks

`packages/rpc-client` has no test files; lint, `tsc`, and package build are clean, root `pnpm lint` 15/15 and `pnpm type-check` 16/16.