### PR TITLE
feat(wallet-inventory): walk the wallet a user connects, once

### DIFF
--- a/apps/kyberswap-interface/src/state/walletInventory/store.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/store.ts
@@ -68,6 +68,13 @@ const NO_ADDRESSES: string[] = []
 const EMPTY_ROWS: Record<string, InventoryRow> = {}
 
 const subscriptions = new Map<string, number>()
+
+/**
+ * Wallets to walk once although nothing is reading them yet. The wallet a user connects is the one
+ * they are about to ask about, and a walk started then is a walk the first screen does not wait for.
+ * A key is dropped as soon as a walk has answered for it, so this never becomes a second poll.
+ */
+const prefetches = new Set<string>()
 const entries = new Map<string, InventoryEntry>()
 const meta = new Map<string, Meta>()
 
@@ -123,6 +130,20 @@ export const unregister = (chainId: number, account: string) => {
 }
 
 export const readSubscriptions = () => subscriptions
+
+/**
+ * Ask for one walk of this wallet without subscribing to it. Ignored for a wallet already walked,
+ * already queued, or already being polled by a consumer — this fetches what nothing else will.
+ */
+export const prefetchInventory = (chainId: number, account: string) => {
+  if (!isInventoryChain(chainId)) return
+  const key = inventoryKey(chainId, account)
+  if (entries.has(key) || prefetches.has(key) || subscriptions.has(key)) return
+  prefetches.add(key)
+  emit()
+}
+
+export const readPrefetches = () => prefetches
 export const readEntry = (key: string) => entries.get(key)
 export const readMeta = (key: string) => meta.get(key)
 
@@ -192,6 +213,7 @@ const rowsEqual = (a: Record<string, InventoryRow>, b: Record<string, InventoryR
 }
 
 export const commitResult = (key: string, result: WalletInventoryResult) => {
+  prefetches.delete(key)
   const now = Date.now()
   const previous = entries.get(key)
 
@@ -250,6 +272,7 @@ export const commitResult = (key: string, result: WalletInventoryResult) => {
 }
 
 export const commitFailure = (key: string) => {
+  prefetches.delete(key)
   const previous = meta.get(key)
   const failures = (previous?.failures ?? 0) + 1
   const base = INVENTORY_RETRY_BACKOFF_MS[Math.min(failures - 1, INVENTORY_RETRY_BACKOFF_MS.length - 1)]
@@ -273,6 +296,7 @@ export const commitFailure = (key: string) => {
 /** Test-only: drop all subscriptions, data and bookkeeping. */
 export const resetInventoryStore = () => {
   subscriptions.clear()
+  prefetches.clear()
   entries.clear()
   meta.clear()
   version = 0

--- a/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
+++ b/apps/kyberswap-interface/src/state/walletInventory/updater.tsx
@@ -2,6 +2,7 @@ import { ChainId } from '@kyberswap/ks-sdk-core'
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
 import { UnsupportedChainError, fetchWalletInventory } from 'services/walletInventory'
 
+import { useActiveWeb3React } from 'hooks'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { INVENTORY_CATCHUP_INTERVAL_MS, INVENTORY_TTL_MS } from 'state/walletInventory/constants'
 import {
@@ -11,8 +12,10 @@ import {
   isCatchingUp,
   isInventoryChain,
   markChainUnsupported,
+  prefetchInventory,
   readEntry,
   readMeta,
+  readPrefetches,
   readSubscriptions,
   readTouchedTokens,
   subscribeStore,
@@ -27,11 +30,26 @@ const MAX_PARALLEL = 3
 type DueTarget = { key: string; chainId: ChainId; account: string }
 
 /**
- * Which subscribed wallets need fetching right now. A cold or explicitly expired wallet is always
- * fetched; TTL refreshes are visibility-gated so a background tab stops polling.
+ * Which wallets need fetching right now: those a consumer is subscribed to, and those asked for by
+ * `prefetchInventory` and not yet walked. A cold or explicitly expired wallet is always fetched; TTL
+ * refreshes are visibility-gated so a background tab stops polling.
  */
 export const selectDue = (now: number, windowVisible: boolean): DueTarget[] => {
   const due: DueTarget[] = []
+  const target = (key: string): DueTarget | undefined => {
+    const [chainPart, account] = key.split(':')
+    const chainId = Number(chainPart) as ChainId
+    return isInventoryChain(chainId) ? { key, chainId, account } : undefined
+  }
+
+  // Asked for once and never walked; a walk retires the key, so this yields it at most once.
+  readPrefetches().forEach(key => {
+    if (readEntry(key) || readSubscriptions().has(key)) return
+    const entryMeta = readMeta(key)
+    if (entryMeta && now < entryMeta.nextRetryAt) return
+    const found = target(key)
+    if (found) due.push(found)
+  })
 
   readSubscriptions().forEach((count, key) => {
     if (count <= 0) return
@@ -84,6 +102,15 @@ export const selectDue = (now: number, windowVisible: boolean): DueTarget[] => {
  */
 export default function Updater(): null {
   const windowVisible = useIsWindowVisible()
+  const { chainId, account } = useActiveWeb3React()
+
+  // The wallet a user has just connected, or just switched a chain on, is the one they are about to
+  // ask about. Walking it now means the first selector or wallet popup they open reads an answer
+  // instead of starting a request; a walk retires the ask, so this costs one request per wallet and
+  // chain, not a poll.
+  useEffect(() => {
+    if (account) prefetchInventory(chainId, account)
+  }, [chainId, account])
 
   // useSyncExternalStore rather than state, so a burst of mounts coalesces into one sweep.
   const storeVersion = useSyncExternalStore(subscribeStore, getStoreVersion, getStoreVersion)

--- a/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
+++ b/apps/kyberswap-interface/src/state/walletInventory/walletInventory.test.ts
@@ -30,8 +30,10 @@ import {
   getStoreVersion,
   inventoryKey,
   isCatchingUp,
+  prefetchInventory,
   readEntry,
   readMeta,
+  readPrefetches,
   readTouchedTokens,
   register,
   resetInventoryStore,
@@ -490,6 +492,42 @@ describe('post-transaction catch-up', () => {
   it('ignores transactions on chains off the served list', () => {
     expireInventory(ChainId.LINEA, ACCOUNT, 120)
     expect(readMeta(inventoryKey(ChainId.LINEA, ACCOUNT))).toBeUndefined()
+  })
+
+  it('walks a prefetched wallet once, then forgets it', () => {
+    prefetchInventory(ChainId.MAINNET, ACCOUNT)
+    expect(selectDue(Date.now(), true)).toHaveLength(1)
+    // Nothing is subscribed, so the walk that answers is the only one this ever asks for.
+    commitResult(KEY, { rows: [row(USDT_CHECKSUM, 5n, 100)], complete: true, blockNumber: 100 })
+    expect(readPrefetches().size).toBe(0)
+    expect(selectDue(Date.now(), true)).toHaveLength(0)
+  })
+
+  it('leaves a prefetched wallet alone once it is walked, subscribed to, or off the served list', () => {
+    // Already walked: the answer the prefetch existed to get is already there.
+    commitResult(KEY, { rows: [], complete: true, blockNumber: 100 })
+    prefetchInventory(ChainId.MAINNET, ACCOUNT)
+    expect(readPrefetches().size).toBe(0)
+
+    // A consumer is already polling this wallet.
+    resetInventoryStore()
+    register(ChainId.MAINNET, ACCOUNT)
+    prefetchInventory(ChainId.MAINNET, ACCOUNT)
+    expect(readPrefetches().size).toBe(0)
+    expect(selectDue(Date.now(), true)).toHaveLength(1)
+
+    // A chain the inventory does not serve.
+    resetInventoryStore()
+    prefetchInventory(ChainId.LINEA, ACCOUNT)
+    expect(readPrefetches().size).toBe(0)
+  })
+
+  it('gives up a prefetch that failed rather than retrying it forever', () => {
+    prefetchInventory(ChainId.MAINNET, ACCOUNT)
+    commitFailure(KEY)
+    expect(readPrefetches().size).toBe(0)
+    // The failure entry is what a subscriber would retry on its own backoff; nothing is subscribed.
+    expect(selectDue(Date.now(), true)).toHaveLength(0)
   })
 
   it('paces the catch-up poll instead of refiring on every sweep', () => {


### PR DESCRIPTION
## What changes

The wallet a user connects is walked once, so the first selector or wallet popup they open reads an answer instead of starting a request.

- `prefetchInventory(chainId, account)` queues one walk for a wallet nothing is subscribed to. It does nothing for a wallet already walked, already queued, or already being polled by a consumer — a chain switch costs one walk, a reconnect costs none.
- The sweep picks those up alongside its subscribed wallets, and both commit paths retire the ask, so a prefetch is walked at most once. A failed one is dropped rather than retried: nothing is subscribed to it, and a consumer that turns up later brings its own polling and backoff.
- The trigger is an effect in the inventory `Updater`, which is already mounted and already owns the sweep. No new mount point, and no polling for a wallet nobody is looking at.

## Testing

Three unit tests cover the lifecycle: walked once then forgotten; no-op when the wallet is already walked, already subscribed, or on a chain the inventory does not serve; a failed prefetch given up rather than retried. App suite 200/200, root lint and type-check clean.