### PR TITLE
fix(limit-order): refine rate section layout and shared inversion

### DIFF
--- a/apps/kyberswap-interface/src/components/LimitOrder/Form/LimitOrderForm.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/Form/LimitOrderForm.tsx
@@ -14,7 +14,6 @@ import {
   LimitOrderOutputTokenPanel,
   type LimitOrderTokenPanelProps,
 } from 'components/LimitOrder/Form/LimitOrderTokenSection'
-import MarketPrice from 'components/LimitOrder/Form/MarketPrice'
 import { useLimitOrderFormState } from 'components/LimitOrder/Form/useLimitOrderFormState'
 import { NetworkSelector } from 'components/NetworkSelector'
 import { HStack, Stack } from 'components/Stack'
@@ -182,6 +181,7 @@ const LimitOrderForm = ({ currencyIn: currencyInProp, currencyOut: currencyOutPr
               displayRate: form.displayRate,
               rateInfo: form.rateInfo,
               tradeInfo: form.tradeInfo,
+              loadingTrade: form.loadingTrade,
             }}
             events={{
               onRateChange: form.onChangeRate,
@@ -196,21 +196,7 @@ const LimitOrderForm = ({ currencyIn: currencyInProp, currencyOut: currencyOutPr
             }}
           />
 
-          <HStack className="items-center justify-between gap-3">
-            <HStack className="min-w-0 items-center gap-2 text-sm text-subText">
-              <span className="shrink-0 italic">
-                <Trans>Market Price</Trans>
-              </span>
-              <div className="min-w-0">
-                <MarketPrice
-                  price={form.tradeInfo}
-                  loading={form.loadingTrade}
-                  symbolIn={currencyIn?.symbol}
-                  symbolOut={currencyOut?.symbol}
-                  className="italic"
-                />
-              </div>
-            </HStack>
+          <HStack className="-my-1 justify-center">
             <ReverseTokenSelectionButton className="size-6 bg-buttonGray p-0.5" onClick={form.handleRotateClick} />
           </HStack>
 

--- a/apps/kyberswap-interface/src/components/LimitOrder/Form/LimitOrderRateSection.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/Form/LimitOrderRateSection.tsx
@@ -3,8 +3,8 @@ import { Trans, t } from '@lingui/macro'
 import { useEffect, useMemo, useState } from 'react'
 import { Repeat } from 'react-feather'
 
-import CurrencyLogo from 'components/CurrencyLogo'
 import InfoHelper from 'components/InfoHelper'
+import MarketPrice from 'components/LimitOrder/Form/MarketPrice'
 import { DeltaRateLimitOrder, RateInfo } from 'components/LimitOrder/types'
 import { formatPriceInputValue, removeTrailingZero } from 'components/LimitOrder/utils'
 import NumericalInput from 'components/NumericalInput'
@@ -50,12 +50,10 @@ export const useGetDeltaRateLimitOrder = ({
 }
 
 type DeltaRateProps = {
-  symbol?: string
   deltaRate: DeltaRateLimitOrder
-  showInvertedRate: boolean
 }
 
-const DeltaRate = ({ symbol, deltaRate, showInvertedRate }: DeltaRateProps) => {
+const DeltaRate = ({ deltaRate }: DeltaRateProps) => {
   const theme = useTheme()
   const { percent, profit } = deltaRate
   const color = profit ? theme.apr : theme.warning
@@ -64,7 +62,7 @@ const DeltaRate = ({ symbol, deltaRate, showInvertedRate }: DeltaRateProps) => {
 
   return (
     <div className="flex items-center whitespace-nowrap text-sm font-medium text-subText">
-      {showInvertedRate ? <Trans>Buy {symbol} at rate</Trans> : <Trans>Sell {symbol} at rate</Trans>}
+      <Trans>Rate</Trans>
       {percent ? (
         <InfoHelper
           color={color}
@@ -171,6 +169,7 @@ type RateSectionState = {
   displayRate?: string
   rateInfo?: RateInfo
   tradeInfo?: BaseTradeInfo
+  loadingTrade?: boolean
 }
 
 type RateSectionEvents = {
@@ -190,7 +189,7 @@ type Props = {
 
 const LimitOrderRateSection = ({ tokens = {}, rate = {}, events = {} }: Props) => {
   const { currencyIn, currencyOut } = tokens
-  const { displayRate = '', rateInfo = DEFAULT_RATE_INFO, tradeInfo } = rate
+  const { displayRate = '', rateInfo = DEFAULT_RATE_INFO, tradeInfo, loadingTrade } = rate
   const [showInvertedRate, setShowInvertedRate] = useState(false)
 
   const deltaRate = useGetDeltaRateLimitOrder({ marketPrice: tradeInfo, rateInfo })
@@ -239,17 +238,25 @@ const LimitOrderRateSection = ({ tokens = {}, rate = {}, events = {} }: Props) =
 
   return (
     <Stack className="gap-2 rounded-2xl bg-buttonBlack p-4">
-      <HStack className="items-center justify-between gap-3">
-        <DeltaRate symbol={baseCurrency?.symbol} deltaRate={deltaRate} showInvertedRate={showInvertedRate} />
-        {tradeInfo ? (
+      <HStack className="min-h-7 items-center justify-between gap-3">
+        <DeltaRate deltaRate={deltaRate} />
+        <HStack className="min-w-0 items-center justify-end gap-2">
           <button
             type="button"
-            className="shrink-0 text-sm font-medium text-primary transition hover:brightness-90"
+            className="shrink-0 rounded-lg bg-primary/10 px-2 py-1 text-sm font-medium text-primary transition enabled:hover:brightness-90 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!tradeInfo || loadingTrade}
             onClick={events.onSetMarketRate}
           >
             <Trans>Market</Trans>
           </button>
-        ) : null}
+          <MarketPrice
+            price={tradeInfo}
+            loading={loadingTrade}
+            showInverted={showInvertedRate}
+            symbolIn={currencyIn?.symbol}
+            symbolOut={currencyOut?.symbol}
+          />
+        </HStack>
       </HStack>
 
       <HStack className="min-h-8 min-w-0 items-center gap-2">
@@ -264,11 +271,10 @@ const LimitOrderRateSection = ({ tokens = {}, rate = {}, events = {} }: Props) =
             onBlur={events.onRateInputBlur}
           />
         </div>
-        {quoteCurrency && (
+        {quoteCurrency && baseCurrency && (
           <HStack className="min-w-0 shrink-0 items-center gap-1.5">
-            <CurrencyLogo currency={quoteCurrency} size="20px" />
-            <span className="max-w-[92px] shrink-0 truncate text-lg font-medium text-subText">
-              {quoteCurrency.symbol}
+            <span className="max-w-[160px] shrink-0 truncate text-lg font-medium text-subText">
+              {quoteCurrency.symbol}/{baseCurrency.symbol}
             </span>
             <button
               type="button"

--- a/apps/kyberswap-interface/src/components/LimitOrder/Form/MarketPrice.tsx
+++ b/apps/kyberswap-interface/src/components/LimitOrder/Form/MarketPrice.tsx
@@ -14,10 +14,19 @@ type MarketPriceProps = {
   symbolIn?: string
   symbolOut?: string
   className?: string
+  showInverted?: boolean
 }
 
-const MarketPrice = ({ price, loading, symbolIn, symbolOut, className }: MarketPriceProps) => {
-  const [showInverted, setShowInverted] = useState(false)
+const MarketPrice = ({
+  price,
+  loading,
+  symbolIn,
+  symbolOut,
+  className,
+  showInverted: controlledShowInverted,
+}: MarketPriceProps) => {
+  const [internalShowInverted, setInternalShowInverted] = useState(false)
+  const showInverted = controlledShowInverted ?? internalShowInverted
   const formattedPrice = price
     ? formatDisplayNumber(showInverted ? price.invertRate : price.marketRate, { significantDigits: 6 })
     : undefined
@@ -36,18 +45,24 @@ const MarketPrice = ({ price, loading, symbolIn, symbolOut, className }: MarketP
     )
   }
 
+  const priceLabel = (
+    <span className={cn('min-w-0 truncate text-sm font-medium text-text', className)}>
+      {showInverted
+        ? `1 ${symbolOut} = ${formattedPrice} ${symbolIn}`
+        : `1 ${symbolIn} = ${formattedPrice} ${symbolOut}`}
+    </span>
+  )
+
+  if (controlledShowInverted !== undefined) return priceLabel
+
   return (
     <HStack
       as="button"
       type="button"
       className="min-w-0 max-w-full items-center gap-2 hover:brightness-75"
-      onClick={() => setShowInverted(showInverted => !showInverted)}
+      onClick={() => setInternalShowInverted(value => !value)}
     >
-      <span className={cn('min-w-0 truncate text-sm font-medium text-text', className)}>
-        {showInverted
-          ? `1 ${symbolOut} = ${formattedPrice} ${symbolIn}`
-          : `1 ${symbolIn} = ${formattedPrice} ${symbolOut}`}
-      </span>
+      {priceLabel}
       <Repeat size={14} className="text-subText" />
     </HStack>
   )


### PR DESCRIPTION
## Summary
- Move market price beside the styled Market button, simplify the Rate label, and display the token pair without logos.
- Share the rate inversion control with market price and center the token swap button.
- Keep the Market button visible and disabled while loading to stabilize the rate section layout.
