### PR TITLE
fix(cross-chain): use SVG logo for Symbiosis

### DIFF
--- a/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
+++ b/apps/kyberswap-interface/src/pages/CrossChainSwap/adapters/SymbiosisAdapter.ts
@@ -146,7 +146,7 @@ export class SymbiosisAdapter extends BaseSwapAdapter {
     return 'Symbiosis'
   }
   getIcon(): string {
-    return 'https://app.symbiosis.finance/images/favicon-32x32.png'
+    return 'https://app.symbiosis.finance/images/favicon.svg'
   }
 
   canSupport(category: string, tokenIn?: AdapterCurrency, tokenOut?: AdapterCurrency): boolean {


### PR DESCRIPTION
## Summary
- Replace the Symbiosis PNG favicon with its SVG favicon for Cross-chain provider logos.