### PR TITLE
chore(token-selector): replace the market cap metric with FDV

### DIFF
--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenList.tsx
@@ -105,7 +105,7 @@ type TokenRowProps = {
   onShowTokenInfo?: (token: Token) => void
   priceUsd?: number
   priceChange24h?: number
-  /** USD value shown in the metric column — 24h volume or market cap, per the list's active metric. */
+  /** USD value shown in the metric column — 24h volume or FDV, per the list's active metric. */
   metricValue?: number
   addedAt?: number
   showAddress?: boolean
@@ -116,7 +116,7 @@ type TokenRowProps = {
   showPriceColumn?: boolean
   /**
    * What the right column renders: the wallet 'balance' (default), the 'metric' value — 24h volume or
-   * market cap (Trending / New) — or an 'import' button for a not-yet-imported token (which also makes
+   * FDV (Trending / New) — or an 'import' button for a not-yet-imported token (which also makes
    * the whole row trigger import).
    */
   rightColumn?: 'balance' | 'metric' | 'import'
@@ -600,7 +600,7 @@ type TokenListProps = {
   showCopyAddress?: boolean
   /** Render the price / 24h-change column (every tab except All). */
   showPriceColumn?: boolean
-  /** Right column shows this metric — 24h volume or market cap — instead of the balance (Trending / New). */
+  /** Right column shows this metric — 24h volume or FDV — instead of the balance (Trending / New). */
   metricColumn?: TokenMetricColumn
   /** Render a not-yet-imported token as a normal row dimmed to 50% (click imports) instead of an Import button (Trending / All). */
   importAsRow?: boolean
@@ -644,7 +644,7 @@ const TokenList = ({
   const { favoriteTokens } = useUserFavoriteTokens(customChainId)
   const tokenImports = useUserAddedTokens(customChainId)
 
-  // Row-aligned view of the shared balance map. The metric tabs show volume / market cap rather than
+  // Row-aligned view of the shared balance map. The metric tabs show volume / FDV rather than
   // a balance, so they read nothing.
   const currencyBalances = useMemo(
     () =>

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/TokenSelectorContent.tsx
@@ -195,10 +195,10 @@ const metricCopy = (metric: TokenMetricColumn) =>
         show: t`Show 24h volume`,
         sort: t`Sort by 24h volume`,
       }
-    : { label: <Trans>MCAP</Trans>, show: t`Show market cap`, sort: t`Sort by market cap` }
+    : { label: <Trans>FDV</Trans>, show: t`Show fully diluted valuation`, sort: t`Sort by fully diluted valuation` }
 
 // The Trending / New tabs' third column header: a switch choosing which metric the rows show — 24h
-// volume or market cap — plus the sort control for whichever metric is active. The showing metric's
+// volume or FDV — plus the sort control for whichever metric is active. The showing metric's
 // own button doubles as a sort target, so the sort stays reachable without aiming at the small arrows.
 const MetricColumnHeader = ({
   metric,
@@ -612,7 +612,7 @@ export const TokenSelectorContent = ({
 
   // Imported and Favorites take their price from the live prices endpoint (buy/sell mid — the same
   // source the All tab and the wallet-value sort use, so a token reads the same on every tab), while
-  // 24h change / volume / market cap stay from the tokens-list metrics.
+  // 24h change / volume / FDV stay from the tokens-list metrics.
   const localPriceAddresses = useMemo(
     () => (metricsSource.length ? metricsSource.map(currency => currency.wrapped.address) : EMPTY_ADDRESSES),
     [metricsSource],
@@ -675,14 +675,13 @@ export const TokenSelectorContent = ({
     [sort, listExtras],
   )
 
-  // The Favorites tab's natural order is descending market cap; tokens with no market cap sink to the bottom.
-  const sortByMarketCap = useCallback(
+  // The Favorites tab's natural order is descending FDV; tokens with no FDV sink to the bottom.
+  const sortByFdv = useCallback(
     (list: Currency[]): Currency[] => {
-      const capOf = (currency: Currency) =>
-        listExtras[tokenRowKey(currency.chainId, currency.wrapped.address)]?.marketCap
+      const fdvOf = (currency: Currency) => listExtras[tokenRowKey(currency.chainId, currency.wrapped.address)]?.fdv
       return [...list].sort((a, b) => {
-        const ca = capOf(a)
-        const cb = capOf(b)
+        const ca = fdvOf(a)
+        const cb = fdvOf(b)
         if (ca === undefined && cb === undefined) return 0
         if (ca === undefined) return 1
         if (cb === undefined) return -1
@@ -701,9 +700,9 @@ export const TokenSelectorContent = ({
         return newCurrenciesBase
       case TokenSelectorTab.Imported:
         return sortByMetric(importedCurrenciesBase)
-      // Favorites default to market cap desc; a clicked sort header (24h change) overrides that.
+      // Favorites default to FDV desc; a clicked sort header (24h change) overrides that.
       case TokenSelectorTab.Favorites:
-        return sort ? sortByMetric(favoriteCurrenciesBase) : sortByMarketCap(favoriteCurrenciesBase)
+        return sort ? sortByMetric(favoriteCurrenciesBase) : sortByFdv(favoriteCurrenciesBase)
       case TokenSelectorTab.All:
       default:
         return allTabTokens
@@ -717,7 +716,7 @@ export const TokenSelectorContent = ({
     allTabTokens,
     sort,
     sortByMetric,
-    sortByMarketCap,
+    sortByFdv,
   ])
 
   // Show skeleton rows while a tab's whole list is loading from the API.

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/constants.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/constants.ts
@@ -46,7 +46,7 @@ export const NEW_TOKEN_MAX_DISPLAY = 20
 
 /**
  * Widths of the list's right-hand column, shared by the header and the rows so the two stay aligned.
- * Below `sm` the metric column is the wider of the two, to fit the VOL / MCAP switch in its header.
+ * Below `sm` the metric column is the wider of the two, to fit the VOL / FDV switch in its header.
  */
 export const METRIC_COLUMN_CLASS = 'w-[76px] sm:w-[128px]'
 export const BALANCE_COLUMN_CLASS = 'w-[72px] sm:w-[104px]'

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/hooks/catalog.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/hooks/catalog.ts
@@ -23,12 +23,12 @@ export const catalogTokenToWrapped = (t: TokenCatalogListToken): WrappedTokenInf
   }
 }
 
-/** Pull the price / 24h-change / volume / market-cap row metadata out of a catalog token's `metrics`. */
+/** Pull the price / 24h-change / volume / FDV row metadata out of a catalog token's `metrics`. */
 export const catalogMetricsToExtra = (t: TokenCatalogListToken): TokenRowExtra => ({
   price: t.metrics?.price,
   priceChange24h: t.metrics?.priceChange24h ?? undefined,
   volume24h: t.metrics?.stats24h?.volume24h,
-  marketCap: t.metrics?.marketCap ?? t.marketCap,
+  fdv: t.metrics?.fdv ?? t.fdv,
 })
 
 /**

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/hooks/useNewTokens.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/hooks/useNewTokens.ts
@@ -13,9 +13,9 @@ const toSortParam = (sort: TokenSort | null): string | undefined => (sort ? `${s
 
 /**
  * Recently whitelisted tokens for the selected chains from the public token-catalog `tag=new`
- * endpoint (newest-first by default). Sorting by 24h change / volume / market cap is resolved
- * server-side via the `sort` param — the API supports all three columns — so consumers don't sort
- * these in memory. Price / 24h change / volume / market cap come from each token's `metrics`.
+ * endpoint (newest-first by default). Sorting by 24h change / volume / FDV is resolved server-side
+ * via the `sort` param, so consumers don't sort these in memory. Price / 24h change / volume / FDV
+ * come from each token's `metrics`.
  */
 export const useNewTokens = (
   chainIds: ChainId[],

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/hooks/useTrendingTokens.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/hooks/useTrendingTokens.ts
@@ -22,9 +22,9 @@ type UseTrendingTokensResult = {
 /**
  * Trending tokens for a chain, ranked by KyberScore, from the public token-catalog list endpoint
  * (`tag=kyberscore`), paginated for infinite scroll. Sorting is server-side — the default KyberScore
- * order, or `priceChange24h` / `volume24h` / `marketCap` when the user sorts a column; changing the
+ * order, or `priceChange24h` / `volume24h` / `fdv` when the user sorts a column; changing the
  * sort restarts pagination from page 1 (the sort param is part of the query key). Price / 24h-change
- * / volume / market cap come straight from each token's `metrics`.
+ * / volume / FDV come straight from each token's `metrics`.
  */
 export const useTrendingTokens = (chainId: ChainId, sort: TokenSort | null, active = true): UseTrendingTokensResult => {
   const sortParam = toSortParam(sort)

--- a/apps/kyberswap-interface/src/components/TokenSelectorModal/types.ts
+++ b/apps/kyberswap-interface/src/components/TokenSelectorModal/types.ts
@@ -8,8 +8,8 @@ export type TokenRowExtra = {
   priceChange24h?: number
   /** 24h trading volume on KyberSwap, in USD. */
   volume24h?: number
-  /** Market capitalization, in USD, from the catalog's `metrics.marketCap` or top-level `marketCap`. */
-  marketCap?: number
+  /** Fully diluted valuation, in USD, from the catalog's `metrics.fdv` or top-level `fdv`. */
+  fdv?: number
   /** Unix seconds the token was whitelisted (New tab age badge; falls back to creation time). */
   addedAt?: number
 }
@@ -21,15 +21,15 @@ export const tokenRowKey = (chainId: number | ChainId, address: string): string 
 
 /**
  * Column the list is sorted by. `priceChange24h` (the "Price & 24h change" column) applies to every
- * discovery tab; `volume24h` / `marketCap` are the two metrics the Trending and New tabs' switchable
+ * discovery tab; `volume24h` / `fdv` are the two metrics the Trending and New tabs' switchable
  * third column can show. Trending and New resolve every field to a server-side `sort` param (the
  * values match the catalog API's own field names); Imported / Favorites sort in-memory. A `null` sort
  * means the tab's natural order (KyberScore / newest / balance).
  */
-export type TokenSortField = 'priceChange24h' | 'volume24h' | 'marketCap'
+export type TokenSortField = 'priceChange24h' | 'volume24h' | 'fdv'
 export type TokenSort = { field: TokenSortField; dir: 'asc' | 'desc' }
 
-/** Which metric the Trending / New tabs' third column shows, picked with its VOL / MCAP switch. */
-export type TokenMetricColumn = Extract<TokenSortField, 'volume24h' | 'marketCap'>
+/** Which metric the Trending / New tabs' third column shows, picked with its VOL / FDV switch. */
+export type TokenMetricColumn = Extract<TokenSortField, 'volume24h' | 'fdv'>
 
-export const TOKEN_METRIC_COLUMNS: TokenMetricColumn[] = ['volume24h', 'marketCap']
+export const TOKEN_METRIC_COLUMNS: TokenMetricColumn[] = ['volume24h', 'fdv']

--- a/apps/kyberswap-interface/src/services/tokenCatalog.ts
+++ b/apps/kyberswap-interface/src/services/tokenCatalog.ts
@@ -54,8 +54,8 @@ export type TokenCatalogMetrics = {
   priceChange24h?: number | null
   kyberScore?: number
   liquidityUsd?: number
-  /** Market capitalization in USD. Absent for tokens the catalog has no circulating supply for. */
-  marketCap?: number
+  /** Fully diluted valuation in USD. Absent for tokens the catalog has no total supply for. */
+  fdv?: number
   stats24h?: { volume24h?: number }
 }
 
@@ -72,7 +72,7 @@ export type TokenCatalogListToken = {
   isStable?: boolean
   isStandardERC20?: boolean
   cmcRank?: number
-  marketCap?: number
+  fdv?: number
   createdAt?: number
   whitelistedAt?: number
   metrics?: TokenCatalogMetrics


### PR DESCRIPTION
## Summary

The token catalog serves `fdv` alongside `marketCap`, and the backend asked the token selector to read the former. The Trending / New tabs' switchable third column now tracks fully diluted valuation instead of market cap.

## Changes

- **API types** — `TokenCatalogMetrics.marketCap` and `TokenCatalogListToken.marketCap` become `fdv`. `catalogMetricsToExtra` reads `metrics.fdv ?? fdv`.
- **Sort model** — `TokenRowExtra.fdv`, `TokenSortField = 'priceChange24h' | 'volume24h' | 'fdv'`, `TOKEN_METRIC_COLUMNS = ['volume24h', 'fdv']`. Both hooks derive the query's `sort` param from `sort.field`, so Trending and New send `sort=fdv:<dir>` without a separate edit.
- **Copy** — the column label reads `FDV`; the switch and sort a11y strings read "fully diluted valuation". Neither replaced string had a zh-CN translation, and the lingui catalogs regenerate during the `i18n` build step.
- **Favorites** — its natural (unsorted) order is now descending FDV; rows with no FDV sink to the bottom.

Market Overview's `AssetToken.marketCap` comes from a different endpoint and is untouched.

## Backend support

Both the `fdv` field and the `sort=fdv` param are live on prod, so this needs no further backend work.

`sort=fdv` is accepted on the tagged list endpoints — `tag=kyberscore` (Trending) and `tag=new` (New), in both directions and across every chain in `TRENDING_SUPPORTED_CHAINS`. The untagged variant still rejects the param, which does not affect this change: the only calls that pass a `sort` are the two tagged ones, while `useTokensMetrics` (untagged, address-filtered) sends none.

Note that the pre environment returns no rows for either tag, so the sorted lists can only be exercised against prod.

## Test plan

- [x] `tsc --noEmit` clean
- [x] ESLint clean on the changed files
- [x] `sort=fdv:desc` / `:asc` verified on prod for `tag=kyberscore` and `tag=new`
- [x] Trending / New: the third column switches between `24h VOL` and `FDV`, and the values match `metrics.fdv`
- [x] Sorting by the FDV column reorders the list in both directions
- [x] Favorites with no active sort lists highest FDV first
