### PR TITLE
chore(earn): update third-party liquidity disclaimer copy

### DIFF
--- a/apps/kyberswap-interface/src/locales/en-US.po
+++ b/apps/kyberswap-interface/src/locales/en-US.po
@@ -8245,8 +8245,8 @@ msgstr "The information is intended solely for your reference at the time you ar
 
 #: src/pages/Earns/PoolExplorer/index.tsx
 #: src/pages/Earns/UserPositions/index.tsx
-msgid "KyberSwap provides tools for tracking & adding liquidity to third-party Protocols. For any pool-related concerns, please contact the respective Liquidity Protocol directly."
-msgstr "KyberSwap provides tools for tracking & adding liquidity to third-party Protocols. For any pool-related concerns, please contact the respective Liquidity Protocol directly."
+msgid "KyberSwap only provides tools to track and add liquidity to Third-party protocols. Users assume all risks and contact the respective protocol for any concerns."
+msgstr "KyberSwap only provides tools to track and add liquidity to Third-party protocols. Users assume all risks and contact the respective protocol for any concerns."
 
 #: src/components/Header/web3/SignWallet/ConfirmModal.tsx
 #~ msgid "this profile"

--- a/apps/kyberswap-interface/src/locales/zh-CN.po
+++ b/apps/kyberswap-interface/src/locales/zh-CN.po
@@ -8245,7 +8245,7 @@ msgstr ""
 
 #: src/pages/Earns/PoolExplorer/index.tsx
 #: src/pages/Earns/UserPositions/index.tsx
-msgid "KyberSwap provides tools for tracking & adding liquidity to third-party Protocols. For any pool-related concerns, please contact the respective Liquidity Protocol directly."
+msgid "KyberSwap only provides tools to track and add liquidity to Third-party protocols. Users assume all risks and contact the respective protocol for any concerns."
 msgstr "KyberSwap 提供用于跟踪并向第三方协议添加流动性工具，池相关问题请直接联系对应流动性协议"
 
 #: src/components/Header/web3/SignWallet/ConfirmModal.tsx

--- a/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/PoolExplorer/index.tsx
@@ -289,7 +289,7 @@ const PoolExplorer = () => {
         onSubmit={openZapCreatePoolWidget}
       />
 
-      <ListingPageDisclaimer>{t`KyberSwap provides tools for tracking & adding liquidity to third-party Protocols. For any pool-related concerns, please contact the respective Liquidity Protocol directly.`}</ListingPageDisclaimer>
+      <ListingPageDisclaimer>{t`KyberSwap only provides tools to track and add liquidity to Third-party protocols. Users assume all risks and contact the respective protocol for any concerns.`}</ListingPageDisclaimer>
     </ListingPageWrapper>
   )
 }

--- a/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
+++ b/apps/kyberswap-interface/src/pages/Earns/UserPositions/index.tsx
@@ -407,7 +407,7 @@ const UserPositions = () => {
           )}
         </PositionTableWrapper>
 
-        <ListingPageDisclaimer>{t`KyberSwap provides tools for tracking & adding liquidity to third-party Protocols. For any pool-related concerns, please contact the respective Liquidity Protocol directly.`}</ListingPageDisclaimer>
+        <ListingPageDisclaimer>{t`KyberSwap only provides tools to track and add liquidity to Third-party protocols. Users assume all risks and contact the respective protocol for any concerns.`}</ListingPageDisclaimer>
       </ListingPageWrapper>
     </>
   )


### PR DESCRIPTION
## Summary

Rewords the disclaimer shown at the bottom of the Earn **Pool Explorer** and **My Positions** pages.

Before:
> KyberSwap provides tools for tracking & adding liquidity to third-party Protocols. For any pool-related concerns, please contact the respective Liquidity Protocol directly.

After:
> KyberSwap only provides tools to track and add liquidity to Third-party protocols. Users assume all risks and contact the respective protocol for any concerns.

## Changes

- `pages/Earns/PoolExplorer/index.tsx` and `pages/Earns/UserPositions/index.tsx` — updated the `ListingPageDisclaimer` string.
- `locales/en-US.po` — updated `msgid`/`msgstr` for the new copy.
- `locales/zh-CN.po` — updated `msgid` to match the new source string; the existing Chinese `msgstr` is kept and still needs a translation pass for the new wording.

## Testing

Copy-only change, no logic touched.