### PR TITLE
fix(token-selector): wait for the wallet's own answer, and let the service vouch for it

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -1,4 +1,4 @@
-import { ChainId, Currency, Token, WETH } from '@kyberswap/ks-sdk-core'
+import { ChainId, Currency, CurrencyAmount, Token, WETH } from '@kyberswap/ks-sdk-core'
 import { Trans, t } from '@lingui/macro'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { motion, useAnimationControls, useReducedMotion } from 'framer-motion'
@@ -509,17 +509,25 @@ export const TokenSelectorContent = ({
     [showDiscoveries, balanceTokens, discoveryTokens],
   )
 
-  // The multicall answers until the inventory can. Its cost is one sweep per open, ended the moment a
-  // walk lands; what the inventory saves is the per-block repeat of that sweep, which is the expensive
-  // part. A wallet is walked page by page, and no screen waits on that to show a balance.
-  const multicallTokens = inventory.active ? EMPTY_TOKENS : balanceTokensWithDiscoveries
+  // The multicall answers only once the inventory has said it cannot. While the first walk is in
+  // flight the list waits for it: a wallet is one request, and sweeping the whole whitelist in the
+  // meantime would run the very thing this layer removes and throw it away a moment later.
+  const multicallTokens = inventory.active || inventory.pending ? EMPTY_TOKENS : balanceTokensWithDiscoveries
   const multicallBalances = useTokenBalances(multicallTokens, primaryChainId)
   const inventoryBalances = useInventoryTokenBalances(balanceTokensWithDiscoveries, inventory)
   const balances = inventory.active ? inventoryBalances : multicallBalances
   // Whichever source answers, a balance it never delivers stops reading as "loading": every new map
   // restarts the wait, so a source still working keeps its rows on a loader and a stalled one does not.
   const waitingForBalances = useBalanceWait(balances, !!account)
-  const nativeBalance = useNativeBalance(primaryChainId)
+  const liveNativeBalance = useNativeBalance(primaryChainId)
+  // The chain read is fresher and wins, but the walk already carries a native balance and the row
+  // shows that until the read lands, so nothing in the list waits on RPC.
+  const nativeBalance = useMemo(() => {
+    if (liveNativeBalance) return liveNativeBalance
+    const row = inventory.rows[ETHER_ADDRESS]
+    const native = NativeCurrencies[primaryChainId] as Currency | undefined
+    return row && native ? CurrencyAmount.fromRawAmount(native, row.rawBalance.toString()) : undefined
+  }, [liveNativeBalance, inventory.rows, primaryChainId])
 
   // Only the All (default order) and Imported tabs sort by wallet value; gate the comparator so the
   // rest never register its /prices fetch.

--- a/apps/kyberswap-interface/src/components/WalletPopup/MyAssets.tsx
+++ b/apps/kyberswap-interface/src/components/WalletPopup/MyAssets.tsx
@@ -38,6 +38,7 @@ export default function MyAssets({
   loadingTokens,
   usdBalances,
   currencyBalances,
+  inventoryNativeBalance,
   hasNetworkIssue,
   hideBalance,
   hiddenTokens,
@@ -48,6 +49,8 @@ export default function MyAssets({
   hasNetworkIssue: boolean
   usdBalances: { [address: string]: number }
   currencyBalances: { [address: string]: TokenAmount | undefined }
+  /** The native balance the inventory holds; shown until the chain's own read lands. */
+  inventoryNativeBalance?: CurrencyAmount<Currency>
   hideBalance: boolean
   /** Held tokens that are neither whitelisted nor imported; listed after the vetted ones, not totalled. */
   hiddenTokens: WrappedTokenInfo[]
@@ -78,7 +81,9 @@ export default function MyAssets({
   useEnsureTokenMetadata(chainId, visibleHidden)
   const [importTarget, setImportTarget] = useState<Token | null>(null)
   const closeImport = () => setImportTarget(null)
-  const nativeBalance = useNativeBalance()
+  const liveNativeBalance = useNativeBalance()
+  // The chain read is fresher and wins; until it lands the row shows what the walk carried.
+  const nativeBalance = liveNativeBalance ?? inventoryNativeBalance
   // The native row is displayed off the live per-block read; bound the wait so a read that never
   // lands leaves the row reading as unknown rather than on a loader for good.
   const waitingForNative = useBalanceWait(nativeBalance, !!account)

--- a/apps/kyberswap-interface/src/components/WalletPopup/WalletView.tsx
+++ b/apps/kyberswap-interface/src/components/WalletPopup/WalletView.tsx
@@ -68,6 +68,7 @@ export default function WalletView({
     usdBalances,
     hiddenTokens,
     impersonators,
+    nativeBalance: inventoryNativeBalance,
   } = useWalletAssets()
 
   const [hasNetworkIssue, setHasNetworkIssue] = useState(false)
@@ -178,6 +179,7 @@ export default function WalletView({
               currencyBalances={currencyBalances}
               hiddenTokens={hiddenTokens}
               impersonators={impersonators}
+              inventoryNativeBalance={inventoryNativeBalance}
             />
           </div>
         )

--- a/apps/kyberswap-interface/src/components/WalletPopup/hooks/useWalletAssets.ts
+++ b/apps/kyberswap-interface/src/components/WalletPopup/hooks/useWalletAssets.ts
@@ -37,9 +37,9 @@ export type WalletAssets = {
 export const useWalletAssets = (): WalletAssets => {
   const { chainId } = useActiveWeb3React()
   const inventory = useWalletInventory()
-  // The multicall hook answers until the inventory can. A wallet is walked page by page, and the
-  // popup shows balances from the first read rather than from the end of that walk.
-  const legacy = useTokensHasBalance(true, !inventory.active)
+  // The multicall hook answers only once the inventory has said it cannot; while the first walk is in
+  // flight the popup waits for it rather than sweeping the whole whitelist behind it.
+  const legacy = useTokensHasBalance(true, !inventory.active && !inventory.pending)
 
   const defaultTokens = useAllTokens()
   const tokenImports = useUserAddedTokens()

--- a/apps/kyberswap-interface/src/components/WalletPopup/hooks/useWalletAssets.ts
+++ b/apps/kyberswap-interface/src/components/WalletPopup/hooks/useWalletAssets.ts
@@ -1,6 +1,8 @@
-import { Currency, TokenAmount } from '@kyberswap/ks-sdk-core'
+import { Currency, CurrencyAmount, TokenAmount } from '@kyberswap/ks-sdk-core'
 import { useMemo } from 'react'
 
+import { ETHER_ADDRESS } from 'constants/index'
+import { NativeCurrencies } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 import { useAllTokens } from 'hooks/useTokens'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
@@ -17,6 +19,8 @@ const EMPTY_HIDDEN: WrappedTokenInfo[] = []
 
 export type WalletAssets = {
   loading: boolean
+  /** The native balance the inventory holds, for the row to show until a fresher read lands. */
+  nativeBalance?: CurrencyAmount<Currency>
   /** Vetted holdings (whitelisted or imported), highest USD value first. */
   currencies: Currency[]
   currencyBalances: { [address: string]: TokenAmount | undefined }
@@ -95,11 +99,15 @@ export const useWalletAssets = (): WalletAssets => {
         impersonators: EMPTY_DISCOVERIES.impersonators,
       }
     }
+    const nativeRow = inventory.rows[ETHER_ADDRESS]
+    const native = NativeCurrencies[chainId] as Currency | undefined
     return {
       loading: !tokenListReady,
       currencies: ranked.currencies,
       currencyBalances: holdings.currencyBalances,
       usdBalances: prices,
+      nativeBalance:
+        nativeRow && native ? CurrencyAmount.fromRawAmount(native, nativeRow.rawBalance.toString()) : undefined,
       // Null while prices are still on their way, so the header keeps its placeholder instead of
       // printing $0 and then jumping.
       totalBalanceInUsd: pricesLoading && holdings.vetted.length ? null : ranked.totalBalanceInUsd,
@@ -108,6 +116,8 @@ export const useWalletAssets = (): WalletAssets => {
     }
   }, [
     inventory.active,
+    inventory.rows,
+    chainId,
     tokenListReady,
     pricesLoading,
     legacyLoading,

--- a/apps/kyberswap-interface/src/services/walletInventory.ts
+++ b/apps/kyberswap-interface/src/services/walletInventory.ts
@@ -1,4 +1,11 @@
-import { InventoryRawRow, UnsupportedChainError, parseRawAmount, walkWalletInventory } from '@kyber/hooks'
+import {
+  InventoryRawRow,
+  UnsupportedChainError,
+  judgeInventory,
+  parseRawAmount,
+  readLiveNative,
+  walkWalletInventory,
+} from '@kyber/hooks'
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import { z } from 'zod'
 
@@ -34,6 +41,10 @@ export type WalletInventoryResult = {
    * moment it asked for one.
    */
   blockNumber: number
+  /** Whether the index itself listed the native currency; see `judgeInventory`. */
+  nativeIndexed: boolean
+  /** The node's native balance as read by the service, when it was asked for and answered. */
+  nativeLive?: bigint
 }
 
 // Metadata is omitted per row for tokens the catalog does not know, so all of it is optional.
@@ -91,6 +102,8 @@ export const fetchWalletInventory = async ({
     rows: raw,
     complete,
     indexedBlock,
+    nativeIndexed,
+    nativeLive,
   } = await walkWalletInventory({
     baseUrl: KD_API_URL,
     chainId,
@@ -106,5 +119,40 @@ export const fetchWalletInventory = async ({
     if (row) rows.push(row)
   })
 
-  return { rows, complete, blockNumber: indexedBlock }
+  return { rows, complete, blockNumber: indexedBlock, nativeIndexed, nativeLive }
+}
+
+/**
+ * The node's native balance for the wallet, read by the service: the one request that settles what
+ * an answer without a native row means. Undefined when the service did not answer.
+ */
+export const readNativeBalance = async ({
+  chainId,
+  account,
+  signal,
+}: {
+  chainId: ChainId
+  account: string
+  signal?: AbortSignal
+}): Promise<bigint | undefined> => {
+  if (!KD_API_URL) return undefined
+  return readLiveNative({ baseUrl: KD_API_URL, chainId, account, signal })
+}
+
+/**
+ * A walk, plus the node's word on native where the index was silent about it: the one request that
+ * settles what such an answer means, made only for such answers. A walk made while a watch is on
+ * carries that word already, and the index carries it for most wallets most of the time. A read the
+ * service does not answer leaves the answer as it was, which the resolver reads as not to be relied on.
+ */
+export const fetchWalletInventoryJudged = async (args: {
+  chainId: ChainId
+  account: string
+  signal?: AbortSignal
+  liveAddrs?: readonly string[]
+}): Promise<WalletInventoryResult> => {
+  const result = await fetchWalletInventory(args)
+  if (judgeInventory(result) !== 'unknown') return result
+  const nativeLive = await readNativeBalance(args).catch(() => undefined)
+  return { ...result, nativeLive }
 }

--- a/apps/kyberswap-interface/src/state/transactions/updater.tsx
+++ b/apps/kyberswap-interface/src/state/transactions/updater.tsx
@@ -8,7 +8,6 @@ import { usePublicClient } from 'wagmi'
 
 import { NotificationType } from 'components/Announcement/type'
 import { CONNECTION } from 'components/Web3Provider'
-import { ETHER_ADDRESS } from 'constants/index'
 import { useActiveWeb3React, useWeb3React } from 'hooks'
 import useTracking, { NEED_CHECK_SUBGRAPH_TRANSACTION_TYPES, TRACKING_EVENT_TYPE } from 'hooks/useTracking'
 import { AppDispatch, AppState } from 'state'
@@ -121,7 +120,7 @@ const touchedTokens = (chainId: ChainId, extraInfo: TransactionExtraInfo | undef
   const info = extraInfo as { tokenAddress?: string; tokenAddressIn?: string; tokenAddressOut?: string } | undefined
   return [info?.tokenAddress, info?.tokenAddressIn, info?.tokenAddressOut].flatMap(address => {
     const checksummed = address ? isAddress(chainId, address) : false
-    return checksummed && checksummed !== ETHER_ADDRESS ? [checksummed] : []
+    return checksummed ? [checksummed] : []
   })
 }
 

--- a/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/hooks.ts
@@ -2,7 +2,6 @@ import { ChainId, Token, TokenAmount } from '@kyberswap/ks-sdk-core'
 import { useEffect, useMemo, useSyncExternalStore } from 'react'
 
 import { useActiveWeb3React } from 'hooks'
-import { useNativeBalance } from 'state/wallet/hooks'
 import {
   TokenMetadata,
   ensureTokenMetadata,
@@ -49,11 +48,7 @@ export const useWalletInventory = (chainId?: ChainId, enabled = true): WalletInv
   const entry = useMemo(() => (key ? readEntry(key) : undefined), [key, storeVersion])
   /* eslint-enable react-hooks/exhaustive-deps */
 
-  // Read live per block. Identity changes every block even when the value does not, so the resolver is
-  // keyed on the value to avoid rebuilding rows for a balance that did not move.
-  const nativeRawBalance = useNativeBalance(resolvedChain)?.quotient.toString()
-
-  return useMemo(() => resolveInventory(entry, subscribed, nativeRawBalance), [entry, subscribed, nativeRawBalance])
+  return useMemo(() => resolveInventory(entry, subscribed), [entry, subscribed])
 }
 
 /**

--- a/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
@@ -1,7 +1,7 @@
+import { judgeInventory } from '@kyber/hooks'
 import { Token, TokenAmount } from '@kyberswap/ks-sdk-core'
 import { InventoryRow } from 'services/walletInventory'
 
-import { ETHER_ADDRESS } from 'constants/index'
 import { InventoryEntry } from 'state/walletInventory/store'
 
 /**
@@ -38,20 +38,12 @@ const PENDING_INVENTORY: WalletInventory = { rows: EMPTY_ROWS, active: false, pe
 /**
  * Turns a store entry into what consumers should read.
  *
- * `nativeRawBalance` is the live per-block native balance (undefined while its first read is still in
- * flight). The service lists every non-zero holding, the native currency included, so an answer
- * without a native row is complete only for a wallet that holds none — and the chain is what says so.
- * The same read then supplies the native balance itself, which the index lags and users watch most
- * closely.
- *
- * Anything this cannot vouch for reads as inactive rather than as a half-answer: the caller has its
- * own balance source and reads it, which is what keeps a screen from waiting on this one.
+ * The walk itself says whether the answer can be relied on — see `judgeInventory` — and the sweep
+ * has already asked the service for the node's word where the index was silent about native, so
+ * nothing here waits on a read of its own. Anything not relied on reads as inactive rather than as a
+ * half-answer: the caller has its own balance source and reads it.
  */
-export const resolveInventory = (
-  entry: InventoryEntry | undefined,
-  subscribed: boolean,
-  nativeRawBalance?: string,
-): WalletInventory => {
+export const resolveInventory = (entry: InventoryEntry | undefined, subscribed: boolean): WalletInventory => {
   if (!subscribed) return INACTIVE_INVENTORY
   // The first walk is on its way; a failed one commits an entry, so this does not outlast it.
   if (!entry) return PENDING_INVENTORY
@@ -60,33 +52,15 @@ export const resolveInventory = (
   // list, which is most of what the selector renders — multicall answers those in one block instead.
   if (entry.status !== 'settled') return INACTIVE_INVENTORY
 
-  const held = withoutTombstones(entry.rows)
-  const nativeRead = nativeRawBalance !== undefined ? BigInt(nativeRawBalance) : undefined
-  const nativeRow = held[ETHER_ADDRESS]
+  // A wallet the node says is funded while the index lists no native is missing at least one
+  // holding; one the node says holds none is complete as listed. Decided by what the walk brought
+  // back, never waited on.
+  if (judgeInventory(entry) !== 'trusted') return INACTIVE_INVENTORY
 
-  // No native row means either a wallet that holds none or one the index has not covered — the two
-  // are the same answer here, and only the chain tells them apart. That is decided now, not waited
-  // for: without the chain's word the answer is not relied on, and if the read arrives saying the
-  // wallet holds no native, the next render trusts it. Nothing on screen waits on that read.
-  if (!nativeRow && (nativeRead === undefined || nativeRead > 0n)) return INACTIVE_INVENTORY
-
-  // The chain owns the native balance: the index lags it, and it is the number users watch most
-  // closely. Read as zero, the wallet holds none — a max-send just mined must not keep showing the
-  // index's pre-transaction amount, and a token held at zero is a token absent from the rows.
-  const rows =
-    nativeRead === undefined || !nativeRow
-      ? held
-      : nativeRead === 0n
-      ? withoutNative(held)
-      : { ...held, [ETHER_ADDRESS]: { ...nativeRow, rawBalance: nativeRead } }
-
-  return { rows, active: true, pending: false }
-}
-
-const withoutNative = (rows: Record<string, InventoryRow>): Record<string, InventoryRow> => {
-  const next = { ...rows }
-  delete next[ETHER_ADDRESS]
-  return next
+  // Live reads are merged into the rows at the head block, so a native balance read live — after a
+  // transaction of the user's own — already outranks the index's amount, and one read as zero is a
+  // tombstone the reader never sees.
+  return { rows: withoutTombstones(entry.rows), active: true, pending: false }
 }
 
 /**

--- a/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/resolve.ts
@@ -21,11 +21,19 @@ export type WalletInventory = {
    * caller reads its own source instead.
    */
   active: boolean
+  /**
+   * No answer yet, but one is on its way: the first walk for this wallet is in flight. A caller waits
+   * rather than starting the whole-list sweep this layer exists to remove — a wallet is one request
+   * and the walk carries its own deadline, so the wait is short and bounded. Every other way of not
+   * being `active` is a decision already made, and the caller reads its own source at once.
+   */
+  pending: boolean
 }
 
-// Module constant, not built per call: a caller sees it on every render until a walk lands, and a
-// fresh object would ripple a new balance map (and a list re-sort) out of every one of them.
-export const INACTIVE_INVENTORY: WalletInventory = { rows: EMPTY_ROWS, active: false }
+// Module constants, not built per call: a caller sees one of these on every render until a walk
+// lands, and a fresh object would ripple a new balance map (and a list re-sort) out of every one.
+export const INACTIVE_INVENTORY: WalletInventory = { rows: EMPTY_ROWS, active: false, pending: false }
+const PENDING_INVENTORY: WalletInventory = { rows: EMPTY_ROWS, active: false, pending: true }
 
 /**
  * Turns a store entry into what consumers should read.
@@ -45,7 +53,8 @@ export const resolveInventory = (
   nativeRawBalance?: string,
 ): WalletInventory => {
   if (!subscribed) return INACTIVE_INVENTORY
-  if (!entry) return INACTIVE_INVENTORY
+  // The first walk is on its way; a failed one commits an entry, so this does not outlast it.
+  if (!entry) return PENDING_INVENTORY
   if (entry.status === 'error') return INACTIVE_INVENTORY
   // A partial walk (wallet larger than the page cap) is not authoritative about anything it did not
   // list, which is most of what the selector renders — multicall answers those in one block instead.
@@ -56,8 +65,9 @@ export const resolveInventory = (
   const nativeRow = held[ETHER_ADDRESS]
 
   // No native row means either a wallet that holds none or one the index has not covered — the two
-  // are the same answer here, and only the chain tells them apart. Until it does, or if it says the
-  // wallet is funded, this answer is missing at least one holding and is not relied on.
+  // are the same answer here, and only the chain tells them apart. That is decided now, not waited
+  // for: without the chain's word the answer is not relied on, and if the read arrives saying the
+  // wallet holds no native, the next render trusts it. Nothing on screen waits on that read.
   if (!nativeRow && (nativeRead === undefined || nativeRead > 0n)) return INACTIVE_INVENTORY
 
   // The chain owns the native balance: the index lags it, and it is the number users watch most
@@ -70,7 +80,7 @@ export const resolveInventory = (
       ? withoutNative(held)
       : { ...held, [ETHER_ADDRESS]: { ...nativeRow, rawBalance: nativeRead } }
 
-  return { rows, active: true }
+  return { rows, active: true, pending: false }
 }
 
 const withoutNative = (rows: Record<string, InventoryRow>): Record<string, InventoryRow> => {

--- a/apps/kyberswap-interface/src/state/walletInventory/store.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/store.ts
@@ -40,6 +40,9 @@ export type InventoryEntry = {
   /** How far this inventory has caught up to the chain. */
   blockNumber: number
   fetchedAt: number
+  /** Whether the index listed the native currency, and what the node said if it was asked. */
+  nativeIndexed: boolean
+  nativeLive?: bigint
 }
 
 type Meta = {
@@ -235,6 +238,8 @@ export const commitResult = (key: string, result: WalletInventoryResult) => {
   if (previous && previous.status === status && rowsEqual(previous.rows, rows)) {
     previous.fetchedAt = now
     previous.blockNumber = Math.max(result.blockNumber, previous.blockNumber)
+    previous.nativeIndexed = result.nativeIndexed
+    previous.nativeLive = result.nativeLive
     meta.set(key, { ...meta.get(key), failures: 0, nextRetryAt: 0, forced: false })
     return
   }
@@ -244,6 +249,8 @@ export const commitResult = (key: string, result: WalletInventoryResult) => {
     status,
     blockNumber: Math.max(result.blockNumber, previous?.blockNumber ?? 0),
     fetchedAt: now,
+    nativeIndexed: result.nativeIndexed,
+    nativeLive: result.nativeLive,
   })
   meta.set(key, { ...meta.get(key), failures: 0, nextRetryAt: 0, forced: false })
   emit()
@@ -265,7 +272,7 @@ export const commitFailure = (key: string) => {
   // nothing at all is marked failed, which is what tells consumers to use the multicall path.
   const entry = entries.get(key)
   if (!entry) {
-    entries.set(key, { rows: EMPTY_ROWS, status: 'error', blockNumber: 0, fetchedAt: 0 })
+    entries.set(key, { rows: EMPTY_ROWS, status: 'error', blockNumber: 0, fetchedAt: 0, nativeIndexed: false })
   }
   emit()
 }

--- a/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
+++ b/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
@@ -1,6 +1,6 @@
 import { ChainId } from '@kyberswap/ks-sdk-core'
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
-import { UnsupportedChainError, fetchWalletInventory } from 'services/walletInventory'
+import { UnsupportedChainError, fetchWalletInventoryJudged } from 'services/walletInventory'
 
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { INVENTORY_CATCHUP_INTERVAL_MS, INVENTORY_TTL_MS } from 'state/walletInventory/constants'
@@ -113,7 +113,7 @@ export default function Updater(): null {
           // Tokens a just-confirmed transaction moved are asked for as live reads, so the answer
           // carries their balance at the head block instead of the indexer's lagging one.
           const liveAddrs = readTouchedTokens(key, Date.now())
-          commitResult(key, await fetchWalletInventory({ chainId, account, signal, liveAddrs }))
+          commitResult(key, await fetchWalletInventoryJudged({ chainId, account, signal, liveAddrs }))
         } catch (error) {
           // An unindexed chain is a permanent answer, not a transient failure: disable it for the
           // session so consumers settle on the multicall path instead of retrying forever.

--- a/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
@@ -1,6 +1,13 @@
-import { UnsupportedChainError, isChainUnsupported, walkWalletInventory } from '@kyber/hooks'
+import {
+  NATIVE_SENTINEL,
+  UnsupportedChainError,
+  isChainUnsupported,
+  judgeInventory,
+  readLiveNative,
+  walkWalletInventory,
+} from '@kyber/hooks'
 import { ChainId, Token, TokenAmount } from '@kyberswap/ks-sdk-core'
-import { InventoryRow, adaptRow, parseRawAmount } from 'services/walletInventory'
+import { InventoryRow, adaptRow, fetchWalletInventoryJudged, parseRawAmount } from 'services/walletInventory'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getTokenComparator, mergeHeldSearchResults } from 'components/TokenSelectorModal/utils'
@@ -140,6 +147,101 @@ describe('walkWalletInventory deadline', () => {
     )
     await vi.advanceTimersByTimeAsync(9_000)
     expect(await outcome).toBe('rejected')
+  })
+})
+
+describe('judgeInventory', () => {
+  it('trusts an answer whose index lists the native currency, whatever the node said', () => {
+    expect(judgeInventory({ nativeIndexed: true })).toBe('trusted')
+    expect(judgeInventory({ nativeIndexed: true, nativeLive: 0n })).toBe('trusted')
+  })
+
+  it('cannot judge an answer without a native row until the node has spoken', () => {
+    expect(judgeInventory({ nativeIndexed: false })).toBe('unknown')
+  })
+
+  it('reads the node saying funded as the index missing a holding, and zero as the wallet holding none', () => {
+    expect(judgeInventory({ nativeIndexed: false, nativeLive: 1n })).toBe('distrusted')
+    expect(judgeInventory({ nativeIndexed: false, nativeLive: 0n })).toBe('trusted')
+  })
+})
+
+describe('the native currency through the service', () => {
+  const raw = (tokenAddress: string, rawAmount: string, blockNumber: number) => ({
+    tokenAddress,
+    rawAmount,
+    blockNumber,
+    decimals: 18,
+    symbol: 'TKN',
+  })
+  type Page = { balances: ReturnType<typeof raw>[]; liveBalances: ReturnType<typeof raw>[] }
+  /** Stubs the service with a page per URL and hands back the mock, so requests can be counted. */
+  const stub = (page: (url: string) => Page) => {
+    const fetchMock = vi.fn(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: 0, data: page(url) }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('walks report whether the index listed native, and what the node said when asked', async () => {
+    stub(url => ({
+      balances: [raw(USDT_CHECKSUM, '0x5', 100)],
+      liveBalances: url.includes('liveAddrs') ? [raw(NATIVE_SENTINEL, '0x7', 500)] : [],
+    }))
+    const silent = await walkWalletInventory({ baseUrl: 'http://kd', chainId: 1, account: ACCOUNT })
+    expect(silent.nativeIndexed).toBe(false)
+    expect(silent.nativeLive).toBeUndefined()
+
+    const asked = await walkWalletInventory({
+      baseUrl: 'http://kd',
+      chainId: 1,
+      account: ACCOUNT,
+      liveAddrs: [NATIVE_SENTINEL],
+    })
+    expect(asked.nativeIndexed).toBe(false)
+    expect(asked.nativeLive).toBe(7n)
+  })
+
+  it('reads the node in one request for the smallest page, even for a wallet the index never saw', async () => {
+    const fetchMock = stub(() => ({ balances: [], liveBalances: [raw(NATIVE_SENTINEL, '0x', 500)] }))
+    await expect(readLiveNative({ baseUrl: 'http://kd', chainId: 1, account: ACCOUNT })).resolves.toBe(0n)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const url = String(fetchMock.mock.calls[0][0])
+    expect(url).toContain('limit=1')
+    expect(url).toContain(`liveAddrs=${NATIVE_SENTINEL}`)
+  })
+
+  it('answers undefined when the service did not read the node', async () => {
+    stub(() => ({ balances: [], liveBalances: [] }))
+    await expect(readLiveNative({ baseUrl: 'http://kd', chainId: 1, account: ACCOUNT })).resolves.toBeUndefined()
+  })
+
+  it("asks for the node's word only when the index was silent about native", async () => {
+    const silent = stub(url => ({
+      balances: url.includes('liveAddrs') ? [] : [raw(USDT_CHECKSUM, '0x5', 100)],
+      liveBalances: url.includes('liveAddrs') ? [raw(NATIVE_SENTINEL, '0x9', 500)] : [],
+    }))
+    const judged = await fetchWalletInventoryJudged({ chainId: ChainId.MAINNET, account: ACCOUNT })
+    expect(judged.nativeIndexed).toBe(false)
+    expect(judged.nativeLive).toBe(9n)
+    expect(judgeInventory(judged)).toBe('distrusted')
+    // The walk, then the one extra request.
+    expect(silent).toHaveBeenCalledTimes(2)
+
+    const listed = stub(() => ({
+      balances: [raw(NATIVE_SENTINEL, '0x3', 100), raw(USDT_CHECKSUM, '0x5', 100)],
+      liveBalances: [],
+    }))
+    const trusted = await fetchWalletInventoryJudged({ chainId: ChainId.MAINNET, account: ACCOUNT })
+    expect(trusted.nativeIndexed).toBe(true)
+    expect(judgeInventory(trusted)).toBe('trusted')
+    expect(listed).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -305,30 +407,30 @@ describe('adaptRow', () => {
 
 describe('store commits', () => {
   it('marks a complete walk settled so absence can be read as zero', () => {
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expect(readEntry(KEY)?.status).toBe('settled')
   })
 
   it('records a capped walk as partial, which consumers read as "use multicall"', () => {
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 7n, 110)], complete: false, blockNumber: 110 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 7n, 110)], complete: false, nativeIndexed: true, blockNumber: 110 })
     expect(readEntry(KEY)?.status).toBe('partial')
-    expect(resolveInventory(readEntry(KEY), true, '7').active).toBe(false)
+    expect(resolveInventory(readEntry(KEY), true).active).toBe(false)
   })
 
   it('never moves a token backwards in block terms', () => {
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 200)], complete: true, blockNumber: 200 })
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 3n, 150)], complete: true, blockNumber: 150 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 200)], complete: true, nativeIndexed: true, blockNumber: 200 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 3n, 150)], complete: true, nativeIndexed: true, blockNumber: 150 })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM]?.rawBalance).toBe(9n)
   })
 
   it('keeps the entry reference and wakes no subscribers when a poll returns unchanged data', () => {
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     const before = readEntry(KEY)
     const versionBefore = getStoreVersion()
 
     // The steady-state 30s poll: same balances, only the walk's high-water block advanced. A new
     // entry object here would cascade into a full re-sort of the token list on every tick.
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 130 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 130 })
 
     expect(readEntry(KEY)).toBe(before)
     expect(readEntry(KEY)?.rows).toBe(before?.rows)
@@ -338,11 +440,11 @@ describe('store commits', () => {
   })
 
   it('still emits and replaces the entry when a balance actually moves', () => {
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     const before = readEntry(KEY)
     const versionBefore = getStoreVersion()
 
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 130)], complete: true, blockNumber: 130 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 130)], complete: true, nativeIndexed: true, blockNumber: 130 })
 
     expect(readEntry(KEY)).not.toBe(before)
     expect(getStoreVersion()).toBeGreaterThan(versionBefore)
@@ -351,15 +453,15 @@ describe('store commits', () => {
 
   it('ends a catch-up watch when the indexer passes the block without any balance change', () => {
     // An approve: the transaction confirms at block 120 but moves no token balance.
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expireInventory(ChainId.MAINNET, ACCOUNT, 120)
 
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 125 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 125 })
     expect(isCatchingUp(KEY, Date.now())).toBe(false)
   })
 
   it('serves stale data after a failure instead of blanking the screen', () => {
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     commitFailure(KEY)
 
     const entry = readEntry(KEY)
@@ -382,6 +484,7 @@ describe('live reads across walks', () => {
     commitResult(KEY, {
       rows: [row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 0n, 500)],
       complete: true,
+      nativeIndexed: true,
       blockNumber: 95,
     })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM].rawBalance).toBe(0n)
@@ -389,19 +492,25 @@ describe('live reads across walks', () => {
     commitResult(KEY, {
       rows: [row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 5n, 95)],
       complete: true,
+      nativeIndexed: true,
       blockNumber: 95,
     })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM].rawBalance).toBe(0n)
-    expect(resolveInventory(readEntry(KEY), true, '10').rows[USDT_CHECKSUM]).toBeUndefined()
+    expect(resolveInventory(readEntry(KEY), true).rows[USDT_CHECKSUM]).toBeUndefined()
     // Once the index has passed the block the zero was read at, its silence about USDT is authoritative.
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 600)], complete: true, blockNumber: 600 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 600)], complete: true, nativeIndexed: true, blockNumber: 600 })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM]).toBeUndefined()
   })
 
   it('carries a token first seen live forward until the index lists it', () => {
     register(ChainId.MAINNET, ACCOUNT)
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 90), row(DAI, 7n, 500)], complete: true, blockNumber: 95 })
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 90)], complete: true, blockNumber: 96 })
+    commitResult(KEY, {
+      rows: [row(ETHER_ADDRESS, 10n, 90), row(DAI, 7n, 500)],
+      complete: true,
+      nativeIndexed: true,
+      blockNumber: 95,
+    })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 90)], complete: true, nativeIndexed: true, blockNumber: 96 })
     expect(readEntry(KEY)?.rows[DAI].rawBalance).toBe(7n)
   })
 
@@ -410,25 +519,26 @@ describe('live reads across walks', () => {
     commitResult(KEY, {
       rows: [{ ...row(USDT_CHECKSUM, 5n, 100), decimals: 6, symbol: 'USDT' }],
       complete: true,
+      nativeIndexed: true,
       blockNumber: 100,
     })
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 500)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 500)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM]).toMatchObject({ rawBalance: 9n, decimals: 6, symbol: 'USDT' })
   })
 
   it('does not wake subscribers when only the block stamp of a live row moved', () => {
     register(ChainId.MAINNET, ACCOUNT)
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 500)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 500)], complete: true, nativeIndexed: true, blockNumber: 100 })
     const before = getStoreVersion()
     const entry = readEntry(KEY)
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 505)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 9n, 505)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expect(getStoreVersion()).toBe(before)
     expect(readEntry(KEY)).toBe(entry)
   })
 
   it('reads live for the whole window when the receipt carries no block, as for a Safe', () => {
     register(ChainId.MAINNET, ACCOUNT)
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expireInventory(ChainId.MAINNET, ACCOUNT, undefined, [USDT_CHECKSUM])
     const now = Date.now()
     expect(isCatchingUp(KEY, now)).toBe(true)
@@ -438,10 +548,10 @@ describe('live reads across walks', () => {
 
   it('starts a fresh token list once the previous watch has retired', () => {
     register(ChainId.MAINNET, ACCOUNT)
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expireInventory(ChainId.MAINNET, ACCOUNT, 110, [USDT_CHECKSUM])
     // The index reaches the block: the watch retires and its tokens go with it.
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 120)], complete: true, blockNumber: 120 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 120)], complete: true, nativeIndexed: true, blockNumber: 120 })
     expireInventory(ChainId.MAINNET, ACCOUNT, 130, [DAI])
     expect(readTouchedTokens(KEY, Date.now())).toEqual([DAI])
   })
@@ -449,31 +559,31 @@ describe('live reads across walks', () => {
 
 describe('post-transaction catch-up', () => {
   it('keeps the watch alive across commits fetched inside the indexer lag', () => {
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expireInventory(ChainId.MAINNET, ACCOUNT, 120)
 
     // Indexer still behind the transaction: the result commits (it matches what is on screen, so it
     // repaints nothing), but the watch must survive it, or catch-up would stop at the first stale poll.
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 110)], complete: true, blockNumber: 110 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 110)], complete: true, nativeIndexed: true, blockNumber: 110 })
     expect(readEntry(KEY)?.blockNumber).toBe(110)
     expect(isCatchingUp(KEY, Date.now())).toBe(true)
 
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 2n, 125)], complete: true, blockNumber: 125 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 2n, 125)], complete: true, nativeIndexed: true, blockNumber: 125 })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM]?.rawBalance).toBe(2n)
     expect(isCatchingUp(KEY, Date.now())).toBe(false)
   })
 
   it('never lets a stale in-flight walk overwrite a fresher committed balance', () => {
     // Two walks resolve out of order around a swap: the post-swap result lands first.
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 2n, 125)], complete: true, blockNumber: 125 })
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 110)], complete: true, blockNumber: 110 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 2n, 125)], complete: true, nativeIndexed: true, blockNumber: 125 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 110)], complete: true, nativeIndexed: true, blockNumber: 110 })
     expect(readEntry(KEY)?.rows[USDT_CHECKSUM]?.rawBalance).toBe(2n)
   })
 
   it('names the tokens a watched transaction moved, until the inventory catches up', () => {
     const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
     register(ChainId.MAINNET, ACCOUNT)
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expireInventory(ChainId.MAINNET, ACCOUNT, 120, [USDT_CHECKSUM])
     const first = readTouchedTokens(KEY, Date.now())
     expect(first).toEqual([USDT_CHECKSUM])
@@ -483,7 +593,7 @@ describe('post-transaction catch-up', () => {
     expireInventory(ChainId.MAINNET, ACCOUNT, 122, [DAI])
     expect(readTouchedTokens(KEY, Date.now())).toBe(readTouchedTokens(KEY, Date.now()))
     // Once a walk lands at or past the transaction's block, nothing is read live any more.
-    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 125)], complete: true, blockNumber: 125 })
+    commitResult(KEY, { rows: [row(ETHER_ADDRESS, 10n, 125)], complete: true, nativeIndexed: true, blockNumber: 125 })
     expect(readTouchedTokens(KEY, Date.now())).toEqual([])
   })
 
@@ -496,14 +606,14 @@ describe('post-transaction catch-up', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
     register(ChainId.MAINNET, ACCOUNT)
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expireInventory(ChainId.MAINNET, ACCOUNT, 120)
 
     // Forced: the first fetch fires immediately.
     expect(selectDue(1_000_000, true)).toHaveLength(1)
     // The stale result commits, advancing fetchedAt; the very next sweep must NOT refire —
     // this is the regression guard against the refuse-and-refetch tight loop.
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 105 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 105 })
     expect(selectDue(Date.now() + 50, true)).toHaveLength(0)
     // After the catch-up interval it fires again — and only while the tab is visible.
     const later = Date.now() + INVENTORY_CATCHUP_INTERVAL_MS + 1
@@ -515,7 +625,7 @@ describe('post-transaction catch-up', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
     register(ChainId.MAINNET, ACCOUNT)
-    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, nativeIndexed: true, blockNumber: 100 })
     expireInventory(ChainId.MAINNET, ACCOUNT, 120)
     commitFailure(KEY)
 
@@ -525,11 +635,17 @@ describe('post-transaction catch-up', () => {
 })
 
 describe('resolveInventory', () => {
-  const entry = (rows: InventoryRow[], status: InventoryEntry['status']): InventoryEntry => ({
+  const entry = (
+    rows: InventoryRow[],
+    status: InventoryEntry['status'],
+    native: { indexed?: boolean; live?: bigint } = {},
+  ): InventoryEntry => ({
     rows: Object.fromEntries(rows.map(r => [r.address, r])),
     status,
     blockNumber: 100,
     fetchedAt: 1,
+    nativeIndexed: native.indexed ?? rows.some(r => r.address === ETHER_ADDRESS),
+    nativeLive: native.live,
   })
 
   it('stays inactive without a subscription', () => {
@@ -545,9 +661,9 @@ describe('resolveInventory', () => {
   it('drops pending once a walk has answered, whatever the answer', () => {
     // Every other way of not being active is a decision already made; only the first walk is a wait.
     expect(resolveInventory({ ...entry([], 'error'), status: 'error' as const }, true).pending).toBe(false)
-    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'partial'), true, '1000').pending).toBe(false)
-    // Settled but missing a native row while the chain read is still out: decided now, not waited on.
-    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled'), true, undefined).pending).toBe(false)
+    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'partial'), true).pending).toBe(false)
+    // Settled without a native row and without the node's word: decided now, not waited on.
+    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled'), true).pending).toBe(false)
   })
 
   it('stays inactive after a fetch fails', () => {
@@ -556,45 +672,51 @@ describe('resolveInventory', () => {
   })
 
   it('hands a partial inventory back to multicall — a capped walk is not authoritative', () => {
-    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'partial'), true, '1000').active).toBe(false)
+    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'partial', { live: 0n }), true).active).toBe(false)
   })
 
-  it('does not answer for a wallet the chain says holds native the index has not listed', () => {
+  it('does not answer for a wallet the node says holds native the index has not listed', () => {
     // The service lists every non-zero holding, native included, so this answer is missing at least
     // one of them — and what it leaves out elsewhere cannot be told from what the wallet does not hold.
-    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled'), true, '1000').active).toBe(false)
-    expect(resolveInventory(entry([], 'settled'), true, '1000').active).toBe(false)
+    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled', { live: 1000n }), true).active).toBe(false)
+    expect(resolveInventory(entry([], 'settled', { live: 1000n }), true).active).toBe(false)
   })
 
-  it('does not answer until the chain has said what a missing native row means', () => {
-    // The read is still on its way: the same answer fits a wallet holding no native and one the
-    // index has not covered, and the caller keeps reading its own source until they can be told apart.
-    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled'), true, undefined).active).toBe(false)
-    expect(resolveInventory(entry([], 'settled'), true, undefined).active).toBe(false)
+  it('does not answer while nothing has said what a missing native row means', () => {
+    // The sweep asks the service for the node's word before committing; an entry without it is one
+    // the service did not answer for, and the caller keeps reading its own source.
+    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled'), true).active).toBe(false)
+    expect(resolveInventory(entry([], 'settled'), true).active).toBe(false)
   })
 
-  it('answers for a wallet holding no native currency, listed or empty', () => {
-    const withTokens = resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled'), true, '0')
+  it('answers for a wallet the node says holds no native, listed or empty', () => {
+    const withTokens = resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled', { live: 0n }), true)
     expect(withTokens.active).toBe(true)
     expect(withTokens.rows[USDT_CHECKSUM].rawBalance).toBe(5n)
-    expect(resolveInventory(entry([], 'settled'), true, '0').active).toBe(true)
+    expect(resolveInventory(entry([], 'settled', { live: 0n }), true).active).toBe(true)
   })
 
-  it('answers with the indexed native row while the chain read is still on its way', () => {
-    const resolved = resolveInventory(entry([row(ETHER_ADDRESS, 5n, 100)], 'settled'), true, undefined)
+  it('answers on the strength of an indexed native row alone', () => {
+    const resolved = resolveInventory(entry([row(ETHER_ADDRESS, 5n, 100)], 'settled'), true)
     expect(resolved.active).toBe(true)
     expect(resolved.rows[ETHER_ADDRESS].rawBalance).toBe(5n)
   })
 
-  it('overlays the live native balance over the indexed one', () => {
-    const resolved = resolveInventory(entry([row(ETHER_ADDRESS, 5n, 100)], 'settled'), true, '999')
+  it('serves a native balance read live at the head over the indexed one', () => {
+    // The walk merges live reads at the head block, so the row already carries the fresher amount.
+    const resolved = resolveInventory(
+      entry([row(ETHER_ADDRESS, 999n, 500)], 'settled', { indexed: true, live: 999n }),
+      true,
+    )
     expect(resolved.rows[ETHER_ADDRESS].rawBalance).toBe(999n)
   })
 
-  it('drops the native row on a live read of zero — a drained wallet must not show its stale amount', () => {
-    // Max-send just mined: the chain says 0 while the index still reports the old 5. A token held at
-    // zero is a token the wallet does not hold, so the row goes rather than reading back as zero.
-    const resolved = resolveInventory(entry([row(ETHER_ADDRESS, 5n, 100)], 'settled'), true, '0')
+  it('hides a native balance read live as zero — a drained wallet must not show its stale amount', () => {
+    // Max-send just mined: the live read at the head is a zero row, a tombstone the reader never sees.
+    const resolved = resolveInventory(
+      entry([row(ETHER_ADDRESS, 0n, 500)], 'settled', { indexed: true, live: 0n }),
+      true,
+    )
     expect(resolved.rows[ETHER_ADDRESS]).toBeUndefined()
     expect(resolved.active).toBe(true)
   })
@@ -606,14 +728,15 @@ describe('resolveInventory tombstones', () => {
     status: 'settled',
     blockNumber: 100,
     fetchedAt: 1,
+    nativeIndexed: true,
   })
 
   it('hides a zero row from readers, and hands back the same rows object when there is none', () => {
     const clean = entry([row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 5n, 100)])
-    expect(resolveInventory(clean, true, undefined).rows).toBe(clean.rows)
+    expect(resolveInventory(clean, true).rows).toBe(clean.rows)
 
     const withTombstone = entry([row(ETHER_ADDRESS, 10n, 90), row(USDT_CHECKSUM, 0n, 500)])
-    const resolved = resolveInventory(withTombstone, true, '10')
+    const resolved = resolveInventory(withTombstone, true)
     expect(resolved.rows[USDT_CHECKSUM]).toBeUndefined()
     expect(resolved.active).toBe(true)
   })
@@ -1075,7 +1198,7 @@ describe('selectDue', () => {
     register(ChainId.MAINNET, ACCOUNT)
     vi.useFakeTimers()
     vi.setSystemTime(now)
-    commitResult(KEY, { rows: [], complete: true, blockNumber: 100 })
+    commitResult(KEY, { rows: [], complete: true, nativeIndexed: true, blockNumber: 100 })
 
     const later = now + INVENTORY_TTL_MS + 1
     expect(selectDue(later, false)).toHaveLength(0)

--- a/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
@@ -536,8 +536,18 @@ describe('resolveInventory', () => {
     expect(resolveInventory(entry([], 'settled'), false).active).toBe(false)
   })
 
-  it('stays inactive before the first fetch lands, so the caller reads its own source meanwhile', () => {
-    expect(resolveInventory(undefined, true).active).toBe(false)
+  it('reports pending before the first fetch lands, so the caller waits rather than sweeping', () => {
+    const resolved = resolveInventory(undefined, true)
+    expect(resolved.active).toBe(false)
+    expect(resolved.pending).toBe(true)
+  })
+
+  it('drops pending once a walk has answered, whatever the answer', () => {
+    // Every other way of not being active is a decision already made; only the first walk is a wait.
+    expect(resolveInventory({ ...entry([], 'error'), status: 'error' as const }, true).pending).toBe(false)
+    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'partial'), true, '1000').pending).toBe(false)
+    // Settled but missing a native row while the chain read is still out: decided now, not waited on.
+    expect(resolveInventory(entry([row(USDT_CHECKSUM, 5n, 100)], 'settled'), true, undefined).pending).toBe(false)
   })
 
   it('stays inactive after a fetch fails', () => {
@@ -616,6 +626,7 @@ describe('buildInventoryBalanceMap', () => {
   const inventory = (rows: InventoryRow[]) => ({
     rows: Object.fromEntries(rows.map(r => [r.address, r])),
     active: true,
+    pending: false,
   })
 
   it('synthesizes an explicit zero for tokens an active inventory does not list', () => {
@@ -626,7 +637,7 @@ describe('buildInventoryBalanceMap', () => {
   })
 
   it('returns nothing at all when the inventory is inactive', () => {
-    const map = buildInventoryBalanceMap([token], { rows: {}, active: false })
+    const map = buildInventoryBalanceMap([token], { rows: {}, active: false, pending: false })
     expect(Object.keys(map)).toHaveLength(0)
   })
 
@@ -648,6 +659,7 @@ describe('computeInventoryDiscoveries', () => {
   const activeInventory = (rows: InventoryRow[]) => ({
     rows: Object.fromEntries(rows.map(r => [r.address, r])),
     active: true,
+    pending: false,
   })
 
   const heldRow = (address: string, symbol: string): InventoryRow => ({
@@ -766,6 +778,7 @@ describe('wallet assets', () => {
       ),
     ),
     active: true,
+    pending: false,
   }
 
   it('reports the token list as not ready while the map holds nothing but imports', () => {
@@ -775,7 +788,7 @@ describe('wallet assets', () => {
   })
 
   it('does no work and keeps one identity while the legacy hook owns the popup', () => {
-    const inactive = { rows: {}, active: false }
+    const inactive = { rows: {}, active: false, pending: false }
     const first = selectWalletHoldings(inactive, defaultTokens, imports, ChainId.MAINNET)
     const second = selectWalletHoldings(inactive, defaultTokens, imports, ChainId.MAINNET)
     expect(first).toBe(second)
@@ -887,6 +900,7 @@ describe('token metadata', () => {
   const activeInventory = (rows: InventoryRow[]) => ({
     rows: Object.fromEntries(rows.map(r => [r.address, r])),
     active: true,
+    pending: false,
   })
 
   beforeEach(() => {

--- a/packages/hooks/src/use-wallet-inventory.ts
+++ b/packages/hooks/src/use-wallet-inventory.ts
@@ -1,16 +1,19 @@
 import { useEffect, useState } from 'react';
 
-import { getBalance } from '@kyber/rpc-client';
-import { API_URLS, NATIVE_TOKEN_ADDRESS } from '@kyber/schema';
+import { API_URLS } from '@kyber/schema';
 
 import {
   INDEXER_CATCHUP_WINDOW_MS,
   UnsupportedChainError,
   isChainUnsupported,
   isWalletInventoryChain,
+  judgeInventory,
   parseRawAmount,
+  readLiveNative,
   walkWalletInventory,
 } from './wallet-inventory-client';
+
+export type { InventoryVerdict } from './wallet-inventory-client';
 
 export {
   UnsupportedChainError,
@@ -21,6 +24,9 @@ export {
   parseRawAmount,
   walkWalletInventory,
   INDEXER_CATCHUP_WINDOW_MS,
+  judgeInventory,
+  readLiveNative,
+  NATIVE_SENTINEL,
 } from './wallet-inventory-client';
 export type { InventoryRawRow } from './wallet-inventory-client';
 
@@ -68,7 +74,6 @@ const RETRY_JITTER = 0.4;
 const STALE_MAX_MS = 120_000;
 /** Inventories kept for wallets no one is looking at, so a reopened selector paints at once. */
 const KEEP_IDLE_ENTRIES = 8;
-const NATIVE_KEY = NATIVE_TOKEN_ADDRESS.toLowerCase();
 
 const IDLE: WalletInventory = { balances: null, holdings: null, status: 'idle' };
 const LOADING: WalletInventory = { balances: null, holdings: null, status: 'loading' };
@@ -120,14 +125,6 @@ const pendingWatches = new Map<string, LiveWatch>();
 
 const watchStillOn = (watch: LiveWatch | undefined, indexedBlock: number, now: number): watch is LiveWatch =>
   !!watch && now <= watch.until && (watch.block === undefined || indexedBlock < watch.block);
-
-/** A node read the environment never settles must not hold the poller; the walk has the same guard. */
-const withTimeout = <T>(work: Promise<T>, ms: number): Promise<T> =>
-  new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('timed out')), ms);
-    work.then(resolve, reject).finally(() => clearTimeout(timer));
-  });
-const NATIVE_READ_TIMEOUT_MS = 8_000;
 
 const keyOf = (chainId: number, account: string) => `${chainId}:${account.toLowerCase()}`;
 
@@ -208,7 +205,7 @@ const run = async (entry: Entry) => {
     // the next walk's still-lagging indexed rows.
     const watch = watchStillOn(entry.live, entry.indexedBlock, Date.now()) ? entry.live : undefined;
     if (!watch) entry.live = undefined;
-    const { rows, complete, indexedBlock } = await walkWalletInventory({
+    const { rows, complete, indexedBlock, nativeIndexed, nativeLive } = await walkWalletInventory({
       baseUrl: API_URLS.KD_API,
       chainId: entry.chainId,
       account: entry.account,
@@ -257,32 +254,25 @@ const run = async (entry: Entry) => {
     // Sorted so two walks over an unchanged wallet compare equal whatever order the service listed them in.
     holdings.sort((a, b) => (a.address < b.address ? -1 : a.address > b.address ? 1 : 0));
 
-    // The service returns no rows both for an empty wallet and for one it has never indexed. A wallet
-    // that holds native currency but has no native row is the latter, and its "zeros" are not to be
-    // believed; it is retried on the backoff schedule in case the indexer catches up. The native
-    // currency is not read live through the service — its row is this trust check, which must stay
-    // independent of the node — so while a watch is on the same chain read stands in for it on screen.
-    if (!balances[NATIVE_KEY] || watch) {
-      const native = await withTimeout(getBalance(entry.chainId, entry.account), NATIVE_READ_TIMEOUT_MS).catch(
-        () => undefined,
-      );
+    // An answer without a native row is either a wallet holding none or one the index has not
+    // covered, and only the node tells them apart. The walk carries the node's word when a watch is
+    // on; otherwise it is one more request, to the service — a node read this client does not make.
+    let verdict = judgeInventory({ nativeIndexed, nativeLive });
+    if (verdict === 'unknown') {
+      const read = await readLiveNative({
+        baseUrl: API_URLS.KD_API,
+        chainId: entry.chainId,
+        account: entry.account,
+        signal: controller.signal,
+      }).catch(() => undefined);
       if (controller.signal.aborted) return;
-      // No native row means either a wallet that holds none or one the index has not covered, and
-      // only the chain tells them apart. Until it does, or if it says the wallet is funded, the
-      // answer is missing a holding and the caller reads its own source instead. A read that did not
-      // answer is not the service's fault, so it does not count against the backoff.
-      if (!balances[NATIVE_KEY] && (native === undefined || native > 0n)) {
-        if (native !== undefined) entry.failures += 1;
-        commit(entry, null, 'unavailable');
-        return;
-      }
-      if (watch && native !== undefined && native > 0n) {
-        balances[NATIVE_KEY] = native;
-        const index = holdings.findIndex(h => h.address === NATIVE_KEY);
-        const live = { address: NATIVE_KEY, rawBalance: native, blockNumber: indexedBlock };
-        if (index >= 0) holdings[index] = { ...holdings[index], rawBalance: native };
-        else holdings.push(live);
-      }
+      verdict = judgeInventory({ nativeIndexed, nativeLive: read });
+    }
+    if (verdict !== 'trusted') {
+      // A read that did not answer is not the service's fault, so it does not count against the backoff.
+      if (verdict === 'distrusted') entry.failures += 1;
+      commit(entry, null, 'unavailable');
+      return;
     }
 
     entry.failures = 0;

--- a/packages/hooks/src/wallet-inventory-client.ts
+++ b/packages/hooks/src/wallet-inventory-client.ts
@@ -61,6 +61,9 @@ export const isChainUnsupported = (chainId: number): boolean => unsupportedChain
 export const isWalletInventoryChain = (chainId: number): boolean =>
   WALLET_INVENTORY_CHAINS.some(chain => chain === chainId) && !unsupportedChains.has(chainId);
 
+/** The service's address for the chain's native currency, on every chain. */
+export const NATIVE_SENTINEL = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
 const PAGE_SIZE = 1000;
 /** Safety stop for the cursor walk; a wallet past this is left to the caller's own balance source. */
 const MAX_PAGES = 10;
@@ -151,8 +154,10 @@ export const walkWalletInventory = async ({
   account: string;
   signal?: AbortSignal;
   liveAddrs?: readonly string[];
-}): Promise<{ rows: InventoryRawRow[]; complete: boolean; indexedBlock: number }> => {
+}): Promise<WalkResult> => {
   const byAddress = new Map<string, InventoryRawRow>();
+  let nativeIndexed = false;
+  let nativeLive: bigint | undefined;
   const merge = (row: InventoryRawRow) => {
     const key = row.tokenAddress.toLowerCase();
     const existing = byAddress.get(key);
@@ -181,11 +186,15 @@ export const walkWalletInventory = async ({
 
     batch.balances.forEach(row => {
       indexedBlock = Math.max(indexedBlock, row.blockNumber);
+      if (row.tokenAddress.toLowerCase() === NATIVE_SENTINEL) nativeIndexed = true;
       merge(row);
     });
     // Live reads share the block-monotonic merge: stamped at the head, they win over the indexed row
     // for the same token, including when they report it emptied.
-    batch.live.forEach(merge);
+    batch.live.forEach(row => {
+      if (row.tokenAddress.toLowerCase() === NATIVE_SENTINEL) nativeLive = parseRawAmount(row.rawAmount);
+      merge(row);
+    });
 
     // A short page is the only end-of-data signal the service gives; live rows are extra to it.
     if (batch.balances.length < PAGE_SIZE) {
@@ -196,5 +205,62 @@ export const walkWalletInventory = async ({
     cursor = { block: last.blockNumber, address: last.tokenAddress };
   }
 
-  return { rows: Array.from(byAddress.values()), complete, indexedBlock };
+  return { rows: Array.from(byAddress.values()), complete, indexedBlock, nativeIndexed, nativeLive };
+};
+
+export type WalkResult = {
+  rows: InventoryRawRow[];
+  complete: boolean;
+  /** How far the index has come, live reads excluded. */
+  indexedBlock: number;
+  /** Whether the index itself listed the native currency. */
+  nativeIndexed: boolean;
+  /** The node's native balance, when the sentinel was among `liveAddrs` and the service answered. */
+  nativeLive?: bigint;
+};
+
+/**
+ * The node's native balance for the wallet, read by the service, without walking the index: one
+ * request for the smallest page the service allows, carrying the sentinel as a live read. The
+ * service answers for wallets its index has never seen. Undefined when it did not answer.
+ */
+export const readLiveNative = async ({
+  baseUrl,
+  chainId,
+  account,
+  signal,
+}: {
+  baseUrl: string;
+  chainId: number;
+  account: string;
+  signal?: AbortSignal;
+}): Promise<bigint | undefined> => {
+  const params = new URLSearchParams({ limit: '1', liveAddrs: NATIVE_SENTINEL });
+  const batch = await fetchPage(
+    `${baseUrl}/v1/wallets/${chainId}/${account}/balances?${params.toString()}`,
+    chainId,
+    signal,
+  );
+  const row = batch.live.find(candidate => candidate.tokenAddress.toLowerCase() === NATIVE_SENTINEL);
+  return row ? parseRawAmount(row.rawAmount) : undefined;
+};
+
+export type InventoryVerdict = 'trusted' | 'distrusted' | 'unknown';
+
+/**
+ * Whether an answer can be relied on for the whole wallet. The service lists every non-zero holding,
+ * the native currency included, so an answer without a native row is complete only for a wallet that
+ * holds none — and only the node says which. `unknown` asks the caller for that read; a wallet the
+ * node says is funded while the index lists no native is missing at least one holding.
+ */
+export const judgeInventory = ({
+  nativeIndexed,
+  nativeLive,
+}: {
+  nativeIndexed: boolean;
+  nativeLive?: bigint;
+}): InventoryVerdict => {
+  if (nativeIndexed) return 'trusted';
+  if (nativeLive === undefined) return 'unknown';
+  return nativeLive > 0n ? 'distrusted' : 'trusted';
 };


### PR DESCRIPTION
Two changes to how the token selector and the wallet popup get their balances. Both are in the wallet-inventory layer; the second builds on the first.

## 1. Waiting instead of sweeping

Opening the selector started a `balanceOf` sweep over the whole token list while the wallet's inventory was still being fetched, and discarded it when the answer landed a moment later. That sweep is the work this layer exists to remove, and it was paid on every open — worst of all on the rate-limited endpoints where the balances were slow to begin with.

The inventory now reports when an answer is on its way, and callers wait for it rather than starting their own. Every other way of having no answer — a walk that failed, one that hit the page cap, one whose native row nothing has vouched for — is a decision already made, and the caller reads its own source at once. The wait is one request per wallet, and the walk carries its own deadline.

The native row is served from that answer until the chain read lands, so nothing in the list waits on RPC to show a balance.

## 2. The service answers for the native currency

The trust check asks one question: has the index covered this wallet? An answer listing no native currency is either a wallet that holds none or one the index has not reached — a wallet funded a moment ago is invisible to it for about half a minute — and only a node read tells the two apart. Reading such an answer as "empty" would show zeros to a user who has just topped up.

That node read no longer comes from the client:

- `walkWalletInventory` reports whether the index listed the native currency (`nativeIndexed`) and, where it was asked for as a live read, what the node said (`nativeLive`).
- `judgeInventory` turns the two into `trusted` / `distrusted` / `unknown`, and both the app and the widget reach their verdict through it — one rule, one place.
- Only an `unknown` costs a second request: `limit=1&liveAddrs=<native>`, which the service answers even for a wallet its index has never seen. Most answers never need it.
- `resolveInventory` no longer takes a chain balance, `useWalletInventory` no longer reads one, and the widget no longer calls `getBalance`.

Nothing waits on that read either: an answer the service has not vouched for is inactive at once. A chain read is still welcome where it is already registered — it is fresher, and the native row shows it when it lands — but no screen is held for it, and after a transaction of the user's own the native currency is read live through the service like any other token it moved.

## Trade-off

A wallet whose answer lists no native currency costs one extra request. In exchange the balance path no longer depends on the user's RPC at all, which is where the reports of empty balance columns came from.

## Testing

86 unit tests in `walletInventory.test.ts` (205 in the app suite), covering the verdict in each of its three states, the pending state and where it does not apply, the second request being made only for an unknown, and that request's shape. Verified against production kd-api through the app's own modules: a funded wallet takes one request; a wallet holding a token but no native takes two and is then served.