### PR TITLE
feat(rpc): read Base through @kyber/rpc-client, public endpoints first

### DIFF
--- a/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
+++ b/apps/kyberswap-interface/src/components/Web3Provider/index.tsx
@@ -3,7 +3,7 @@ import { ChainId } from '@kyberswap/ks-sdk-core'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { reconnect, watchChainId } from '@wagmi/core'
 import { ReactNode, useEffect } from 'react'
-import { type Chain, defineChain, fallback, http } from 'viem'
+import { type Chain, type Transport, defineChain, fallback, http } from 'viem'
 import {
   arbitrum,
   avalanche,
@@ -44,6 +44,7 @@ import SAFEPAL_ICON from 'assets/wallets-connect/safepal.svg'
 import WALLET_CONNECT_ICON from 'assets/wallets-connect/wallet-connect.svg'
 import INJECTED_DARK_ICON from 'assets/wallets/browser-wallet-dark.svg'
 import { setMetaMaskMobileLink } from 'components/Web3Provider/metamaskMobileLink'
+import { RPC_CLIENT_CHAINS, rpcClientTransport } from 'components/Web3Provider/rpcClientTransport'
 import { WALLETCONNECT_PROJECT_ID } from 'constants/env'
 import { KYBERSWAP_URL } from 'constants/index'
 import { NETWORKS_INFO, isSupportedChainId } from 'constants/networks'
@@ -392,21 +393,23 @@ const wagmiChains: readonly [Chain, ...Chain[]] = [
 // we can't vouch for, and `batch.multicall.batchSize` keeps their call count in check on its own.
 const PRIMARY_HTTP_CONFIG = { batch: { batchSize: 50 } } as const
 
-// viem `fallback()` rotates through URLs on transport errors (network, 429, 5xx),
-// giving us true client-side RPC rotation for every wagmi-issued call (multicall,
-// useReadContract, polling). KyberSwap RPC sits first; public endpoints are tried
-// only when it errors. Connector-internal calls still use URL[0] of `rpcUrls.default`
-// (set by `withKyberRpc` above), which is the same KyberSwap RPC.
+// Two transports, chosen per chain. Chains in `RPC_CLIENT_CHAINS` read through `@kyber/rpc-client`
+// (see ./rpcClientTransport). The rest use viem `fallback()`, which rotates through URLs on
+// transport errors (network, 429, 5xx) for every wagmi-issued call (multicall, useReadContract,
+// polling); KyberSwap RPC sits first there, and public endpoints are tried only when it errors.
+// Connector-internal calls still use URL[0] of `rpcUrls.default` (set by `withKyberRpc` above),
+// which is the KyberSwap RPC, on every chain.
 
 const transports = Object.fromEntries(
   wagmiChains.map(c => {
+    if (RPC_CLIENT_CHAINS.has(c.id)) return [c.id, rpcClientTransport(c.id)]
     const primaryUrl = NETWORKS_INFO[c.id as ChainId]?.defaultRpcUrl
     const urls = getRpcUrlsForChain(c.id)
     const httpTransports =
       urls.length > 0 ? urls.map(url => (url === primaryUrl ? http(url, PRIMARY_HTTP_CONFIG) : http(url))) : [http()]
     return [c.id, fallback(httpTransports, { retryCount: 1 })]
   }),
-) as Record<(typeof wagmiChains)[number]['id'], ReturnType<typeof fallback>>
+) as Record<(typeof wagmiChains)[number]['id'], Transport>
 
 // Migrate localStorage's recent-connector hint from the EIP-6963 io.metamask id (used by the
 // pre-PR injected connector) to the metaMaskSDK id (the new SDK connector). wagmi auto-resets

--- a/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.test.ts
+++ b/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.test.ts
@@ -39,8 +39,8 @@ const stubFetch = () =>
     return reply(answer.error ? { error: answer.error } : { result: answer.result ?? '0x1' }, answer.status)
   })
 
-const transport = (retryCount = 0) => rpcClientTransport(CHAIN)({ chain: undefined, retryCount } as never)
-const request = (method = 'eth_chainId', params: unknown[] = []) => transport().request({ method, params } as never)
+const transport = rpcClientTransport(CHAIN)({ chain: undefined, retryCount: 3 } as never)
+const request = (method = 'eth_chainId', params: unknown[] = []) => transport.request({ method, params } as never)
 
 describe('rpcClientTransport', () => {
   beforeEach(() => {
@@ -53,8 +53,8 @@ describe('rpcClientTransport', () => {
     vi.useRealTimers()
   })
 
-  it('builds a transport that does not retry on its own', () => {
-    expect(transport(3).config.retryCount).toBe(0)
+  it('does not retry on its own, whatever the client asks for', () => {
+    expect(transport.config.retryCount).toBe(0)
   })
 
   it('reads a public endpoint first and answers with the node value', async () => {
@@ -64,13 +64,18 @@ describe('rpcClientTransport', () => {
     expect(hits).not.toContain(KYBER)
   })
 
-  it('hands a revert to viem with its code and data, without rotating', async () => {
+  it('hands a revert to viem as the node said it, without rotating', async () => {
     const data = '0x08c379a0'
-    answers = () => ({ error: { code: 3, message: 'execution reverted: Foo()', data } })
+    answers = () => ({ error: { code: -32000, message: 'execution reverted', data } })
     const error = await request('eth_call', [{ to: '0x1', data: '0x' }, 'latest']).catch(e => e)
-    expect(error).toBeInstanceOf(RpcRequestError)
-    expect(error.code).toBe(3)
-    expect(error.data).toBe(data)
+    // viem types the node's code for its callers and keeps the node's answer underneath, which is
+    // where its revert decoder looks — for the code, the data, and details that are exactly the
+    // node's words.
+    expect(error.code).toBe(-32000)
+    const node = error.walk((e: unknown) => e instanceof RpcRequestError)
+    expect(node).toBeInstanceOf(RpcRequestError)
+    expect(node.data).toBe(data)
+    expect(node.details).toBe('execution reverted')
     // A revert is the node's answer; asking another node cannot change it.
     expect(hits).toHaveLength(1)
   })
@@ -84,10 +89,25 @@ describe('rpcClientTransport', () => {
     expect(new Set(hits.slice(0, -1))).toEqual(new Set(PUBLICS))
   })
 
+  it('treats a refusal from one endpoint as that endpoint failing, and moves on', async () => {
+    // A geo-block answers 403; the request is fine and the next endpoint serves it.
+    let refused: string | undefined
+    answers = url => {
+      refused ??= url
+      return url === refused ? { status: 403 } : { result: '0x5' }
+    }
+    await expect(request()).resolves.toBe('0x5')
+    expect(hits).toHaveLength(2)
+    expect(hits[0]).toBe(refused)
+  })
+
   it('reports a transport failure as one when every endpoint refuses', async () => {
     answers = () => ({ status: 503 })
     const error = await request().catch(e => e)
     expect(error).toBeInstanceOf(HttpRequestError)
+    // It gave up only after the whole list and the last resort had refused.
+    expect(hits).toHaveLength(PUBLICS.length + 1)
+    expect(hits.at(-1)).toBe(KYBER)
   })
 
   it('gives a hanging endpoint three seconds, then moves on', async () => {

--- a/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.test.ts
+++ b/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.test.ts
@@ -1,0 +1,104 @@
+import { PUBLIC_RPC_ENDPOINTS, clearRpcClients } from '@kyber/rpc-client'
+import { ChainId } from '@kyberswap/ks-sdk-core'
+import { HttpRequestError, RpcRequestError } from 'viem'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NETWORKS_INFO } from 'constants/networks'
+
+import { rpcClientTransport } from './rpcClientTransport'
+
+const CHAIN = ChainId.BASE
+const KYBER = NETWORKS_INFO[CHAIN].defaultRpcUrl
+const PUBLICS = PUBLIC_RPC_ENDPOINTS[CHAIN]
+/** The client's own freshness probes use this method; they are not the transport's calls. */
+const PROBE_METHOD = 'eth_blockNumber'
+
+type Answer = {
+  status?: number
+  result?: unknown
+  error?: { code: number; message: string; data?: unknown }
+  hang?: boolean
+}
+
+/** Hosts the transport's calls reached, in order. */
+const hits: string[] = []
+let answers: (url: string) => Answer
+
+const stubFetch = () =>
+  vi.stubGlobal('fetch', async (url: string, init: { body: string }) => {
+    const { id, method } = JSON.parse(init.body)
+    const reply = (body: object, status = 200) =>
+      new Response(JSON.stringify({ jsonrpc: '2.0', id, ...body }), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      })
+    if (method === PROBE_METHOD) return reply({ result: '0x1' })
+    hits.push(url)
+    const answer = answers(url)
+    if (answer.hang) return new Promise<Response>(() => undefined)
+    return reply(answer.error ? { error: answer.error } : { result: answer.result ?? '0x1' }, answer.status)
+  })
+
+const transport = (retryCount = 0) => rpcClientTransport(CHAIN)({ chain: undefined, retryCount } as never)
+const request = (method = 'eth_chainId', params: unknown[] = []) => transport().request({ method, params } as never)
+
+describe('rpcClientTransport', () => {
+  beforeEach(() => {
+    hits.length = 0
+    clearRpcClients()
+    stubFetch()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('builds a transport that does not retry on its own', () => {
+    expect(transport(3).config.retryCount).toBe(0)
+  })
+
+  it('reads a public endpoint first and answers with the node value', async () => {
+    answers = () => ({ result: '0x42' })
+    await expect(request()).resolves.toBe('0x42')
+    expect(PUBLICS).toContain(hits[0])
+    expect(hits).not.toContain(KYBER)
+  })
+
+  it('hands a revert to viem with its code and data, without rotating', async () => {
+    const data = '0x08c379a0'
+    answers = () => ({ error: { code: 3, message: 'execution reverted: Foo()', data } })
+    const error = await request('eth_call', [{ to: '0x1', data: '0x' }, 'latest']).catch(e => e)
+    expect(error).toBeInstanceOf(RpcRequestError)
+    expect(error.code).toBe(3)
+    expect(error.data).toBe(data)
+    // A revert is the node's answer; asking another node cannot change it.
+    expect(hits).toHaveLength(1)
+  })
+
+  it('walks the public endpoints once on rate limits and lands on the KyberSwap endpoint last', async () => {
+    answers = url => (url === KYBER ? { result: '0x7' } : { status: 429 })
+    await expect(request()).resolves.toBe('0x7')
+    expect(hits.at(-1)).toBe(KYBER)
+    // Every public once, KyberSwap once: no second pass over a list that has just refused the call.
+    expect(hits).toHaveLength(PUBLICS.length + 1)
+    expect(new Set(hits.slice(0, -1))).toEqual(new Set(PUBLICS))
+  })
+
+  it('reports a transport failure as one when every endpoint refuses', async () => {
+    answers = () => ({ status: 503 })
+    const error = await request().catch(e => e)
+    expect(error).toBeInstanceOf(HttpRequestError)
+  })
+
+  it('gives a hanging endpoint three seconds, then moves on', async () => {
+    vi.useFakeTimers()
+    let calls = 0
+    answers = () => (calls++ === 0 ? { hang: true } : { result: '0x9' })
+    const pending = request()
+    await vi.advanceTimersByTimeAsync(2_900)
+    expect(hits).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(200)
+    await expect(pending).resolves.toBe('0x9')
+    expect(hits).toHaveLength(2)
+  })
+})

--- a/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.ts
+++ b/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.ts
@@ -1,0 +1,83 @@
+import { AllEndpointsFailedError, PUBLIC_RPC_ENDPOINTS, RpcError, getRpcClient } from '@kyber/rpc-client'
+import { ChainId } from '@kyberswap/ks-sdk-core'
+import { HttpRequestError, RpcRequestError, custom } from 'viem'
+
+import { NETWORKS_INFO } from 'constants/networks'
+
+/**
+ * Chains whose reads go through `@kyber/rpc-client` rather than viem's own `fallback()`. The client
+ * rotates across the public endpoints and keeps the KyberSwap endpoint as the last resort — the
+ * public ones are free, the KyberSwap one is paid for — and it remembers which endpoints failed, so
+ * a rate-limited or hanging endpoint is skipped for a cooldown rather than paid for on every call.
+ * Chains not listed keep viem's fallback; adding a chain here is the whole rollout for it.
+ */
+export const RPC_CLIENT_CHAINS: ReadonlySet<number> = new Set([ChainId.BASE])
+
+/** One instance per chain for the app, apart from the ones the embedded widgets configure. */
+const APP_SCOPE = 'app'
+
+/**
+ * One endpoint's share of the wait. Rotation moves on only once the current endpoint has failed or
+ * run out of time, so a hop that hangs costs the whole call this long. A healthy endpoint answers a
+ * multicall-sized call in well under two seconds.
+ */
+const HOP_TIMEOUT_MS = 3_000
+
+/**
+ * The app owns its chain list. The client's built-in tables are the widgets' and cover a different
+ * set of chains, so the public endpoints and the last-resort endpoint are handed in here: the public
+ * list the app already uses, and this chain's `defaultRpcUrl`, which the client tries after the
+ * public ones.
+ */
+const clientFor = (chainId: number) =>
+  getRpcClient(chainId, {
+    scope: APP_SCOPE,
+    customEndpoints: PUBLIC_RPC_ENDPOINTS[chainId],
+    configRpcEndpoint: NETWORKS_INFO[chainId as ChainId]?.defaultRpcUrl,
+    timeout: HOP_TIMEOUT_MS,
+  })
+
+/**
+ * The client's errors in the shapes viem reads. A timeout or an HTTP status is the transport
+ * failing; anything else is the node answering, and viem takes the node's code and data from it —
+ * a revert's reason lives in `data`, and only a `RpcRequestError` carries it to the decoder.
+ */
+const toViemError = (error: unknown, chainId: number, method: string, params: unknown): Error => {
+  const body = { method, params }
+  const url = `@kyber/rpc-client chain ${chainId}`
+  if (error instanceof AllEndpointsFailedError) return new HttpRequestError({ body, details: error.message, url })
+  if (error instanceof RpcError) {
+    const transportFailure = error.code === -1 || (error.code >= 100 && error.code <= 599)
+    if (transportFailure) {
+      return new HttpRequestError({
+        body,
+        details: error.message,
+        status: error.code > 0 ? error.code : undefined,
+        url,
+      })
+    }
+    return new RpcRequestError({ body, error: { code: error.code, message: error.message, data: error.data }, url })
+  }
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+/**
+ * A viem transport over `@kyber/rpc-client`, for `RPC_CLIENT_CHAINS`. The client is created on the
+ * first request, not when the transport is built, so building one per chain at startup sends nothing.
+ */
+export const rpcClientTransport = (chainId: number) =>
+  custom(
+    {
+      request: async ({ method, params }: { method: string; params?: unknown }) => {
+        try {
+          return await clientFor(chainId).call(method, (params ?? []) as unknown[])
+        } catch (error) {
+          throw toViemError(error, chainId, method, params)
+        }
+      },
+    },
+    // The client rotates and retries on its own. A second layer of retries here would walk the
+    // whole list again for a call every endpoint has just refused, and double the load on
+    // endpoints already rate-limiting the user.
+    { key: 'kyberRpcClient', name: 'KyberSwap RPC client', retryCount: 0 },
+  )

--- a/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.ts
+++ b/apps/kyberswap-interface/src/components/Web3Provider/rpcClientTransport.ts
@@ -1,4 +1,4 @@
-import { AllEndpointsFailedError, PUBLIC_RPC_ENDPOINTS, RpcError, getRpcClient } from '@kyber/rpc-client'
+import { AllEndpointsFailedError, RpcError, getRpcClient } from '@kyber/rpc-client'
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import { HttpRequestError, RpcRequestError, custom } from 'viem'
 
@@ -13,51 +13,48 @@ import { NETWORKS_INFO } from 'constants/networks'
  */
 export const RPC_CLIENT_CHAINS: ReadonlySet<number> = new Set([ChainId.BASE])
 
-/** One instance per chain for the app, apart from the ones the embedded widgets configure. */
-const APP_SCOPE = 'app'
-
 /**
- * One endpoint's share of the wait. Rotation moves on only once the current endpoint has failed or
- * run out of time, so a hop that hangs costs the whole call this long. A healthy endpoint answers a
- * multicall-sized call in well under two seconds.
+ * How far behind the freshest endpoint a node may be before it is benched, in blocks — about half a
+ * minute of each chain's block time. Consecutive reads land on different nodes, so a node further
+ * behind than this would show a balance from before the transaction the user just watched confirm.
  */
-const HOP_TIMEOUT_MS = 3_000
+const MAX_BLOCK_LAG: Partial<Record<number, number>> = { [ChainId.BASE]: 15 }
 
 /**
- * The app owns its chain list. The client's built-in tables are the widgets' and cover a different
- * set of chains, so the public endpoints and the last-resort endpoint are handed in here: the public
- * list the app already uses, and this chain's `defaultRpcUrl`, which the client tries after the
- * public ones.
+ * The client shared by everything on the chain — the wagmi transport here, gas estimation before a
+ * signature, the widgets — so what one learns about an endpoint the others use. The chain's own
+ * `defaultRpcUrl` is named as the last resort for chains the client's tables do not cover.
  */
 const clientFor = (chainId: number) =>
   getRpcClient(chainId, {
-    scope: APP_SCOPE,
-    customEndpoints: PUBLIC_RPC_ENDPOINTS[chainId],
     configRpcEndpoint: NETWORKS_INFO[chainId as ChainId]?.defaultRpcUrl,
-    timeout: HOP_TIMEOUT_MS,
+    maxBlockLag: MAX_BLOCK_LAG[chainId],
   })
 
 /**
- * The client's errors in the shapes viem reads. A timeout or an HTTP status is the transport
- * failing; anything else is the node answering, and viem takes the node's code and data from it —
- * a revert's reason lives in `data`, and only a `RpcRequestError` carries it to the decoder.
+ * The client's errors in the shapes viem reads. The node answering is a `RpcRequestError` carrying
+ * the node's own code, message and data — the message untouched, since viem decodes a revert only
+ * when it reads exactly what the node said; the endpoint failing is a `HttpRequestError`.
  */
 const toViemError = (error: unknown, chainId: number, method: string, params: unknown): Error => {
   const body = { method, params }
   const url = `@kyber/rpc-client chain ${chainId}`
-  if (error instanceof AllEndpointsFailedError) return new HttpRequestError({ body, details: error.message, url })
-  if (error instanceof RpcError) {
-    const transportFailure = error.code === -1 || (error.code >= 100 && error.code <= 599)
-    if (transportFailure) {
-      return new HttpRequestError({
-        body,
-        details: error.message,
-        status: error.code > 0 ? error.code : undefined,
-        url,
-      })
-    }
-    return new RpcRequestError({ body, error: { code: error.code, message: error.message, data: error.data }, url })
+  if (error instanceof RpcError && error.kind === 'rpc') {
+    return new RpcRequestError({
+      body,
+      error: { code: error.code, message: error.nodeMessage ?? error.message, data: error.data },
+      url,
+    })
   }
+  if (error instanceof RpcError) {
+    return new HttpRequestError({
+      body,
+      details: error.message,
+      status: error.kind === 'http' ? error.code : undefined,
+      url,
+    })
+  }
+  if (error instanceof AllEndpointsFailedError) return new HttpRequestError({ body, details: error.message, url })
   return error instanceof Error ? error : new Error(String(error))
 }
 

--- a/apps/kyberswap-interface/src/utils/sendTransaction.ts
+++ b/apps/kyberswap-interface/src/utils/sendTransaction.ts
@@ -37,11 +37,6 @@ const NO_BUILDER_CODE_SELECTORS = new Set([
   '0xa22cb465', // setApprovalForAll
 ])
 
-// Per-request timeout for the pre-signature RPC reads (gas + fee estimation).
-// Tighter than the rotating client's 10s default so a slow endpoint fails over
-// quickly instead of stalling the "Waiting For Confirmation" step. Only applied
-// when the chain's RpcClient is first created (the client is a per-chain singleton).
-const PRE_SIGN_RPC_TIMEOUT_MS = 6000
 // Time-box the compliance check so a slow Blackjack service can't hold up the
 // wallet prompt — consistent with the existing fail-open policy on errors.
 const BLACKJACK_TIMEOUT_MS = 2000
@@ -131,20 +126,15 @@ export async function sendEVMTransaction({
     // Route gas estimation through the rotating RPC client (round-robin across
     // healthy public endpoints, per-request timeout, Kyber RPC fallback) so a
     // single slow/overloaded RPC can't stall the flow before the wallet prompt.
-    const gasHex = await rpcFetch<string>(
-      chainId as number,
-      'eth_estimateGas',
-      [
-        {
-          from: account,
-          to: contractAddress,
-          data: callData,
-          ...(txValue !== undefined ? { value: `0x${txValue.toString(16)}` } : {}),
-          ...(accessList ? { accessList } : {}),
-        },
-      ],
-      { timeout: PRE_SIGN_RPC_TIMEOUT_MS },
-    )
+    const gasHex = await rpcFetch<string>(chainId as number, 'eth_estimateGas', [
+      {
+        from: account,
+        to: contractAddress,
+        data: callData,
+        ...(txValue !== undefined ? { value: `0x${txValue.toString(16)}` } : {}),
+        ...(accessList ? { accessList } : {}),
+      },
+    ])
     gasEstimate = BigInt(gasHex)
   } catch (error) {
     throw new TransactionError(

--- a/packages/rpc-client/src/client.ts
+++ b/packages/rpc-client/src/client.ts
@@ -12,11 +12,22 @@ import {
   RpcEventHandlers,
 } from './types';
 
-const DEFAULT_TIMEOUT = 10000;
+/**
+ * One endpoint's share of the wait. Rotation only moves on once the current endpoint has failed or
+ * run out of time, so a hop that hangs costs the whole call this long. A healthy endpoint answers a
+ * multicall-sized `eth_call` in well under two seconds; three is generous for one and keeps a walk
+ * over a full list to tens of seconds rather than minutes.
+ */
+const DEFAULT_TIMEOUT = 3000;
 const DEFAULT_MAX_RETRIES_PER_ENDPOINT = 1;
 const DEFAULT_ENDPOINT_COOLDOWN_MS = 60000; // 1 minute
 const DEFAULT_MAX_BLOCK_LAG = 50;
 const DEFAULT_PROBE_INTERVAL_MS = 60000; // 1 minute
+/**
+ * A probe loop follows traffic: it starts with the first call and stops once no call has been made
+ * for this long, so a client held for a chain nobody is reading costs the endpoints nothing.
+ */
+const DEFAULT_PROBE_IDLE_STOP_MS = 5 * 60000;
 
 /**
  * JSON-RPC error codes that every healthy node answers identically, so rotating
@@ -90,7 +101,7 @@ function normalizeRpcError(error: unknown): { code: number; message: string; dat
  *
  * Features:
  * - Round-robin rotation through public endpoints, sorted by probe latency
- * - Background block freshness probing to detect stale/slow endpoints
+ * - Block freshness probing while the client is in use, to detect stale/slow endpoints
  * - Health tracking with cooldown for failed endpoints
  * - Kyber RPC fallback when all public endpoints fail
  * - Optional telemetry hooks for monitoring
@@ -122,6 +133,7 @@ export class RpcClient {
   private requestId = 1;
   private probeTimer: ReturnType<typeof setInterval> | undefined;
   private isProbing = false;
+  private lastCallAt = 0;
 
   constructor(config: RpcClientConfig) {
     this.chainId = config.chainId;
@@ -146,12 +158,24 @@ export class RpcClient {
         isHealthy: true,
       });
     }
+  }
 
-    // Start background probing
-    if (this.endpoints.length > 1 && this.probeIntervalMs > 0) {
+  /**
+   * Probing follows traffic. Constructing a client sends nothing — an app builds one per chain it
+   * serves, most of which the user never reads — and the loop starts with the first call and ends
+   * once calls stop, so it never outlives the code that needed it.
+   */
+  private ensureProbing(): void {
+    this.lastCallAt = Date.now();
+    if (this.probeTimer || this.endpoints.length <= 1 || this.probeIntervalMs <= 0) return;
+    this.probeEndpoints();
+    this.probeTimer = setInterval(() => {
+      if (Date.now() - this.lastCallAt >= DEFAULT_PROBE_IDLE_STOP_MS) {
+        this.destroy();
+        return;
+      }
       this.probeEndpoints();
-      this.probeTimer = setInterval(() => this.probeEndpoints(), this.probeIntervalMs);
-    }
+    }, this.probeIntervalMs);
   }
 
   getChainId(): number {
@@ -166,6 +190,7 @@ export class RpcClient {
    * Non-retryable errors (e.g. execution reverted) are thrown immediately.
    */
   async call<T>(method: string, params: unknown[] = []): Promise<T> {
+    this.ensureProbing();
     const errors: Array<{ endpoint: string; error: Error }> = [];
 
     // Try all public endpoints via rotation
@@ -213,6 +238,7 @@ export class RpcClient {
    * Make an RPC call and return result with metadata.
    */
   async callWithMetadata<T>(method: string, params: unknown[] = []): Promise<RpcCallResult<T>> {
+    this.ensureProbing();
     const errors: Array<{ endpoint: string; error: Error }> = [];
 
     for (let i = 0; i < this.endpoints.length; i++) {
@@ -254,6 +280,7 @@ export class RpcClient {
    * Make a batch RPC call.
    */
   async batchCall<T extends unknown[]>(calls: Array<{ method: string; params?: unknown[] }>): Promise<T> {
+    this.ensureProbing();
     const errors: Array<{ endpoint: string; error: Error }> = [];
 
     for (let i = 0; i < this.endpoints.length; i++) {
@@ -345,7 +372,7 @@ export class RpcClient {
   }
 
   /**
-   * Stop background probing. Call this when the client is no longer needed.
+   * Stop probing. The next call starts it again, so this is safe to call at any time.
    */
   destroy(): void {
     if (this.probeTimer) {
@@ -536,6 +563,25 @@ export class RpcClient {
 
   // ─── Fetch helpers ───────────────────────────────────────────────────
 
+  /**
+   * A request's budget. The abort is the polite cancel; the rejection is the guarantee. An
+   * environment that leaves an aborted fetch pending — a mobile in-app browser, a frozen tab — must
+   * not hold the call, and with it the rotation, for good; racing the fetch and the body read against
+   * `deadline` settles them regardless.
+   */
+  private deadlineFor(endpoint: string, method: string, timeoutMs: number) {
+    const controller = new AbortController();
+    let expire: (() => void) | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      expire = () => {
+        controller.abort();
+        reject(new RpcError(-1, buildRpcErrorMessage(endpoint, method, `Request timeout after ${timeoutMs}ms`)));
+      };
+    });
+    const timeoutId = setTimeout(() => expire?.(), timeoutMs);
+    return { controller, deadline, timeoutId };
+  }
+
   private async fetchRpc<T>(
     endpoint: string,
     method: string,
@@ -552,19 +598,21 @@ export class RpcClient {
       params,
     };
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
+    const { controller, deadline, timeoutId } = this.deadlineFor(endpoint, method, effectiveTimeout);
 
     try {
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...this.headers,
-        },
-        body: JSON.stringify(request),
-        signal: controller.signal,
-      });
+      const response = await Promise.race([
+        fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...this.headers,
+          },
+          body: JSON.stringify(request),
+          signal: controller.signal,
+        }),
+        deadline,
+      ]);
 
       clearTimeout(timeoutId);
 
@@ -588,7 +636,7 @@ export class RpcClient {
         );
       }
 
-      const data = (await response.json()) as JsonRpcResponse<T>;
+      const data = (await Promise.race([response.json(), deadline])) as JsonRpcResponse<T>;
 
       if (data.error) {
         const { code, message, data: errData } = normalizeRpcError(data.error);
@@ -634,19 +682,21 @@ export class RpcClient {
       params: call.params ?? [],
     }));
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    const { controller, deadline, timeoutId } = this.deadlineFor(endpoint, 'batch', this.timeout);
 
     try {
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...this.headers,
-        },
-        body: JSON.stringify(requests),
-        signal: controller.signal,
-      });
+      const response = await Promise.race([
+        fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...this.headers,
+          },
+          body: JSON.stringify(requests),
+          signal: controller.signal,
+        }),
+        deadline,
+      ]);
 
       clearTimeout(timeoutId);
 
@@ -670,7 +720,7 @@ export class RpcClient {
         );
       }
 
-      const data = (await response.json()) as JsonRpcResponse[];
+      const data = (await Promise.race([response.json(), deadline])) as JsonRpcResponse[];
 
       // Sort by id to maintain order
       const sortedData = [...data].sort((a, b) => Number(a.id) - Number(b.id));
@@ -891,18 +941,20 @@ export class RpcClient {
   }
 }
 
-// Singleton instances per chain - keyed by chainId only for proper health tracking sharing
-const clientInstances: Map<number, RpcClient> = new Map();
+// One instance per chain and scope, so callers share health tracking within a scope.
+const clientInstances: Map<string, RpcClient> = new Map();
 
 /**
- * Get or create an RpcClient instance for a chain.
+ * Get or create the RpcClient for a chain.
  *
- * Uses singleton pattern to reuse health tracking across calls.
- * Note: Only chainId is used as cache key, so custom config is only applied on first creation.
+ * Instances are shared per chain within a `scope`, so callers on the same chain pool their health
+ * tracking. Configuration is applied when an instance is first created; a caller that needs its own
+ * settings — a different endpoint list, timeout or telemetry — asks for its own scope rather than
+ * depending on being first. `configRpcEndpoint` is the one setting applied to an existing instance.
  *
  * @param chainId - The chain ID to get client for
- * @param config - Optional configuration (only applied on first creation for this chainId)
- * @returns RpcClient instance for the chain
+ * @param config - Optional configuration; see `RpcClientConfig.scope`
+ * @returns RpcClient instance for the chain and scope
  *
  * @example
  * ```typescript
@@ -911,10 +963,11 @@ const clientInstances: Map<number, RpcClient> = new Map();
  * ```
  */
 export function getRpcClient(chainId: number, config?: Partial<RpcClientConfig>): RpcClient {
-  let client = clientInstances.get(chainId);
+  const key = `${chainId}:${config?.scope ?? 'default'}`;
+  let client = clientInstances.get(key);
   if (!client) {
     client = new RpcClient({ chainId, ...config });
-    clientInstances.set(chainId, client);
+    clientInstances.set(key, client);
   } else if (config?.configRpcEndpoint) {
     client.updateConfigEndpoint(config.configRpcEndpoint);
   }

--- a/packages/rpc-client/src/client.ts
+++ b/packages/rpc-client/src/client.ts
@@ -19,6 +19,12 @@ import {
  * over a full list to tens of seconds rather than minutes.
  */
 const DEFAULT_TIMEOUT = 3000;
+/**
+ * Methods the node itself works on for a while — gas estimation searches for the limit — get a
+ * longer budget than a read: giving them a read's three seconds would cut off every honest answer.
+ */
+const SLOW_METHOD_TIMEOUT_MS = 10000;
+const SLOW_METHODS = new Set(['eth_estimateGas']);
 const DEFAULT_MAX_RETRIES_PER_ENDPOINT = 1;
 const DEFAULT_ENDPOINT_COOLDOWN_MS = 60000; // 1 minute
 const DEFAULT_MAX_BLOCK_LAG = 50;
@@ -97,6 +103,69 @@ function normalizeRpcError(error: unknown): { code: number; message: string; dat
 }
 
 /**
+ * One JSON-RPC POST with a real budget. The abort is the polite cancel; the rejection is the
+ * guarantee: the fetch and the body read both race the deadline, and the timer lives until the body
+ * is parsed, so an endpoint that sends headers and then stalls — or an environment that leaves an
+ * aborted fetch pending — cannot hold the call. Every failure is an `RpcError` whose `kind` says
+ * whether the endpoint failed (`http`, `timeout`, `network`) or answered; the caller reads the
+ * answer's own error out of the parsed body.
+ */
+export async function postJsonRpc<R>(
+  endpoint: string,
+  method: string,
+  payload: unknown,
+  timeoutMs: number,
+  headers: Record<string, string> = {},
+): Promise<R> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(
+        new RpcError(-1, buildRpcErrorMessage(endpoint, method, `Request timeout after ${timeoutMs}ms`), undefined, {
+          kind: 'timeout',
+        }),
+      );
+    }, timeoutMs);
+  });
+  const race = <T>(work: Promise<T>) => Promise.race([work, deadline]);
+
+  try {
+    const response = await race(
+      fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      }),
+    );
+    if (!response.ok) {
+      const detail =
+        response.status === 429 || response.status === 402
+          ? 'Rate limit exceeded'
+          : response.status >= 500
+            ? `Provider unavailable (HTTP ${response.status} ${response.statusText})`
+            : `HTTP error ${response.status} ${response.statusText}`;
+      throw new RpcError(response.status, buildRpcErrorMessage(endpoint, method, detail), undefined, { kind: 'http' });
+    }
+    return (await race(response.json())) as R;
+  } catch (error) {
+    if (error instanceof RpcError) throw error;
+    throw new RpcError(
+      -1,
+      buildRpcErrorMessage(endpoint, method, (error as Error).message || 'Network error'),
+      undefined,
+      {
+        kind: 'network',
+      },
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
  * RPC Client with automatic endpoint rotation, health probing, and fallback.
  *
  * Features:
@@ -114,7 +183,7 @@ function normalizeRpcError(error: unknown): { code: number; message: string; dat
  */
 export class RpcClient {
   private readonly chainId: number;
-  private readonly endpoints: string[];
+  private endpoints: string[];
   private readonly kyberEndpoint: string | undefined;
   private readonly defaultRpcEndpoint: string | undefined;
   private configRpcEndpoint: string | undefined;
@@ -124,7 +193,7 @@ export class RpcClient {
   private readonly endpointCooldownMs: number;
   private readonly headers: Record<string, string>;
   private readonly eventHandlers: RpcEventHandlers;
-  private readonly maxBlockLag: number;
+  maxBlockLag: number;
   private readonly probeIntervalMs: number;
 
   private currentIndex = 0;
@@ -137,7 +206,7 @@ export class RpcClient {
 
   constructor(config: RpcClientConfig) {
     this.chainId = config.chainId;
-    this.endpoints = config.customEndpoints?.length ? config.customEndpoints : getRpcEndpoints(config.chainId);
+    this.endpoints = [...(config.customEndpoints?.length ? config.customEndpoints : getRpcEndpoints(config.chainId))];
     this.kyberEndpoint = getKyberRpcEndpoint(config.chainId);
     this.defaultRpcEndpoint = NETWORKS_INFO[config.chainId as ChainId]?.defaultRpc;
     this.configRpcEndpoint = config.configRpcEndpoint;
@@ -161,9 +230,8 @@ export class RpcClient {
   }
 
   /**
-   * Probing follows traffic. Constructing a client sends nothing — an app builds one per chain it
-   * serves, most of which the user never reads — and the loop starts with the first call and ends
-   * once calls stop, so it never outlives the code that needed it.
+   * Probing follows traffic: the loop starts with the first call and ends once calls stop, so a
+   * client nobody is reading through — or nobody remembered to destroy — costs the endpoints nothing.
    */
   private ensureProbing(): void {
     this.lastCallAt = Date.now();
@@ -185,25 +253,62 @@ export class RpcClient {
   /**
    * Make an RPC call with automatic rotation and fallback.
    *
-   * Tries healthy public endpoints in round-robin order (sorted by probe latency),
-   * then falls back to Kyber/config/default RPC if all public endpoints fail.
-   * Non-retryable errors (e.g. execution reverted) are thrown immediately.
+   * Public endpoints are tried round-robin, sorted by probe latency, then the KyberSwap, config and
+   * default endpoints as last resorts. A deterministic node answer (an execution revert) is thrown
+   * at once: rotating cannot change it.
    */
   async call<T>(method: string, params: unknown[] = []): Promise<T> {
+    return (await this.callWithMetadata<T>(method, params)).result;
+  }
+
+  /**
+   * Make an RPC call and return result with metadata.
+   */
+  async callWithMetadata<T>(method: string, params: unknown[] = []): Promise<RpcCallResult<T>> {
+    return this.walk(method, endpoint => this.fetchRpc<T>(endpoint, method, params));
+  }
+
+  /**
+   * Make a batch RPC call.
+   */
+  async batchCall<T extends unknown[]>(calls: Array<{ method: string; params?: unknown[] }>): Promise<T> {
+    return (await this.walk('batch', endpoint => this.fetchBatchRpc<T>(endpoint, calls))).result;
+  }
+
+  /**
+   * One pass over the public endpoints, then the last resorts.
+   *
+   * The pass walks the order the client holds when it starts: a re-ranking that lands mid-pass
+   * replaces the array rather than reordering it, so the pass neither revisits nor skips an
+   * endpoint. An endpoint that fails to answer, or answers with a rate limit, is benched and the
+   * pass moves on; one that answers with a deterministic error ends the call, since no other node
+   * would answer differently. With every endpoint benched the first is knocked on once — it may
+   * have recovered — and the pass goes straight to the last resorts rather than knocking on the
+   * same benched door once per slot.
+   */
+  private async walk<T>(
+    method: string,
+    attempt: (endpoint: string) => Promise<RpcCallResult<T>>,
+  ): Promise<RpcCallResult<T>> {
     this.ensureProbing();
     const errors: Array<{ endpoint: string; error: Error }> = [];
+    const order = this.endpoints;
+    let knockedOnBenched = false;
 
-    // Try all public endpoints via rotation
-    for (let i = 0; i < this.endpoints.length; i++) {
-      const endpoint = this.getNextHealthyEndpoint();
-      if (!endpoint) break;
+    for (let i = 0; i < order.length; i++) {
+      let endpoint = this.nextHealthy(order);
+      if (!endpoint) {
+        if (knockedOnBenched) break;
+        knockedOnBenched = true;
+        endpoint = order[0];
+      }
 
       for (let retry = 0; retry < this.maxRetriesPerEndpoint; retry++) {
         try {
-          const result = await this.fetchRpc<T>(endpoint, method, params);
+          const result = await attempt(endpoint);
           this.markEndpointHealthy(endpoint);
           this.eventHandlers.onSuccess?.(this.chainId, endpoint, method, result.latencyMs);
-          return result.result;
+          return result;
         } catch (error) {
           const err = error as Error;
           this.eventHandlers.onError?.(this.chainId, endpoint, method, err);
@@ -212,58 +317,9 @@ export class RpcClient {
             this.markEndpointFailed(endpoint);
             this.eventHandlers.onRateLimit?.(this.chainId, endpoint);
             errors.push({ endpoint, error: err });
-            break; // Move to next endpoint immediately on rate limit
-          }
-
-          if (!this.isRetryableError(err)) {
-            // Deterministic error (e.g. execution reverted) — throw immediately,
-            // rotating to other endpoints won't help
-            throw err;
-          }
-
-          if (retry >= this.maxRetriesPerEndpoint - 1) {
-            this.markEndpointFailed(endpoint);
-            errors.push({ endpoint, error: err });
-            break; // Move to next endpoint
-          }
-        }
-      }
-    }
-
-    // Fallback chain
-    return this.fallbackCall<T>(method, params, errors);
-  }
-
-  /**
-   * Make an RPC call and return result with metadata.
-   */
-  async callWithMetadata<T>(method: string, params: unknown[] = []): Promise<RpcCallResult<T>> {
-    this.ensureProbing();
-    const errors: Array<{ endpoint: string; error: Error }> = [];
-
-    for (let i = 0; i < this.endpoints.length; i++) {
-      const endpoint = this.getNextHealthyEndpoint();
-      if (!endpoint) break;
-
-      for (let retry = 0; retry < this.maxRetriesPerEndpoint; retry++) {
-        try {
-          const result = await this.fetchRpc<T>(endpoint, method, params);
-          this.markEndpointHealthy(endpoint);
-          return result;
-        } catch (error) {
-          const err = error as Error;
-          this.eventHandlers.onError?.(this.chainId, endpoint, method, err);
-
-          if (this.isRateLimitError(err)) {
-            this.markEndpointFailed(endpoint);
-            errors.push({ endpoint, error: err });
             break;
           }
-
-          if (!this.isRetryableError(err)) {
-            throw err;
-          }
-
+          if (!this.isRetryableError(err)) throw err;
           if (retry >= this.maxRetriesPerEndpoint - 1) {
             this.markEndpointFailed(endpoint);
             errors.push({ endpoint, error: err });
@@ -273,44 +329,40 @@ export class RpcClient {
       }
     }
 
-    return this.fallbackCallWithMetadata<T>(method, params, errors);
+    return this.lastResorts(method, attempt, errors);
   }
 
   /**
-   * Make a batch RPC call.
+   * The endpoints tried once the public ones are out, in order: KyberSwap, the one the runtime
+   * config named, the chain's default — each only if it is not already one of the others.
    */
-  async batchCall<T extends unknown[]>(calls: Array<{ method: string; params?: unknown[] }>): Promise<T> {
-    this.ensureProbing();
-    const errors: Array<{ endpoint: string; error: Error }> = [];
+  private async lastResorts<T>(
+    method: string,
+    attempt: (endpoint: string) => Promise<RpcCallResult<T>>,
+    errors: Array<{ endpoint: string; error: Error }>,
+  ): Promise<RpcCallResult<T>> {
+    const configFallback = this.getConfigFallbackEndpoint();
+    const candidates = [
+      this.useKyberFallback ? this.kyberEndpoint : undefined,
+      configFallback,
+      this.getDefaultFallbackEndpoint(configFallback),
+    ].filter((endpoint): endpoint is string => !!endpoint);
 
-    for (let i = 0; i < this.endpoints.length; i++) {
-      const endpoint = this.getNextHealthyEndpoint();
-      if (!endpoint) break;
-
+    for (const endpoint of candidates) {
       try {
-        const result = await this.fetchBatchRpc<T>(endpoint, calls);
-        this.markEndpointHealthy(endpoint);
+        if (endpoint === this.kyberEndpoint) this.eventHandlers.onFallback?.(this.chainId, endpoint);
+        const result = await attempt(endpoint);
+        this.eventHandlers.onSuccess?.(this.chainId, endpoint, method, result.latencyMs);
         return result;
       } catch (error) {
         const err = error as Error;
-        this.eventHandlers.onError?.(this.chainId, endpoint, 'batch', err);
-
-        if (this.isRateLimitError(err)) {
-          this.markEndpointFailed(endpoint);
-          errors.push({ endpoint, error: err });
-          continue; // next endpoint
-        }
-
-        if (!this.isRetryableError(err)) {
-          throw err; // don't mark failed for non-retryable
-        }
-
-        this.markEndpointFailed(endpoint);
+        this.eventHandlers.onError?.(this.chainId, endpoint, method, err);
+        if (!this.isRetryableError(err) && !this.isRateLimitError(err)) throw err;
         errors.push({ endpoint, error: err });
       }
     }
 
-    return this.fallbackBatchCall<T>(calls, errors);
+    throw new AllEndpointsFailedError(this.chainId, errors);
   }
 
   /**
@@ -322,10 +374,9 @@ export class RpcClient {
     this.isProbing = true;
 
     try {
-      const probeTimeout = 5000;
       const results = await Promise.allSettled(
         this.endpoints.map(async endpoint => {
-          const result = await this.fetchRpc<string>(endpoint, 'eth_blockNumber', [], probeTimeout);
+          const result = await this.fetchRpc<string>(endpoint, 'eth_blockNumber', [], this.timeout);
           const block = parseInt(result.result, 16);
           if (!Number.isFinite(block)) throw new Error('Invalid block number');
           return { endpoint, block, latency: result.latencyMs };
@@ -420,166 +471,11 @@ export class RpcClient {
 
   // ─── Fallback chain ──────────────────────────────────────────────────
 
-  private async fallbackCall<T>(
-    method: string,
-    params: unknown[],
-    errors: Array<{ endpoint: string; error: Error }>,
-  ): Promise<T> {
-    // Fallback to Kyber RPC
-    if (this.useKyberFallback && this.kyberEndpoint) {
-      try {
-        this.eventHandlers.onFallback?.(this.chainId, this.kyberEndpoint);
-        const result = await this.fetchRpc<T>(this.kyberEndpoint, method, params);
-        this.eventHandlers.onSuccess?.(this.chainId, this.kyberEndpoint, method, result.latencyMs);
-        return result.result;
-      } catch (error) {
-        this.eventHandlers.onError?.(this.chainId, this.kyberEndpoint, method, error as Error);
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error; // Non-retryable (e.g. execution reverted), no point trying next fallback
-        }
-        errors.push({ endpoint: this.kyberEndpoint, error: error as Error });
-      }
-    }
-
-    // Fallback to config RPC (from ks-setting API)
-    const configFallback = this.getConfigFallbackEndpoint();
-    if (configFallback) {
-      try {
-        const result = await this.fetchRpc<T>(configFallback, method, params);
-        return result.result;
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: configFallback, error: error as Error });
-      }
-    }
-
-    // Final fallback to defaultRpc from NETWORKS_INFO
-    const defaultFallback = this.getDefaultFallbackEndpoint(configFallback);
-    if (defaultFallback) {
-      try {
-        const result = await this.fetchRpc<T>(defaultFallback, method, params);
-        return result.result;
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: defaultFallback, error: error as Error });
-      }
-    }
-
-    throw new AllEndpointsFailedError(this.chainId, errors);
-  }
-
-  private async fallbackCallWithMetadata<T>(
-    method: string,
-    params: unknown[],
-    errors: Array<{ endpoint: string; error: Error }>,
-  ): Promise<RpcCallResult<T>> {
-    if (this.useKyberFallback && this.kyberEndpoint) {
-      try {
-        this.eventHandlers.onFallback?.(this.chainId, this.kyberEndpoint);
-        const result = await this.fetchRpc<T>(this.kyberEndpoint, method, params);
-        this.eventHandlers.onSuccess?.(this.chainId, this.kyberEndpoint, method, result.latencyMs);
-        return result;
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: this.kyberEndpoint, error: error as Error });
-      }
-    }
-
-    const configFallback = this.getConfigFallbackEndpoint();
-    if (configFallback) {
-      try {
-        return await this.fetchRpc<T>(configFallback, method, params);
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: configFallback, error: error as Error });
-      }
-    }
-
-    const defaultFallback = this.getDefaultFallbackEndpoint(configFallback);
-    if (defaultFallback) {
-      try {
-        return await this.fetchRpc<T>(defaultFallback, method, params);
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: defaultFallback, error: error as Error });
-      }
-    }
-
-    throw new AllEndpointsFailedError(this.chainId, errors);
-  }
-
-  private async fallbackBatchCall<T extends unknown[]>(
-    calls: Array<{ method: string; params?: unknown[] }>,
-    errors: Array<{ endpoint: string; error: Error }>,
-  ): Promise<T> {
-    if (this.useKyberFallback && this.kyberEndpoint) {
-      try {
-        this.eventHandlers.onFallback?.(this.chainId, this.kyberEndpoint);
-        return await this.fetchBatchRpc<T>(this.kyberEndpoint, calls);
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: this.kyberEndpoint, error: error as Error });
-      }
-    }
-
-    const configFallback = this.getConfigFallbackEndpoint();
-    if (configFallback) {
-      try {
-        return await this.fetchBatchRpc<T>(configFallback, calls);
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: configFallback, error: error as Error });
-      }
-    }
-
-    const defaultFallback = this.getDefaultFallbackEndpoint(configFallback);
-    if (defaultFallback) {
-      try {
-        return await this.fetchBatchRpc<T>(defaultFallback, calls);
-      } catch (error) {
-        if (!this.isRetryableError(error as Error) && !this.isRateLimitError(error as Error)) {
-          throw error;
-        }
-        errors.push({ endpoint: defaultFallback, error: error as Error });
-      }
-    }
-
-    throw new AllEndpointsFailedError(this.chainId, errors);
-  }
-
   // ─── Fetch helpers ───────────────────────────────────────────────────
 
-  /**
-   * A request's budget. The abort is the polite cancel; the rejection is the guarantee. An
-   * environment that leaves an aborted fetch pending — a mobile in-app browser, a frozen tab — must
-   * not hold the call, and with it the rotation, for good; racing the fetch and the body read against
-   * `deadline` settles them regardless.
-   */
-  private deadlineFor(endpoint: string, method: string, timeoutMs: number) {
-    const controller = new AbortController();
-    let expire: (() => void) | undefined;
-    const deadline = new Promise<never>((_, reject) => {
-      expire = () => {
-        controller.abort();
-        reject(new RpcError(-1, buildRpcErrorMessage(endpoint, method, `Request timeout after ${timeoutMs}ms`)));
-      };
-    });
-    const timeoutId = setTimeout(() => expire?.(), timeoutMs);
-    return { controller, deadline, timeoutId };
+  /** A read's budget, or a slow method's. */
+  private budgetFor(method: string): number {
+    return SLOW_METHODS.has(method) ? Math.max(this.timeout, SLOW_METHOD_TIMEOUT_MS) : this.timeout;
   }
 
   private async fetchRpc<T>(
@@ -589,208 +485,95 @@ export class RpcClient {
     timeoutOverride?: number,
   ): Promise<RpcCallResult<T>> {
     const startTime = Date.now();
-    const effectiveTimeout = timeoutOverride ?? this.timeout;
-
-    const request: JsonRpcRequest = {
-      jsonrpc: '2.0',
-      id: this.requestId++,
+    const request: JsonRpcRequest = { jsonrpc: '2.0', id: this.requestId++, method, params };
+    const data = await postJsonRpc<JsonRpcResponse<T>>(
+      endpoint,
       method,
-      params,
-    };
+      request,
+      timeoutOverride ?? this.budgetFor(method),
+      this.headers,
+    );
 
-    const { controller, deadline, timeoutId } = this.deadlineFor(endpoint, method, effectiveTimeout);
-
-    try {
-      const response = await Promise.race([
-        fetch(endpoint, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...this.headers,
-          },
-          body: JSON.stringify(request),
-          signal: controller.signal,
-        }),
-        deadline,
-      ]);
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        if (response.status === 429 || response.status === 402) {
-          throw new RpcError(429, buildRpcErrorMessage(endpoint, method, 'Rate limit exceeded'));
-        }
-        if (response.status === 500 || response.status === 502 || response.status === 503 || response.status === 504) {
-          throw new RpcError(
-            response.status,
-            buildRpcErrorMessage(
-              endpoint,
-              method,
-              `Provider unavailable (HTTP ${response.status} ${response.statusText})`,
-            ),
-          );
-        }
-        throw new RpcError(
-          response.status,
-          buildRpcErrorMessage(endpoint, method, `HTTP error ${response.status} ${response.statusText}`),
-        );
-      }
-
-      const data = (await Promise.race([response.json(), deadline])) as JsonRpcResponse<T>;
-
-      if (data.error) {
-        const { code, message, data: errData } = normalizeRpcError(data.error);
-        throw new RpcError(
-          code,
-          buildRpcErrorMessage(endpoint, method, `JSON-RPC error ${code}: ${message}`, code),
-          errData,
-        );
-      }
-
-      if (data.result === undefined) {
-        throw new RpcError(-1, buildRpcErrorMessage(endpoint, method, 'No result in response'));
-      }
-
-      return {
-        result: data.result,
-        endpoint,
-        latencyMs: Date.now() - startTime,
-      };
-    } catch (error) {
-      clearTimeout(timeoutId);
-
-      if (error instanceof RpcError) {
-        throw error;
-      }
-
-      if ((error as Error).name === 'AbortError') {
-        throw new RpcError(-1, buildRpcErrorMessage(endpoint, method, `Request timeout after ${effectiveTimeout}ms`));
-      }
-
-      throw new RpcError(-1, buildRpcErrorMessage(endpoint, method, (error as Error).message || 'Network error'));
+    if (data.error) {
+      const { code, message, data: errData } = normalizeRpcError(data.error);
+      throw new RpcError(
+        code,
+        buildRpcErrorMessage(endpoint, method, `JSON-RPC error ${code}: ${message}`, code),
+        errData,
+        {
+          kind: 'rpc',
+          nodeMessage: message,
+        },
+      );
     }
+    if (data.result === undefined) {
+      throw new RpcError(-1, buildRpcErrorMessage(endpoint, method, 'No result in response'), undefined, {
+        kind: 'network',
+      });
+    }
+    return { result: data.result, endpoint, latencyMs: Date.now() - startTime };
   }
 
   private async fetchBatchRpc<T extends unknown[]>(
     endpoint: string,
     calls: Array<{ method: string; params?: unknown[] }>,
-  ): Promise<T> {
+  ): Promise<RpcCallResult<T>> {
+    const startTime = Date.now();
     const requests: JsonRpcRequest[] = calls.map((call, index) => ({
       jsonrpc: '2.0',
       id: index + 1,
       method: call.method,
       params: call.params ?? [],
     }));
+    const budget = Math.max(...calls.map(call => this.budgetFor(call.method)));
+    const data = await postJsonRpc<JsonRpcResponse[]>(endpoint, 'batch', requests, budget, this.headers);
 
-    const { controller, deadline, timeoutId } = this.deadlineFor(endpoint, 'batch', this.timeout);
-
-    try {
-      const response = await Promise.race([
-        fetch(endpoint, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...this.headers,
-          },
-          body: JSON.stringify(requests),
-          signal: controller.signal,
-        }),
-        deadline,
-      ]);
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        if (response.status === 429 || response.status === 402) {
-          throw new RpcError(429, buildRpcErrorMessage(endpoint, 'batch', 'Rate limit exceeded'));
-        }
-        if (response.status === 500 || response.status === 502 || response.status === 503 || response.status === 504) {
-          throw new RpcError(
-            response.status,
-            buildRpcErrorMessage(
-              endpoint,
-              'batch',
-              `Provider unavailable (HTTP ${response.status} ${response.statusText})`,
-            ),
-          );
-        }
+    // Sort by id to maintain order
+    const sortedData = [...data].sort((a, b) => Number(a.id) - Number(b.id));
+    const results: unknown[] = [];
+    for (const item of sortedData) {
+      if (item.error) {
+        // Requests are sent with 1-indexed numeric ids (see `requests` above), but
+        // a non-compliant provider could echo back a string or null id — guard
+        // against NaN/out-of-range lookups so we always surface the error even
+        // if the method tag falls back to "batch".
+        const rawId = Number(item.id);
+        const idx = Number.isFinite(rawId) ? rawId - 1 : -1;
+        const failedMethod = calls[idx]?.method ?? 'batch';
+        const { code, message, data: errData } = normalizeRpcError(item.error);
         throw new RpcError(
-          response.status,
-          buildRpcErrorMessage(endpoint, 'batch', `HTTP error ${response.status} ${response.statusText}`),
+          code,
+          buildRpcErrorMessage(endpoint, failedMethod, `JSON-RPC error ${code}: ${message}`, code),
+          errData,
+          { kind: 'rpc', nodeMessage: message },
         );
       }
-
-      const data = (await Promise.race([response.json(), deadline])) as JsonRpcResponse[];
-
-      // Sort by id to maintain order
-      const sortedData = [...data].sort((a, b) => Number(a.id) - Number(b.id));
-
-      const results: unknown[] = [];
-      for (const item of sortedData) {
-        if (item.error) {
-          // Requests are sent with 1-indexed numeric ids (see `requests` above), but
-          // a non-compliant provider could echo back a string or null id — guard
-          // against NaN/out-of-range lookups so we always surface the error even
-          // if the method tag falls back to "batch".
-          const rawId = Number(item.id);
-          const idx = Number.isFinite(rawId) ? rawId - 1 : -1;
-          const failedMethod = calls[idx]?.method ?? 'batch';
-          const { code, message, data: errData } = normalizeRpcError(item.error);
-          throw new RpcError(
-            code,
-            buildRpcErrorMessage(endpoint, failedMethod, `JSON-RPC error ${code}: ${message}`, code),
-            errData,
-          );
-        }
-        results.push(item.result);
-      }
-
-      return results as T;
-    } catch (error) {
-      clearTimeout(timeoutId);
-
-      if (error instanceof RpcError) {
-        throw error;
-      }
-
-      if ((error as Error).name === 'AbortError') {
-        throw new RpcError(-1, buildRpcErrorMessage(endpoint, 'batch', `Request timeout after ${this.timeout}ms`));
-      }
-
-      throw new RpcError(-1, buildRpcErrorMessage(endpoint, 'batch', (error as Error).message || 'Network error'));
+      results.push(item.result);
     }
+    return { result: results as T, endpoint, latencyMs: Date.now() - startTime };
   }
 
   // ─── Health tracking & rotation ────────────────────────────────────
 
-  private getNextHealthyEndpoint(): string | undefined {
+  /**
+   * The next endpoint in `order` that is not benched, advancing the shared rotation cursor; an
+   * endpoint whose cooldown has run out is welcomed back on the way. Undefined once every endpoint
+   * is benched — the caller decides what one more knock is worth.
+   */
+  private nextHealthy(order: string[]): string | undefined {
     const now = Date.now();
-    const startIndex = this.currentIndex;
-
-    // Try to find a healthy endpoint
-    do {
-      const endpoint = this.endpoints[this.currentIndex];
+    for (let step = 0; step < order.length; step++) {
+      const endpoint = order[this.currentIndex % order.length];
+      this.currentIndex = (this.currentIndex + 1) % order.length;
       const health = this.endpointHealth.get(endpoint);
-
-      // Check if endpoint has recovered from cooldown
-      if (health && !health.isHealthy && health.failedAt) {
-        if (now - health.failedAt >= this.endpointCooldownMs) {
-          health.isHealthy = true;
-          health.consecutiveFailures = 0;
-          health.failedAt = undefined;
-        }
+      if (health && !health.isHealthy && health.failedAt && now - health.failedAt >= this.endpointCooldownMs) {
+        health.isHealthy = true;
+        health.consecutiveFailures = 0;
+        health.failedAt = undefined;
       }
-
-      this.currentIndex = (this.currentIndex + 1) % this.endpoints.length;
-
-      if (health?.isHealthy) {
-        return endpoint;
-      }
-    } while (this.currentIndex !== startIndex);
-
-    // All endpoints are unhealthy, return the first one anyway
-    // (it might have recovered)
-    return this.endpoints[0];
+      if (health?.isHealthy) return endpoint;
+    }
+    return undefined;
   }
 
   /**
@@ -815,17 +598,9 @@ export class RpcClient {
 
     withLatency.sort((a, b) => a.latency - b.latency);
 
-    // Rebuild endpoints array in-place
-    let idx = 0;
-    for (const item of withLatency) {
-      this.endpoints[idx++] = item.endpoint;
-    }
-    for (const ep of withoutLatency) {
-      this.endpoints[idx++] = ep;
-    }
-
-    // Don't reset currentIndex — an in-progress call() loop may be mid-rotation.
-    // The new order will be picked up naturally on the next rotation cycle.
+    // A new array, not a reorder in place: a walk in progress holds the old one and finishes over
+    // it; the next walk picks this one up. The cursor carries across, which is all round-robin needs.
+    this.endpoints = [...withLatency.map(item => item.endpoint), ...withoutLatency];
   }
 
   private markEndpointFailed(endpoint: string): void {
@@ -852,6 +627,7 @@ export class RpcClient {
 
   private isRateLimitError(error: Error): boolean {
     if (error instanceof RpcError) {
+      if (error.kind === 'http' && (error.code === 429 || error.code === 402)) return true;
       // JSON-RPC error codes that indicate rate limiting / quota
       const rateLimitCodes = [
         429, // Non-standard but widely used (Alchemy, QuickNode, GetBlock)
@@ -887,25 +663,17 @@ export class RpcClient {
     // instead of the actual revert.
     if (/execution reverted/i.test(error.message)) return false;
     if (error instanceof RpcError) {
-      // Retryable RPC error codes (non-deterministic server-side errors).
-      // HTTP 4xx codes here cover provider-side quirks (e.g. drpc.org returning
-      // 400 for soft throttling or payload rejection) — true deterministic errors
-      // like execution-reverted come back as HTTP 200 with a JSON-RPC error code,
-      // not via this path.
+      // Anything but the node answering is the endpoint failing — an HTTP status of any kind, a
+      // timeout, a dropped connection — and says nothing about the request; another endpoint may
+      // well answer it. A geo-block's 403 or a body cap's 413 is as much this endpoint's problem
+      // as a 503.
+      if (error.kind !== 'rpc') return true;
+      // Of the node's own answers, these are the non-deterministic ones.
       const retryableCodes = [
         -32000, // Server error
         -32601, // Method not found — this endpoint lacks the method; another may serve it
         -32602, // Invalid params — some gateways reject requests the canonical nodes accept
         -32603, // Internal error
-        -1, // Timeout
-        400, // Bad request (provider quirk, e.g. drpc soft-throttle)
-        408, // Request timeout
-        409, // Conflict
-        425, // Too early
-        500, // Internal server error
-        502, // Bad gateway
-        503, // Service unavailable
-        504, // Gateway timeout
       ];
       return retryableCodes.includes(error.code);
     }
@@ -941,20 +709,19 @@ export class RpcClient {
   }
 }
 
-// One instance per chain and scope, so callers share health tracking within a scope.
-const clientInstances: Map<string, RpcClient> = new Map();
+// One instance per chain, so every caller on it shares the health tracking.
+const clientInstances: Map<number, RpcClient> = new Map();
 
 /**
  * Get or create the RpcClient for a chain.
  *
- * Instances are shared per chain within a `scope`, so callers on the same chain pool their health
- * tracking. Configuration is applied when an instance is first created; a caller that needs its own
- * settings — a different endpoint list, timeout or telemetry — asks for its own scope rather than
- * depending on being first. `configRpcEndpoint` is the one setting applied to an existing instance.
+ * Most configuration is applied when the instance is created; `configRpcEndpoint` and
+ * `maxBlockLag` are applied to an existing instance too, so a caller can set them without
+ * depending on being the first to ask.
  *
  * @param chainId - The chain ID to get client for
- * @param config - Optional configuration; see `RpcClientConfig.scope`
- * @returns RpcClient instance for the chain and scope
+ * @param config - Optional configuration
+ * @returns RpcClient instance for the chain
  *
  * @example
  * ```typescript
@@ -963,13 +730,13 @@ const clientInstances: Map<string, RpcClient> = new Map();
  * ```
  */
 export function getRpcClient(chainId: number, config?: Partial<RpcClientConfig>): RpcClient {
-  const key = `${chainId}:${config?.scope ?? 'default'}`;
-  let client = clientInstances.get(key);
+  let client = clientInstances.get(chainId);
   if (!client) {
     client = new RpcClient({ chainId, ...config });
-    clientInstances.set(key, client);
-  } else if (config?.configRpcEndpoint) {
-    client.updateConfigEndpoint(config.configRpcEndpoint);
+    clientInstances.set(chainId, client);
+  } else {
+    if (config?.configRpcEndpoint) client.updateConfigEndpoint(config.configRpcEndpoint);
+    if (config?.maxBlockLag !== undefined) client.maxBlockLag = config.maxBlockLag;
   }
 
   return client;

--- a/packages/rpc-client/src/fetch.ts
+++ b/packages/rpc-client/src/fetch.ts
@@ -1,4 +1,4 @@
-import { buildRpcErrorMessage, getRpcClient } from './client';
+import { buildRpcErrorMessage, getRpcClient, postJsonRpc } from './client';
 import { JsonRpcResponse, RpcClientConfig, RpcError } from './types';
 
 /**
@@ -97,7 +97,8 @@ export async function rpcBatchFetch<T extends unknown[]>(
 
 /**
  * Direct RPC fetch without rotation (for when you have a specific URL).
- * Still includes timeout and error handling.
+ * Still includes timeout and error handling. With nowhere to rotate to, the budget is a generous
+ * one: cutting a lone endpoint short only turns a slow answer into no answer.
  */
 async function fetchDirectRpc<T>(
   rpcUrl: string,
@@ -105,66 +106,26 @@ async function fetchDirectRpc<T>(
   params: unknown[],
   timeout: number = 10000,
 ): Promise<T> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
-
-  try {
-    const response = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method,
-        params,
-      }),
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      throw new RpcError(
-        response.status,
-        buildRpcErrorMessage(rpcUrl, method, `HTTP error ${response.status} ${response.statusText}`),
-      );
-    }
-
-    const data = (await response.json()) as JsonRpcResponse<T>;
-
-    if (data.error) {
-      throw new RpcError(
-        data.error.code,
-        buildRpcErrorMessage(
-          rpcUrl,
-          method,
-          `JSON-RPC error ${data.error.code}: ${data.error.message}`,
-          data.error.code,
-        ),
-        data.error.data,
-      );
-    }
-
-    if (data.result === undefined) {
-      throw new RpcError(-1, buildRpcErrorMessage(rpcUrl, method, 'No result in response'));
-    }
-
-    return data.result;
-  } catch (error) {
-    clearTimeout(timeoutId);
-
-    if (error instanceof RpcError) {
-      throw error;
-    }
-
-    if ((error as Error).name === 'AbortError') {
-      throw new RpcError(-1, buildRpcErrorMessage(rpcUrl, method, `Request timeout after ${timeout}ms`));
-    }
-
-    throw new RpcError(-1, buildRpcErrorMessage(rpcUrl, method, (error as Error).message || 'Network error'));
+  const data = await postJsonRpc<JsonRpcResponse<T>>(
+    rpcUrl,
+    method,
+    { jsonrpc: '2.0', id: 1, method, params },
+    timeout,
+  );
+  if (data.error) {
+    throw new RpcError(
+      data.error.code,
+      buildRpcErrorMessage(rpcUrl, method, `JSON-RPC error ${data.error.code}: ${data.error.message}`, data.error.code),
+      data.error.data,
+      { kind: 'rpc', nodeMessage: data.error.message },
+    );
   }
+  if (data.result === undefined) {
+    throw new RpcError(-1, buildRpcErrorMessage(rpcUrl, method, 'No result in response'), undefined, {
+      kind: 'network',
+    });
+  }
+  return data.result;
 }
 
 // ============================================================================

--- a/packages/rpc-client/src/index.ts
+++ b/packages/rpc-client/src/index.ts
@@ -35,5 +35,6 @@ export type {
   RpcEventHandlers,
   EndpointHealth,
   RpcCallResult,
+  RpcErrorKind,
 } from './types';
 export { AllEndpointsFailedError, RpcError } from './types';

--- a/packages/rpc-client/src/types.ts
+++ b/packages/rpc-client/src/types.ts
@@ -96,7 +96,10 @@ export interface RpcClientConfig {
   /** Event handlers for telemetry and monitoring */
   eventHandlers?: RpcEventHandlers;
 
-  /** Max block lag allowed before marking an endpoint as stale (default: 50) */
+  /**
+   * Blocks an endpoint may trail the freshest one before it is benched as stale (default: 50).
+   * `getRpcClient` applies it to an existing instance too, so the value is not first-caller's.
+   */
   maxBlockLag?: number;
 
   /**
@@ -104,13 +107,6 @@ export interface RpcClientConfig {
    * Probing starts with the first call and stops after five minutes without one. Set to 0 to disable.
    */
   probeIntervalMs?: number;
-
-  /**
-   * Which shared instance `getRpcClient` returns for the chain (default: 'default'). Callers on the
-   * same chain and scope share one instance and its health tracking; a caller that needs its own
-   * configuration names its own scope, so it does not depend on being the first to ask.
-   */
-  scope?: string;
 }
 
 /**
@@ -153,15 +149,30 @@ export class AllEndpointsFailedError extends Error {
 }
 
 /**
- * Error thrown when RPC returns an error response
+ * Where an RPC failure came from. Only `rpc` is the node answering — with a JSON-RPC error whose
+ * `code` and `data` are the node's own; the rest are the endpoint failing to answer, and mean
+ * nothing about the request.
+ */
+export type RpcErrorKind = 'rpc' | 'http' | 'timeout' | 'network';
+
+/**
+ * Error thrown when a request fails. `message` is composed for logs and tags infrastructure
+ * failures with the endpoint; `nodeMessage` is the node's own text when the node answered, which is
+ * what a caller matching on it (a revert reason, viem's decoder) needs untouched.
  */
 export class RpcError extends Error {
+  readonly kind: RpcErrorKind;
+  readonly nodeMessage?: string;
+
   constructor(
     public readonly code: number,
     message: string,
     public readonly data?: unknown,
+    options: { kind?: RpcErrorKind; nodeMessage?: string } = {},
   ) {
     super(message);
     this.name = 'RpcError';
+    this.kind = options.kind ?? 'rpc';
+    this.nodeMessage = options.nodeMessage;
   }
 }

--- a/packages/rpc-client/src/types.ts
+++ b/packages/rpc-client/src/types.ts
@@ -81,7 +81,7 @@ export interface RpcClientConfig {
   /** Whether to use Kyber RPC as fallback (default: true) */
   useKyberFallback?: boolean;
 
-  /** Request timeout in milliseconds (default: 10000) */
+  /** Time one endpoint gets to answer before rotation moves on, in milliseconds (default: 3000) */
   timeout?: number;
 
   /** Maximum retries per endpoint before moving to next (default: 1) */
@@ -99,8 +99,18 @@ export interface RpcClientConfig {
   /** Max block lag allowed before marking an endpoint as stale (default: 50) */
   maxBlockLag?: number;
 
-  /** Interval in ms between background block freshness probes (default: 60000). Set to 0 to disable. */
+  /**
+   * Interval in ms between block freshness probes while the client is in use (default: 60000).
+   * Probing starts with the first call and stops after five minutes without one. Set to 0 to disable.
+   */
   probeIntervalMs?: number;
+
+  /**
+   * Which shared instance `getRpcClient` returns for the chain (default: 'default'). Callers on the
+   * same chain and scope share one instance and its health tracking; a caller that needs its own
+   * configuration names its own scope, so it does not depend on being the first to ask.
+   */
+  scope?: string;
 }
 
 /**


### PR DESCRIPTION
## Why

Users on rate-limited or slow RPC saw balances load for tens of seconds. viem's `fallback()` rotates, but it has no memory: a rate-limited or hanging endpoint is paid for on every call, and the KyberSwap endpoint sits first for every one of them. `@kyber/rpc-client` — the client the widgets already read through — remembers which endpoints failed, benches them for a cooldown, ranks by measured latency, and tries the public endpoints before the KyberSwap one, which is the intended order: the public ones are free, the KyberSwap one is paid for.

This makes the client fit for the app and puts Base on it.

## What changes

**Package (`@kyber/rpc-client`)**

- Probing follows traffic: constructing a client sends nothing; the loop starts with the first call and stops after five minutes without one. A client nobody destroys no longer keeps a timer for the life of the page.
- One HTTP layer (`postJsonRpc`) with a real budget: the fetch and the body read both race a rejecting deadline, and the timer lives until the body is parsed. An endpoint that sends headers and then stalls, or an environment that leaves an aborted fetch pending, cannot hold the call.
- Every failure carries `RpcError.kind` — `rpc` when the node answered, else `http` / `timeout` / `network` — and `nodeMessage`, the node's own words. Anything but the node answering rotates; a geo-block's 403 or a body cap's 413 is treated like a 503. Only the node's own codes are classified as deterministic.
- One pass over the endpoints, then the last resorts (`walk` + `lastResorts` replace six near-identical methods). The pass walks a snapshot, so a re-ranking landing mid-pass cannot make it revisit or skip an endpoint; with every endpoint benched it knocks on one and moves on rather than once per slot.
- Budgets: reads 3 s per hop; `eth_estimateGas` 10 s, since the node searches for the limit; the probe uses the read budget so it cannot bless an endpoint that fails every real call.
- One client per chain, shared by every caller on it; `getRpcClient` applies `configRpcEndpoint` and `maxBlockLag` to an existing instance, so nothing depends on who asked first. The client owns a copy of any endpoint list it is given.

**App**

- `rpcClientTransport(chainId)`: viem `custom()` over the client for chains in `RPC_CLIENT_CHAINS` (Base to start; adding a chain is the whole rollout for it). `retryCount: 0`, since the client rotates on its own. The node answering becomes `RpcRequestError` with the node's code, data and untouched message, which is what viem's revert decoder needs; the endpoint failing becomes `HttpRequestError`.
- The app names its chain's `defaultRpcUrl` as the last resort and a lag budget of 15 blocks on Base (about half a minute), since consecutive reads land on different nodes.
- `sendTransaction`'s pre-sign timeout goes: it only ever applied when that call happened to create the instance, and the client owns per-method budgets now.

## Trade-offs, on purpose

- Public-first is a cost decision. Base loses the JSON-RPC batching the KyberSwap-first transport had, and the token-list balance sweep fans out across free endpoints (about five `eth_call` POSTs per poll). Worth watching once live; batching through the client's `batchCall` is a possible follow-up.
- Round-robin means consecutive reads may hit different nodes; the lag budget bounds how stale one may be.
- Under a full outage TanStack's default retries multiply a walk over the whole list. A per-call budget would cap that, at the cost of reaching the KyberSwap endpoint sooner.

## Before merging

The branch predates #3373 and #3374, both now merged, so it needs main merged in — the `transports` block in `Web3Provider` is the only overlap.