### PR TITLE
feat(wallet-inventory): serve Robinhood and HyperEVM

### DIFF
--- a/packages/hooks/src/wallet-inventory-client.ts
+++ b/packages/hooks/src/wallet-inventory-client.ts
@@ -1,13 +1,25 @@
 import { ChainId } from '@kyber/schema';
 
+/** Chain id not in `@kyber/schema`, whose enum backs the widget schemas rather than this list. */
+const HYPEREVM = 999;
+
 /**
  * Chains the inventory is allowed to serve. A release gate as much as a list: the service may index
  * a chain ahead of time for testing, and nothing here reads it until this list says so. A chain the
  * service reports as unsupported is additionally disabled for the session (see
  * `isWalletInventoryChain`), so the list drifting ahead of the backend degrades to the caller's own
  * balance source rather than failing. Both the app and the widget packages read this one list.
+ *
+ * Plain chain ids, since a chain reaches this list whether or not the widget schema names it.
  */
-export const WALLET_INVENTORY_CHAINS: ChainId[] = [ChainId.Ethereum, ChainId.Base, ChainId.Bsc, ChainId.Arbitrum];
+export const WALLET_INVENTORY_CHAINS: number[] = [
+  ChainId.Ethereum,
+  ChainId.Base,
+  ChainId.Bsc,
+  ChainId.Arbitrum,
+  ChainId.Robinhood,
+  HYPEREVM,
+];
 
 /** The service answered that it does not index this chain. */
 export class UnsupportedChainError extends Error {


### PR DESCRIPTION
## What changes

Robinhood (4663) and HyperEVM (999) join the chains the wallet inventory may be asked about. One file: `WALLET_INVENTORY_CHAINS` in `@kyber/hooks`, which both the app and the widget selectors read. Both chains are served by the balances service, native row included, which is what the inventory's trust check compares against the chain before it serves a wallet's balances at all.

The list is typed `number[]` now, with `HYPEREVM = 999` declared beside it. `@kyber/schema`'s enum names Robinhood but not HyperEVM, and that enum feeds `z.nativeEnum(ChainId)` validating widget payloads, so widening it to suit an allowlist would touch every schema validated against it; `packages/rpc-client/src/endpoints.ts` declares its own ids for the same reason.

Nothing else changes: `isWalletInventoryChain` takes a `number` and compares numbers, and no consumer indexes a `Record<ChainId, …>` with this list. `@kyber/hooks` is consumed as source, so there is no build step.

The list is a release gate — merging serves both chains in production.